### PR TITLE
Add inline editing for BOM nodes and requirements during review

### DIFF
--- a/src/components/design-engine/ArtifactPanel.tsx
+++ b/src/components/design-engine/ArtifactPanel.tsx
@@ -10,6 +10,7 @@ import { Check, FileText, Pencil, Wrench } from 'lucide-react'
 import { RequirementsPanel } from './RequirementsPanel'
 import { BomDraftPanel } from './BomDraftPanel'
 import type {
+  BomNodeDraft,
   DesignArtifacts,
   DesignSessionStage,
   RequirementDraft,
@@ -33,6 +34,9 @@ interface ArtifactPanelProps {
   onAddRequirement?: (data: Partial<RequirementDraft>) => void
   onConfirmRequirements?: () => void
   onConfirmBom?: () => void
+  onUpdateBomNode?: (tempId: string, patch: Partial<BomNodeDraft>) => void
+  onRemoveBomNode?: (tempId: string) => void
+  onAddBomChild?: (parentTempId: string, data: Partial<BomNodeDraft>) => void
   className?: string
 }
 
@@ -45,6 +49,9 @@ export function ArtifactPanel({
   onAddRequirement,
   onConfirmRequirements,
   onConfirmBom,
+  onUpdateBomNode,
+  onRemoveBomNode,
+  onAddBomChild,
   className,
 }: ArtifactPanelProps) {
   const [editingDescription, setEditingDescription] = useState(false)
@@ -169,6 +176,9 @@ export function ArtifactPanel({
           totalRequirements={artifacts.requirements.length}
           requirements={artifacts.requirements}
           onConfirm={onConfirmBom}
+          onUpdateNode={onUpdateBomNode}
+          onRemoveNode={onRemoveBomNode}
+          onAddChild={onAddBomChild}
         />
       </section>
     </div>

--- a/src/components/design-engine/BomDraftPanel.tsx
+++ b/src/components/design-engine/BomDraftPanel.tsx
@@ -1,5 +1,9 @@
 /**
- * BomDraftPanel - Renders the BOM draft tree with editing capabilities
+ * BomDraftPanel - Renders the BOM draft tree with optional inline editing.
+ *
+ * During `bom_drafting` and `bom_review`, users can edit a node's core fields
+ * (name, quantity, partType, material), delete a node (its children are
+ * re-parented to its parent), and add a new child under any node.
  */
 
 import { useState } from 'react'
@@ -8,7 +12,11 @@ import {
   ChevronDown,
   ChevronRight,
   Package,
+  Pencil,
+  Plus,
   Sparkles,
+  Trash2,
+  X,
 } from 'lucide-react'
 import { InterfaceIndicator } from './InterfaceIndicator'
 import { RequirementsCoverage } from './RequirementsCoverage'
@@ -20,7 +28,22 @@ import type {
 } from '@/lib/design-engine/types'
 import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/Badge'
+import { Input } from '@/components/ui/Input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select'
 import { cn } from '@/lib/utils'
+
+const PART_TYPES: ReadonlyArray<NonNullable<BomNodeDraft['partType']>> = [
+  'Manufacture',
+  'Purchase',
+  'Software',
+  'Phantom',
+]
 
 interface BomDraftPanelProps {
   bom: BomDraft | null
@@ -28,6 +51,9 @@ interface BomDraftPanelProps {
   totalRequirements: number
   requirements: Array<RequirementDraft>
   onConfirm?: () => void
+  onUpdateNode?: (tempId: string, patch: Partial<BomNodeDraft>) => void
+  onRemoveNode?: (tempId: string) => void
+  onAddChild?: (parentTempId: string, data: Partial<BomNodeDraft>) => void
 }
 
 export function BomDraftPanel({
@@ -36,8 +62,13 @@ export function BomDraftPanel({
   totalRequirements,
   requirements,
   onConfirm,
+  onUpdateNode,
+  onRemoveNode,
+  onAddChild,
 }: BomDraftPanelProps) {
   const canConfirm = currentStage === 'bom_review' && bom !== null
+  const canEdit =
+    currentStage === 'bom_review' || currentStage === 'bom_drafting'
 
   if (!bom) {
     return (
@@ -53,6 +84,7 @@ export function BomDraftPanel({
   }
 
   const hasErrors = bom.validationIssues.some((i) => i.severity === 'error')
+  const rootTempId = bom.rootAssembly.tempId
 
   return (
     <div className="space-y-4">
@@ -66,8 +98,17 @@ export function BomDraftPanel({
           <span className="flex-1">Item</span>
           <span className="w-12 text-center">Qty</span>
           <span className="w-16 text-center">Type</span>
+          {canEdit && <span className="w-20 text-right" />}
         </div>
-        <BomNodeRow node={bom.rootAssembly} depth={0} />
+        <BomNodeRow
+          node={bom.rootAssembly}
+          depth={0}
+          rootTempId={rootTempId}
+          canEdit={canEdit && (!!onUpdateNode || !!onRemoveNode || !!onAddChild)}
+          onUpdateNode={onUpdateNode}
+          onRemoveNode={onRemoveNode}
+          onAddChild={onAddChild}
+        />
       </div>
 
       {/* Validation issues */}
@@ -115,16 +156,50 @@ export function BomDraftPanel({
   )
 }
 
-// Recursive BOM node renderer
-function BomNodeRow({ node, depth }: { node: BomNodeDraft; depth: number }) {
+interface BomNodeRowProps {
+  node: BomNodeDraft
+  depth: number
+  rootTempId: string
+  canEdit: boolean
+  onUpdateNode?: (tempId: string, patch: Partial<BomNodeDraft>) => void
+  onRemoveNode?: (tempId: string) => void
+  onAddChild?: (parentTempId: string, data: Partial<BomNodeDraft>) => void
+}
+
+function BomNodeRow({
+  node,
+  depth,
+  rootTempId,
+  canEdit,
+  onUpdateNode,
+  onRemoveNode,
+  onAddChild,
+}: BomNodeRowProps) {
   const [expanded, setExpanded] = useState(depth < 2)
+  const [editing, setEditing] = useState(false)
+  const [addingChild, setAddingChild] = useState(false)
   const hasChildren = node.children.length > 0
+  const isRoot = node.tempId === rootTempId
+
+  if (editing) {
+    return (
+      <BomNodeEditRow
+        node={node}
+        depth={depth}
+        onSave={(patch) => {
+          onUpdateNode?.(node.tempId, patch)
+          setEditing(false)
+        }}
+        onCancel={() => setEditing(false)}
+      />
+    )
+  }
 
   return (
     <>
       <div
         className={cn(
-          'flex items-center px-3 py-1.5 text-sm border-t border-slate-100 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800/50',
+          'group flex items-center px-3 py-1.5 text-sm border-t border-slate-100 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800/50',
           depth === 0 && 'font-medium',
         )}
       >
@@ -193,12 +268,167 @@ function BomNodeRow({ node, depth }: { node: BomNodeDraft; depth: number }) {
             </Badge>
           )}
         </span>
+        {canEdit && (
+          <span className="w-20 flex justify-end gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+            {onAddChild && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setAddingChild(true)
+                  setExpanded(true)
+                }}
+                className="h-6 w-6 p-0"
+                title="Add child"
+              >
+                <Plus className="h-3 w-3" />
+              </Button>
+            )}
+            {onUpdateNode && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setEditing(true)}
+                className="h-6 w-6 p-0"
+                title="Edit"
+              >
+                <Pencil className="h-3 w-3" />
+              </Button>
+            )}
+            {onRemoveNode && !isRoot && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => onRemoveNode(node.tempId)}
+                className="h-6 w-6 p-0 text-red-500 hover:text-red-700"
+                title="Remove"
+              >
+                <Trash2 className="h-3 w-3" />
+              </Button>
+            )}
+          </span>
+        )}
       </div>
       {expanded &&
         hasChildren &&
         node.children.map((child) => (
-          <BomNodeRow key={child.tempId} node={child} depth={depth + 1} />
+          <BomNodeRow
+            key={child.tempId}
+            node={child}
+            depth={depth + 1}
+            rootTempId={rootTempId}
+            canEdit={canEdit}
+            onUpdateNode={onUpdateNode}
+            onRemoveNode={onRemoveNode}
+            onAddChild={onAddChild}
+          />
         ))}
+      {addingChild && onAddChild && (
+        <BomNodeEditRow
+          depth={depth + 1}
+          onSave={(data) => {
+            onAddChild(node.tempId, data)
+            setAddingChild(false)
+          }}
+          onCancel={() => setAddingChild(false)}
+        />
+      )}
     </>
+  )
+}
+
+interface BomNodeEditRowProps {
+  node?: BomNodeDraft
+  depth: number
+  onSave: (data: Partial<BomNodeDraft>) => void
+  onCancel: () => void
+}
+
+function BomNodeEditRow({ node, depth, onSave, onCancel }: BomNodeEditRowProps) {
+  const [name, setName] = useState(node?.name ?? '')
+  const [quantity, setQuantity] = useState(String(node?.quantity ?? 1))
+  const [partType, setPartType] = useState<NonNullable<BomNodeDraft['partType']>>(
+    node?.partType ?? 'Manufacture',
+  )
+  const [material, setMaterial] = useState(node?.material ?? '')
+
+  const save = () => {
+    if (!name.trim()) return
+    const qty = Number(quantity)
+    onSave({
+      name: name.trim(),
+      quantity: Number.isFinite(qty) && qty > 0 ? qty : 1,
+      partType,
+      material: material.trim() || undefined,
+    })
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-2 px-3 py-2 border-t border-dashed border-cyan-300 dark:border-cyan-700 bg-cyan-50/40 dark:bg-cyan-900/10',
+      )}
+    >
+      <div style={{ width: depth * 20 }} className="flex-shrink-0" />
+      <div className="flex-1 grid grid-cols-[2fr_60px_110px_1fr_auto] gap-1.5 items-center">
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Name"
+          className="h-7 text-xs"
+          autoFocus
+        />
+        <Input
+          type="number"
+          min={1}
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+          placeholder="Qty"
+          className="h-7 text-xs"
+        />
+        <Select
+          value={partType}
+          onValueChange={(v) =>
+            setPartType(v as NonNullable<BomNodeDraft['partType']>)
+          }
+        >
+          <SelectTrigger className="h-7 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PART_TYPES.map((t) => (
+              <SelectItem key={t} value={t} className="text-xs">
+                {t}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input
+          value={material}
+          onChange={(e) => setMaterial(e.target.value)}
+          placeholder="Material (optional)"
+          className="h-7 text-xs"
+        />
+        <div className="flex gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={save}
+            className="h-7 w-7 p-0"
+            disabled={!name.trim()}
+          >
+            <Check className="h-3 w-3" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onCancel}
+            className="h-7 w-7 p-0"
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/src/components/design-engine/CollaborativeWorkspace.tsx
+++ b/src/components/design-engine/CollaborativeWorkspace.tsx
@@ -19,10 +19,10 @@ import type {
   DesignArtifacts,
   DesignSessionStage,
   MaterializationPreview as PreviewType,
-  RequirementDraft,
   MaterializationResult as ResultType,
 } from '@/lib/design-engine/types'
 import { useDesignEngineStream } from '@/hooks/useDesignEngineStream'
+import { useArtifactMutations } from '@/hooks/useArtifactMutations'
 import { Button } from '@/components/ui/Button'
 
 interface CollaborativeWorkspaceProps {
@@ -41,6 +41,10 @@ export function CollaborativeWorkspace({
 }: CollaborativeWorkspaceProps) {
   const navigate = useNavigate()
   const stream = useDesignEngineStream({ sessionId })
+  const mutations = useArtifactMutations({
+    sessionId,
+    artifacts: stream.artifacts,
+  })
 
   const [materializationPreview, setMaterializationPreview] =
     useState<PreviewType | null>(null)
@@ -120,66 +124,12 @@ export function CollaborativeWorkspace({
     [sessionId],
   )
 
-  const handleUpdateRequirement = useCallback(
-    async (tempId: string, data: Partial<RequirementDraft>) => {
-      // Update locally in artifacts then persist
-      const updated = { ...stream.artifacts }
-      const idx = updated.requirements.findIndex((r) => r.tempId === tempId)
-      if (idx >= 0) {
-        updated.requirements = [...updated.requirements]
-        updated.requirements[idx] = { ...updated.requirements[idx], ...data }
-        await fetch(`/api/v1/design-engine/sessions/${sessionId}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ artifacts: updated }),
-        })
-      }
-    },
-    [sessionId, stream.artifacts],
-  )
-
-  const handleRemoveRequirement = useCallback(
-    async (tempId: string) => {
-      const updated = {
-        ...stream.artifacts,
-        requirements: stream.artifacts.requirements.filter(
-          (r) => r.tempId !== tempId,
-        ),
-      }
-      await fetch(`/api/v1/design-engine/sessions/${sessionId}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ artifacts: updated }),
-      })
-    },
-    [sessionId, stream.artifacts],
-  )
-
-  const handleAddRequirement = useCallback(
-    async (data: Partial<RequirementDraft>) => {
-      const newReq: RequirementDraft = {
-        tempId: crypto.randomUUID(),
-        name: data.name ?? '',
-        description: data.description ?? '',
-        requirementType: data.requirementType ?? 'Functional',
-        priority: data.priority ?? 'medium',
-        verificationMethod: data.verificationMethod ?? 'Analysis',
-        rationale: data.rationale ?? '',
-        confidence: data.confidence ?? 1,
-        source: 'user',
-      }
-      const updated = {
-        ...stream.artifacts,
-        requirements: [...stream.artifacts.requirements, newReq],
-      }
-      await fetch(`/api/v1/design-engine/sessions/${sessionId}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ artifacts: updated }),
-      })
-    },
-    [sessionId, stream.artifacts],
-  )
+  const handleUpdateRequirement = mutations.updateRequirement
+  const handleRemoveRequirement = mutations.removeRequirement
+  const handleAddRequirement = mutations.addRequirement
+  const handleUpdateBomNode = mutations.updateNode
+  const handleRemoveBomNode = mutations.removeNode
+  const handleAddBomChild = mutations.addChild
 
   const handleAnswer = useCallback(
     (questionId: string, answer: string) => {
@@ -382,6 +332,9 @@ export function CollaborativeWorkspace({
               onAddRequirement={handleAddRequirement}
               onConfirmRequirements={handleConfirmRequirements}
               onConfirmBom={handleConfirmBom}
+              onUpdateBomNode={handleUpdateBomNode}
+              onRemoveBomNode={handleRemoveBomNode}
+              onAddBomChild={handleAddBomChild}
               className="flex-1"
             />
           )}

--- a/src/components/design-engine/RequirementsPanel.tsx
+++ b/src/components/design-engine/RequirementsPanel.tsx
@@ -11,7 +11,29 @@ import type {
 import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/Badge'
 import { Input } from '@/components/ui/Input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select'
 import { cn } from '@/lib/utils'
+
+const PRIORITY_OPTIONS: ReadonlyArray<RequirementDraft['priority']> = [
+  'low',
+  'medium',
+  'high',
+  'critical',
+]
+
+const TYPE_OPTIONS: ReadonlyArray<RequirementDraft['requirementType']> = [
+  'Functional',
+  'Performance',
+  'Interface',
+  'Constraint',
+  'Other',
+]
 
 const PRIORITY_COLORS: Record<string, string> = {
   critical: 'destructive',
@@ -48,9 +70,17 @@ export function RequirementsPanel({
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editName, setEditName] = useState('')
   const [editDescription, setEditDescription] = useState('')
+  const [editPriority, setEditPriority] =
+    useState<RequirementDraft['priority']>('medium')
+  const [editType, setEditType] =
+    useState<RequirementDraft['requirementType']>('Functional')
   const [addingNew, setAddingNew] = useState(false)
   const [newName, setNewName] = useState('')
   const [newDescription, setNewDescription] = useState('')
+  const [newPriority, setNewPriority] =
+    useState<RequirementDraft['priority']>('medium')
+  const [newType, setNewType] =
+    useState<RequirementDraft['requirementType']>('Functional')
 
   const canEdit =
     currentStage === 'requirements_review' ||
@@ -62,10 +92,17 @@ export function RequirementsPanel({
     setEditingId(req.tempId)
     setEditName(req.name)
     setEditDescription(req.description)
+    setEditPriority(req.priority)
+    setEditType(req.requirementType)
   }
 
   const saveEdit = (tempId: string) => {
-    onUpdate?.(tempId, { name: editName, description: editDescription })
+    onUpdate?.(tempId, {
+      name: editName,
+      description: editDescription,
+      priority: editPriority,
+      requirementType: editType,
+    })
     setEditingId(null)
   }
 
@@ -74,13 +111,15 @@ export function RequirementsPanel({
       onAdd?.({
         name: newName.trim(),
         description: newDescription.trim(),
-        requirementType: 'Functional',
-        priority: 'medium',
+        requirementType: newType,
+        priority: newPriority,
         verificationMethod: 'Analysis',
         source: 'user',
       })
       setNewName('')
       setNewDescription('')
+      setNewPriority('medium')
+      setNewType('Functional')
       setAddingNew(false)
     }
   }
@@ -131,6 +170,42 @@ export function RequirementsPanel({
                   className="text-sm h-8"
                   placeholder="Description"
                 />
+                <div className="grid grid-cols-2 gap-2">
+                  <Select
+                    value={editPriority}
+                    onValueChange={(v) =>
+                      setEditPriority(v as RequirementDraft['priority'])
+                    }
+                  >
+                    <SelectTrigger className="h-8 text-xs">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PRIORITY_OPTIONS.map((p) => (
+                        <SelectItem key={p} value={p} className="text-xs">
+                          {p}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Select
+                    value={editType}
+                    onValueChange={(v) =>
+                      setEditType(v as RequirementDraft['requirementType'])
+                    }
+                  >
+                    <SelectTrigger className="h-8 text-xs">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {TYPE_OPTIONS.map((t) => (
+                        <SelectItem key={t} value={t} className="text-xs">
+                          {t}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
                 <div className="flex gap-1">
                   <Button
                     variant="ghost"
@@ -240,6 +315,42 @@ export function RequirementsPanel({
               className="text-sm h-8"
               placeholder="Description (optional)"
             />
+            <div className="grid grid-cols-2 gap-2">
+              <Select
+                value={newPriority}
+                onValueChange={(v) =>
+                  setNewPriority(v as RequirementDraft['priority'])
+                }
+              >
+                <SelectTrigger className="h-8 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PRIORITY_OPTIONS.map((p) => (
+                    <SelectItem key={p} value={p} className="text-xs">
+                      {p}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Select
+                value={newType}
+                onValueChange={(v) =>
+                  setNewType(v as RequirementDraft['requirementType'])
+                }
+              >
+                <SelectTrigger className="h-8 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TYPE_OPTIONS.map((t) => (
+                    <SelectItem key={t} value={t} className="text-xs">
+                      {t}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
             <div className="flex gap-1">
               <Button
                 variant="default"
@@ -257,6 +368,8 @@ export function RequirementsPanel({
                   setAddingNew(false)
                   setNewName('')
                   setNewDescription('')
+                  setNewPriority('medium')
+                  setNewType('Functional')
                 }}
                 className="h-7 text-xs"
               >

--- a/src/hooks/useArtifactMutations.ts
+++ b/src/hooks/useArtifactMutations.ts
@@ -1,0 +1,145 @@
+/**
+ * Shared hook for editing requirement and BOM artifacts during the review
+ * stages. Each mutation merges the change into the local artifacts and PATCHes
+ * the full artifacts object — the SSE stream / next session GET refreshes the
+ * server-truth state.
+ */
+
+import { useCallback } from 'react'
+import type {
+  BomNodeDraft,
+  DesignArtifacts,
+  RequirementDraft,
+} from '@/lib/design-engine/types'
+import {
+  addBomNodeChild,
+  recomputeBomDerivedFields,
+  removeBomNode,
+  updateBomNode,
+} from '@/lib/design-engine/bom-mutations'
+
+interface UseArtifactMutationsArgs {
+  sessionId: string
+  artifacts: DesignArtifacts
+}
+
+async function patchArtifacts(
+  sessionId: string,
+  artifacts: DesignArtifacts,
+): Promise<void> {
+  await fetch(`/api/v1/design-engine/sessions/${sessionId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ artifacts }),
+  })
+}
+
+export function useArtifactMutations({
+  sessionId,
+  artifacts,
+}: UseArtifactMutationsArgs) {
+  // ---------------- Requirements ----------------
+
+  const updateRequirement = useCallback(
+    async (tempId: string, data: Partial<RequirementDraft>) => {
+      const requirements = artifacts.requirements.map((r) =>
+        r.tempId === tempId ? { ...r, ...data } : r,
+      )
+      await patchArtifacts(sessionId, { ...artifacts, requirements })
+    },
+    [sessionId, artifacts],
+  )
+
+  const removeRequirement = useCallback(
+    async (tempId: string) => {
+      const requirements = artifacts.requirements.filter(
+        (r) => r.tempId !== tempId,
+      )
+      // Coverage may reference this requirement — recompute if BOM exists.
+      let bom = artifacts.bom
+      if (bom) {
+        bom = recomputeBomDerivedFields(
+          bom,
+          requirements.map((r) => r.tempId),
+        )
+      }
+      await patchArtifacts(sessionId, { ...artifacts, requirements, bom })
+    },
+    [sessionId, artifacts],
+  )
+
+  const addRequirement = useCallback(
+    async (data: Partial<RequirementDraft>) => {
+      const newReq: RequirementDraft = {
+        tempId: crypto.randomUUID(),
+        name: data.name ?? '',
+        description: data.description ?? '',
+        requirementType: data.requirementType ?? 'Functional',
+        priority: data.priority ?? 'medium',
+        verificationMethod: data.verificationMethod ?? 'Analysis',
+        rationale: data.rationale ?? '',
+        confidence: data.confidence ?? 1,
+        source: 'user',
+      }
+      const requirements = [...artifacts.requirements, newReq]
+      let bom = artifacts.bom
+      if (bom) {
+        bom = recomputeBomDerivedFields(
+          bom,
+          requirements.map((r) => r.tempId),
+        )
+      }
+      await patchArtifacts(sessionId, { ...artifacts, requirements, bom })
+    },
+    [sessionId, artifacts],
+  )
+
+  // ---------------- BOM ----------------
+
+  const requirementIds = artifacts.requirements.map((r) => r.tempId)
+
+  const updateNode = useCallback(
+    async (tempId: string, patch: Partial<BomNodeDraft>) => {
+      if (!artifacts.bom) return
+      const next = recomputeBomDerivedFields(
+        updateBomNode(artifacts.bom, tempId, patch),
+        requirementIds,
+      )
+      await patchArtifacts(sessionId, { ...artifacts, bom: next })
+    },
+    [sessionId, artifacts, requirementIds],
+  )
+
+  const removeNode = useCallback(
+    async (tempId: string) => {
+      if (!artifacts.bom) return
+      const next = recomputeBomDerivedFields(
+        removeBomNode(artifacts.bom, tempId),
+        requirementIds,
+      )
+      await patchArtifacts(sessionId, { ...artifacts, bom: next })
+    },
+    [sessionId, artifacts, requirementIds],
+  )
+
+  const addChild = useCallback(
+    async (parentTempId: string, data: Partial<BomNodeDraft>) => {
+      if (!artifacts.bom) return
+      const next = recomputeBomDerivedFields(
+        addBomNodeChild(artifacts.bom, parentTempId, data),
+        requirementIds,
+      )
+      await patchArtifacts(sessionId, { ...artifacts, bom: next })
+    },
+    [sessionId, artifacts, requirementIds],
+  )
+
+  return {
+    updateRequirement,
+    removeRequirement,
+    addRequirement,
+    updateNode,
+    removeNode,
+    addChild,
+  }
+}

--- a/src/lib/design-engine/bom-mutations.test.ts
+++ b/src/lib/design-engine/bom-mutations.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import {
+  addBomNodeChild,
+  recomputeBomDerivedFields,
+  removeBomNode,
+  updateBomNode,
+} from './bom-mutations'
+import type { BomDraft, BomNodeDraft } from './types'
+
+function leaf(
+  tempId: string,
+  overrides: Partial<BomNodeDraft> = {},
+): BomNodeDraft {
+  return {
+    tempId,
+    name: tempId,
+    isNew: true,
+    quantity: 1,
+    children: [],
+    requirementTempIds: [],
+    rationale: '',
+    confidence: 1,
+    partType: 'Manufacture',
+    ...overrides,
+  }
+}
+
+function makeBom(): BomDraft {
+  return {
+    rootAssembly: leaf('root', {
+      name: 'Root',
+      partType: 'Phantom',
+      children: [
+        leaf('a', { requirementTempIds: ['r1'] }),
+        leaf('b', {
+          children: [
+            leaf('b1', { requirementTempIds: ['r2'] }),
+            leaf('b2'),
+          ],
+        }),
+      ],
+    }),
+    proposedParts: [],
+    requirementsCoverage: {},
+    uncoveredRequirements: [],
+    validationIssues: [],
+  }
+}
+
+describe('bom-mutations', () => {
+  it('updateBomNode produces a new tree without mutating the input', () => {
+    const before = makeBom()
+    const snapshot = JSON.stringify(before)
+    const after = updateBomNode(before, 'b1', { quantity: 5, name: 'B1!' })
+
+    expect(JSON.stringify(before)).toBe(snapshot) // unchanged
+    expect(after).not.toBe(before)
+
+    const b = after.rootAssembly.children.find((n) => n.tempId === 'b')!
+    const b1 = b.children.find((n) => n.tempId === 'b1')!
+    expect(b1.quantity).toBe(5)
+    expect(b1.name).toBe('B1!')
+  })
+
+  it('removeBomNode re-parents children to the removed node parent', () => {
+    const before = makeBom()
+    const after = removeBomNode(before, 'b')
+
+    const ids = after.rootAssembly.children.map((c) => c.tempId).sort()
+    expect(ids).toEqual(['a', 'b1', 'b2'])
+  })
+
+  it('removeBomNode refuses to remove the root assembly', () => {
+    const before = makeBom()
+    const after = removeBomNode(before, 'root')
+    expect(after.rootAssembly.tempId).toBe('root')
+    expect(after.rootAssembly.children).toHaveLength(2)
+  })
+
+  it('addBomNodeChild inserts under the target parent with a unique tempId', () => {
+    const before = makeBom()
+    const after = addBomNodeChild(before, 'b', { name: 'b3' })
+
+    const b = after.rootAssembly.children.find((n) => n.tempId === 'b')!
+    expect(b.children).toHaveLength(3)
+
+    const newChild = b.children[2]!
+    expect(newChild.name).toBe('b3')
+    expect(newChild.tempId).toBeTruthy()
+    expect(b.children.map((c) => c.tempId)).not.toContain(undefined)
+  })
+
+  it('recomputeBomDerivedFields rebuilds coverage and uncovered list', () => {
+    const before = makeBom()
+    const after = recomputeBomDerivedFields(before, ['r1', 'r2', 'r3'])
+
+    expect(after.requirementsCoverage.r1).toEqual(['a'])
+    expect(after.requirementsCoverage.r2).toEqual(['b1'])
+    expect(after.uncoveredRequirements).toEqual(['r3'])
+  })
+})

--- a/src/lib/design-engine/bom-mutations.ts
+++ b/src/lib/design-engine/bom-mutations.ts
@@ -1,0 +1,128 @@
+/**
+ * Pure helpers for editing the BOM draft tree during the review stage.
+ *
+ * All functions return a NEW BomDraft — the input is never mutated. After any
+ * structural change, call `recomputeBomDerivedFields` to keep the
+ * `requirementsCoverage` and `uncoveredRequirements` maps consistent.
+ */
+
+import type { BomDraft, BomNodeDraft } from './types'
+
+function mapNode(
+  node: BomNodeDraft,
+  fn: (n: BomNodeDraft) => BomNodeDraft,
+): BomNodeDraft {
+  const mappedChildren = node.children.map((c) => mapNode(c, fn))
+  const next = { ...node, children: mappedChildren }
+  return fn(next)
+}
+
+export function updateBomNode(
+  bom: BomDraft,
+  tempId: string,
+  patch: Partial<BomNodeDraft>,
+): BomDraft {
+  const root = mapNode(bom.rootAssembly, (n) =>
+    n.tempId === tempId ? { ...n, ...patch, children: n.children } : n,
+  )
+  return { ...bom, rootAssembly: root }
+}
+
+/**
+ * Remove a node from the tree. Children are re-parented to the deleted node's
+ * parent (per the agreed UX). The root assembly cannot be removed and a
+ * console warning is emitted in that case; the original BOM is returned.
+ */
+export function removeBomNode(bom: BomDraft, tempId: string): BomDraft {
+  if (bom.rootAssembly.tempId === tempId) {
+    console.warn('removeBomNode: refusing to remove the root assembly')
+    return bom
+  }
+
+  function visit(node: BomNodeDraft): BomNodeDraft {
+    const nextChildren: Array<BomNodeDraft> = []
+    for (const child of node.children) {
+      if (child.tempId === tempId) {
+        // Re-parent the deleted node's children to this node.
+        for (const grand of child.children) {
+          nextChildren.push(visit(grand))
+        }
+      } else {
+        nextChildren.push(visit(child))
+      }
+    }
+    return { ...node, children: nextChildren }
+  }
+
+  return { ...bom, rootAssembly: visit(bom.rootAssembly) }
+}
+
+export function addBomNodeChild(
+  bom: BomDraft,
+  parentTempId: string,
+  data: Partial<BomNodeDraft>,
+): BomDraft {
+  const newNode: BomNodeDraft = {
+    tempId: data.tempId ?? crypto.randomUUID(),
+    name: data.name ?? 'New Item',
+    isNew: data.isNew ?? true,
+    quantity: data.quantity ?? 1,
+    children: data.children ?? [],
+    requirementTempIds: data.requirementTempIds ?? [],
+    rationale: data.rationale ?? '',
+    confidence: data.confidence ?? 1,
+    partType: data.partType ?? 'Manufacture',
+    material: data.material,
+    existingItemId: data.existingItemId,
+    existingItemNumber: data.existingItemNumber,
+    findNumber: data.findNumber,
+    parametricSpec: data.parametricSpec,
+    interfaces: data.interfaces,
+    interfaceMappings: data.interfaceMappings,
+    cadGeneration: data.cadGeneration,
+    assemblyComposition: data.assemblyComposition,
+    catalogComponentId: data.catalogComponentId,
+    requiresManualSourcing: data.requiresManualSourcing,
+    selectedStockSize: data.selectedStockSize,
+    assignedToolId: data.assignedToolId,
+    manufacturingConstraints: data.manufacturingConstraints,
+    cadGenerationHint: data.cadGenerationHint,
+    mechanismTemplate: data.mechanismTemplate,
+  }
+
+  const root = mapNode(bom.rootAssembly, (n) =>
+    n.tempId === parentTempId
+      ? { ...n, children: [...n.children, newNode] }
+      : n,
+  )
+  return { ...bom, rootAssembly: root }
+}
+
+/**
+ * Walks every node in the tree and rebuilds `requirementsCoverage` and
+ * `uncoveredRequirements` from each node's `requirementTempIds`. Pass the full
+ * list of requirement IDs currently in `artifacts.requirements`.
+ */
+export function recomputeBomDerivedFields(
+  bom: BomDraft,
+  requirementIds: ReadonlyArray<string>,
+): BomDraft {
+  const coverage: Record<string, Array<string>> = {}
+
+  function walk(node: BomNodeDraft) {
+    for (const reqId of node.requirementTempIds) {
+      if (!coverage[reqId]) coverage[reqId] = []
+      coverage[reqId].push(node.tempId)
+    }
+    for (const child of node.children) walk(child)
+  }
+  walk(bom.rootAssembly)
+
+  const uncoveredRequirements = requirementIds.filter((id) => !coverage[id])
+
+  return {
+    ...bom,
+    requirementsCoverage: coverage,
+    uncoveredRequirements,
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive inline editing capabilities for both BOM nodes and requirements during the `bom_drafting`, `bom_review`, and `requirements_review` stages. Users can now edit core fields, add/remove items, and see changes persist to the server in real-time.

## Key Changes

### BOM Node Editing
- **BomDraftPanel.tsx**: Added inline editing UI with edit/add/delete buttons that appear on hover
  - Edit mode allows updating name, quantity, partType, and material fields
  - Add child button expands the parent and opens a new row for input
  - Delete button removes nodes and re-parents their children (root cannot be deleted)
  - Introduced `BomNodeEditRow` component for the edit form with validation

- **bom-mutations.ts** (new): Pure helper functions for BOM tree mutations
  - `updateBomNode`: Updates a node's fields without mutating the input
  - `removeBomNode`: Removes a node and re-parents its children to the parent
  - `addBomNodeChild`: Adds a new child node with auto-generated tempId
  - `recomputeBomDerivedFields`: Rebuilds `requirementsCoverage` and `uncoveredRequirements` maps after structural changes

- **bom-mutations.test.ts** (new): Comprehensive test suite covering all mutation operations

### Requirements Editing
- **RequirementsPanel.tsx**: Enhanced edit/add forms to include priority and requirementType fields
  - Both editing and adding new requirements now support selecting priority (low/medium/high/critical) and type (Functional/Performance/Interface/Constraint/Other)
  - Maintains existing name and description fields

### Artifact Mutations Hook
- **useArtifactMutations.ts** (new): Centralized hook for all artifact mutations
  - Handles both requirements and BOM mutations
  - Each mutation merges changes locally and PATCHes the full artifacts object
  - Automatically recomputes BOM derived fields when requirements change
  - Generates unique tempIds for new items using `crypto.randomUUID()`

### Integration
- **CollaborativeWorkspace.tsx**: Wired up the new mutation handlers
  - Replaced inline mutation logic with calls to `useArtifactMutations`
  - Passes BOM mutation callbacks to ArtifactPanel

- **ArtifactPanel.tsx**: Added props for BOM mutation callbacks
  - Forwards `onUpdateBomNode`, `onRemoveBomNode`, `onAddBomChild` to BomDraftPanel

## Implementation Details
- All mutations are pure functions that return new objects without mutating inputs
- Edit UI uses a cyan-tinted background to distinguish edit rows from display rows
- Action buttons (edit/add/delete) appear on hover with smooth opacity transitions
- Form validation prevents saving empty names and ensures valid quantities
- The root assembly cannot be deleted to maintain BOM integrity
- After any BOM structural change, derived fields are recomputed to keep requirement coverage maps in sync

https://claude.ai/code/session_01Frh3dVcb5DFvoiBQbdczEF