### PR TITLE
Honor sslmode in DATABASE_URL and disable TLS in compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,8 +55,19 @@ RABBITMQ_URL=amqp://cascadia:cascadia@localhost:5672
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 # ENCRYPTION_KEY=
 
-# Database SSL/TLS (production)
-# Path to CA certificate for database SSL verification
+# Database SSL/TLS
+# When NODE_ENV=production the app requires TLS unless you opt out. Set to
+# "disable" for private-network deployments (e.g. compose-bundled postgres),
+# or "require" to force TLS regardless of NODE_ENV.
+# DATABASE_SSL=
+#
+# Alternatively, pass sslmode in the connection string (libpq style):
+#   DATABASE_URL=postgresql://user:pass@host:5432/db?sslmode=disable
+# Supported sslmode values: disable, require, verify-ca, verify-full.
+# DATABASE_SSL takes precedence over ?sslmode= when both are set.
+#
+# Path to CA certificate for database SSL verification.
+# Required when sslmode is verify-ca or verify-full; optional with require.
 # DATABASE_CA_CERT_PATH=
 
 # Email/SMTP (required for notification jobs in production)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,10 @@ services:
     environment:
       NODE_ENV: ${NODE_ENV:-production}
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-cascadia}
+      # The bundled postgres image does not advertise TLS and is only reachable
+      # on the private cascadia-network. Override to "require" if you put a
+      # TLS-terminating proxy in front or swap in a managed Postgres.
+      DATABASE_SSL: ${DATABASE_SSL:-disable}
       SESSION_SECRET: ${SESSION_SECRET:-change-this-to-a-random-32-char-string}
       BASE_URL: ${BASE_URL:-http://localhost:3000}
       FILE_STORAGE_PATH: ${FILE_STORAGE_PATH:-/app/storage/files}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -22,11 +22,43 @@ const connectionString =
   process.env.DATABASE_URL ||
   'postgresql://postgres:postgres@localhost:5432/cascadia'
 
-// Parse connection string for Cloud SQL Unix socket support
-// postgres.js doesn't parse ?host= from URL, so we extract it manually
-function parseConnectionOptions(connStr: string) {
+export type SslMode = 'disable' | 'require' | 'verify-ca' | 'verify-full'
+
+const VALID_SSL_MODES: ReadonlyArray<SslMode> = [
+  'disable',
+  'require',
+  'verify-ca',
+  'verify-full',
+]
+
+function isSslMode(value: string): value is SslMode {
+  return (VALID_SSL_MODES as ReadonlyArray<string>).includes(value)
+}
+
+// Parse connection string for Cloud SQL Unix socket support and libpq-style
+// sslmode query parameter. postgres.js doesn't honor ?host= or ?sslmode= from
+// the URL, so we extract them manually and strip them before handing the URL
+// to the driver.
+export function parseConnectionOptions(connStr: string): {
+  connectionString: string
+  options: { host?: string }
+  sslMode?: SslMode
+} {
   const url = new URL(connStr)
   const socketPath = url.searchParams.get('host')
+  const rawSslMode = url.searchParams.get('sslmode')
+
+  let sslMode: SslMode | undefined
+  if (rawSslMode !== null) {
+    if (!isSslMode(rawSslMode)) {
+      throw new Error(
+        `Invalid sslmode "${rawSslMode}" in DATABASE_URL. ` +
+          `Supported values: ${VALID_SSL_MODES.join(', ')}.`,
+      )
+    }
+    sslMode = rawSslMode
+    url.searchParams.delete('sslmode')
+  }
 
   if (socketPath && socketPath.startsWith('/cloudsql/')) {
     // Cloud SQL Unix socket connection
@@ -35,33 +67,87 @@ function parseConnectionOptions(connStr: string) {
     return {
       connectionString: url.toString(),
       options: { host: socketPath },
+      sslMode,
     }
   }
 
-  return { connectionString: connStr, options: {} }
-}
-
-const { connectionString: cleanConnString, options } =
-  parseConnectionOptions(connectionString)
-
-// SSL configuration. By default, production NODE_ENV requires SSL. Self-hosted
-// deployments (including the bundled docker-compose.demo.yml) where the app
-// connects to a Postgres on a private network can opt out via DATABASE_SSL=disable.
-const isProduction = process.env.NODE_ENV === 'production'
-const sslMode = process.env.DATABASE_SSL // 'disable' | 'require' | undefined
-const sslOptions: Record<string, unknown> = {}
-
-const sslDisabled =
-  sslMode === 'disable' || options.host?.startsWith('/cloudsql/')
-
-if (!sslDisabled && (sslMode === 'require' || isProduction)) {
-  const caCertPath = process.env.DATABASE_CA_CERT_PATH
-  if (caCertPath) {
-    sslOptions.ssl = { ca: fs.readFileSync(caCertPath) }
-  } else {
-    sslOptions.ssl = 'require'
+  return {
+    connectionString: url.toString(),
+    options: {},
+    sslMode,
   }
 }
+
+const {
+  connectionString: cleanConnString,
+  options,
+  sslMode: urlSslMode,
+} = parseConnectionOptions(connectionString)
+
+// SSL configuration. Precedence (highest first):
+//   1. Cloud SQL Unix socket — SSL is meaningless, always off
+//   2. DATABASE_SSL env var ("disable" | "require") — explicit operator override
+//   3. ?sslmode= in DATABASE_URL — libpq-style URL parameter
+//   4. NODE_ENV=production fallback — require SSL by default in production
+//
+// The DATABASE_CA_CERT_PATH env var supplies a CA bundle when verification is
+// requested. verify-ca / verify-full require it; without it we throw rather
+// than silently downgrade.
+export function resolveSslOption(args: {
+  databaseSslEnv: string | undefined
+  urlSslMode: SslMode | undefined
+  isProduction: boolean
+  isCloudSqlSocket: boolean
+  caCertPath: string | undefined
+  readCaFile: (p: string) => Buffer
+}): { ssl?: 'require' | { ca: Buffer } } {
+  const {
+    databaseSslEnv,
+    urlSslMode: urlMode,
+    isProduction,
+    isCloudSqlSocket,
+    caCertPath,
+    readCaFile,
+  } = args
+
+  if (isCloudSqlSocket) return {}
+
+  // Effective mode after applying precedence. `undefined` means "fall back to
+  // NODE_ENV-based default" (off in dev, require in prod).
+  let effective: SslMode | undefined
+  if (databaseSslEnv === 'disable' || databaseSslEnv === 'require') {
+    effective = databaseSslEnv
+  } else if (urlMode) {
+    effective = urlMode
+  } else if (isProduction) {
+    effective = 'require'
+  }
+
+  if (!effective || effective === 'disable') return {}
+
+  if (effective === 'verify-ca' || effective === 'verify-full') {
+    if (!caCertPath) {
+      throw new Error(
+        `sslmode=${effective} requires DATABASE_CA_CERT_PATH to be set ` +
+          `so the server certificate can be verified.`,
+      )
+    }
+    return { ssl: { ca: readCaFile(caCertPath) } }
+  }
+
+  // require
+  if (caCertPath) return { ssl: { ca: readCaFile(caCertPath) } }
+  return { ssl: 'require' }
+}
+
+const sslOptions = resolveSslOption({
+  databaseSslEnv: process.env.DATABASE_SSL,
+  urlSslMode,
+  isProduction: process.env.NODE_ENV === 'production',
+  isCloudSqlSocket: options.host?.startsWith('/cloudsql/') ?? false,
+  caCertPath: process.env.DATABASE_CA_CERT_PATH,
+  readCaFile: (p) => fs.readFileSync(p),
+})
 
 // For query purposes
 const queryClient = postgres(cleanConnString, { ...options, ...sslOptions })

--- a/src/lib/db/parse-connection-options.test.ts
+++ b/src/lib/db/parse-connection-options.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from 'vitest'
+import { parseConnectionOptions, resolveSslOption } from './index'
+
+describe('parseConnectionOptions', () => {
+  it('passes a plain URL through unchanged', () => {
+    const url = 'postgresql://u:p@h:5432/d'
+    const result = parseConnectionOptions(url)
+    expect(result.connectionString).toBe('postgresql://u:p@h:5432/d')
+    expect(result.options).toEqual({})
+    expect(result.sslMode).toBeUndefined()
+  })
+
+  it('strips ?sslmode=disable and reports the mode', () => {
+    const result = parseConnectionOptions(
+      'postgresql://u:p@h:5432/d?sslmode=disable',
+    )
+    expect(result.connectionString).not.toContain('sslmode')
+    expect(result.sslMode).toBe('disable')
+  })
+
+  it('strips ?sslmode=require and reports the mode', () => {
+    const result = parseConnectionOptions(
+      'postgresql://u:p@h:5432/d?sslmode=require',
+    )
+    expect(result.connectionString).not.toContain('sslmode')
+    expect(result.sslMode).toBe('require')
+  })
+
+  it('accepts verify-ca and verify-full', () => {
+    expect(
+      parseConnectionOptions('postgresql://u:p@h/d?sslmode=verify-ca').sslMode,
+    ).toBe('verify-ca')
+    expect(
+      parseConnectionOptions('postgresql://u:p@h/d?sslmode=verify-full')
+        .sslMode,
+    ).toBe('verify-full')
+  })
+
+  it('throws on an unsupported sslmode value', () => {
+    expect(() =>
+      parseConnectionOptions('postgresql://u:p@h/d?sslmode=prefer'),
+    ).toThrow(/Invalid sslmode "prefer"/)
+  })
+
+  it('extracts cloudsql Unix socket path from ?host=', () => {
+    const result = parseConnectionOptions(
+      'postgresql://u:p@h/d?host=/cloudsql/project:region:instance',
+    )
+    expect(result.options.host).toBe('/cloudsql/project:region:instance')
+    expect(result.connectionString).not.toContain('host=')
+  })
+
+  it('handles cloudsql host AND sslmode in the same URL', () => {
+    const result = parseConnectionOptions(
+      'postgresql://u:p@h/d?host=/cloudsql/x:y:z&sslmode=disable',
+    )
+    expect(result.options.host).toBe('/cloudsql/x:y:z')
+    expect(result.sslMode).toBe('disable')
+    expect(result.connectionString).not.toContain('host=')
+    expect(result.connectionString).not.toContain('sslmode')
+  })
+
+  it('preserves unrelated query parameters', () => {
+    const result = parseConnectionOptions(
+      'postgresql://u:p@h/d?sslmode=require&application_name=cascadia',
+    )
+    expect(result.connectionString).toContain('application_name=cascadia')
+    expect(result.connectionString).not.toContain('sslmode')
+  })
+})
+
+describe('resolveSslOption', () => {
+  const readCaFile = vi.fn(() => Buffer.from('FAKE_CA'))
+
+  it('returns no SSL for a Cloud SQL Unix socket regardless of other settings', () => {
+    const result = resolveSslOption({
+      databaseSslEnv: 'require',
+      urlSslMode: 'require',
+      isProduction: true,
+      isCloudSqlSocket: true,
+      caCertPath: '/etc/ca.pem',
+      readCaFile,
+    })
+    expect(result).toEqual({})
+  })
+
+  it('honors DATABASE_SSL=disable over URL sslmode=require', () => {
+    const result = resolveSslOption({
+      databaseSslEnv: 'disable',
+      urlSslMode: 'require',
+      isProduction: true,
+      isCloudSqlSocket: false,
+      caCertPath: undefined,
+      readCaFile,
+    })
+    expect(result).toEqual({})
+  })
+
+  it('honors URL sslmode=disable when DATABASE_SSL is unset (even in production)', () => {
+    const result = resolveSslOption({
+      databaseSslEnv: undefined,
+      urlSslMode: 'disable',
+      isProduction: true,
+      isCloudSqlSocket: false,
+      caCertPath: undefined,
+      readCaFile,
+    })
+    expect(result).toEqual({})
+  })
+
+  it('falls back to "require" in production when nothing else is set', () => {
+    const result = resolveSslOption({
+      databaseSslEnv: undefined,
+      urlSslMode: undefined,
+      isProduction: true,
+      isCloudSqlSocket: false,
+      caCertPath: undefined,
+      readCaFile,
+    })
+    expect(result).toEqual({ ssl: 'require' })
+  })
+
+  it('returns no SSL in development when nothing else is set', () => {
+    const result = resolveSslOption({
+      databaseSslEnv: undefined,
+      urlSslMode: undefined,
+      isProduction: false,
+      isCloudSqlSocket: false,
+      caCertPath: undefined,
+      readCaFile,
+    })
+    expect(result).toEqual({})
+  })
+
+  it('upgrades "require" to { ca } when DATABASE_CA_CERT_PATH is set', () => {
+    const result = resolveSslOption({
+      databaseSslEnv: 'require',
+      urlSslMode: undefined,
+      isProduction: false,
+      isCloudSqlSocket: false,
+      caCertPath: '/etc/ca.pem',
+      readCaFile,
+    })
+    expect(result).toEqual({ ssl: { ca: Buffer.from('FAKE_CA') } })
+  })
+
+  it('throws on verify-ca without DATABASE_CA_CERT_PATH', () => {
+    expect(() =>
+      resolveSslOption({
+        databaseSslEnv: undefined,
+        urlSslMode: 'verify-ca',
+        isProduction: true,
+        isCloudSqlSocket: false,
+        caCertPath: undefined,
+        readCaFile,
+      }),
+    ).toThrow(/sslmode=verify-ca requires DATABASE_CA_CERT_PATH/)
+  })
+
+  it('throws on verify-full without DATABASE_CA_CERT_PATH', () => {
+    expect(() =>
+      resolveSslOption({
+        databaseSslEnv: undefined,
+        urlSslMode: 'verify-full',
+        isProduction: true,
+        isCloudSqlSocket: false,
+        caCertPath: undefined,
+        readCaFile,
+      }),
+    ).toThrow(/sslmode=verify-full requires DATABASE_CA_CERT_PATH/)
+  })
+
+  it('accepts verify-full when CA cert path is provided', () => {
+    const result = resolveSslOption({
+      databaseSslEnv: undefined,
+      urlSslMode: 'verify-full',
+      isProduction: false,
+      isCloudSqlSocket: false,
+      caCertPath: '/etc/ca.pem',
+      readCaFile,
+    })
+    expect(result).toEqual({ ssl: { ca: Buffer.from('FAKE_CA') } })
+  })
+
+  it('ignores invalid DATABASE_SSL values and falls through to URL mode', () => {
+    const result = resolveSslOption({
+      databaseSslEnv: 'garbage',
+      urlSslMode: 'disable',
+      isProduction: true,
+      isCloudSqlSocket: false,
+      caCertPath: undefined,
+      readCaFile,
+    })
+    expect(result).toEqual({})
+  })
+})


### PR DESCRIPTION
- Parse libpq-style ?sslmode= (disable, require, verify-ca, verify-full) from DATABASE_URL in parseConnectionOptions and strip it before handing the URL to postgres.js
- Split SSL decision into resolveSslOption with explicit precedence: Cloud SQL socket > DATABASE_SSL env > URL sslmode > NODE_ENV=production fallback
- Throw on verify-ca/verify-full without DATABASE_CA_CERT_PATH instead of silently downgrading
- Set DATABASE_SSL=disable by default for the app service in docker-compose.yml so the bundled non-TLS postgres works out of the box
- Document DATABASE_SSL and ?sslmode= in .env.example
- Add unit tests covering the parsing and the precedence matrix