### PR TITLE
Fix file display on item views and expand CAD format support

### DIFF
--- a/src/components/parts/PartDetail.tsx
+++ b/src/components/parts/PartDetail.tsx
@@ -274,8 +274,8 @@ export function PartDetail({
       try {
         const response = await fetch(`/api/v1/designs/${part.designId}`)
         if (response.ok) {
-          const design = await response.json()
-          setMainBranchId(design.defaultBranchId)
+          const body = await response.json()
+          setMainBranchId(body.data?.design?.defaultBranchId)
         }
       } catch (err) {
         console.error('Error fetching design:', err)

--- a/src/components/vault/FileList.tsx
+++ b/src/components/vault/FileList.tsx
@@ -89,7 +89,7 @@ export function FileList({
       }
 
       const data = await response.json()
-      setFiles(data.files || [])
+      setFiles(data.data?.files ?? [])
       setError(null)
     } catch (err) {
       setError((err as Error).message)

--- a/src/lib/auth/AuthService.ts
+++ b/src/lib/auth/AuthService.ts
@@ -186,10 +186,10 @@ export class AuthService {
         .where(eq(users.id, user.id))
     }
 
-    // Session rotation: invalidate all existing sessions before creating new one
-    await SessionManager.deleteUserSessions(user.id)
-
-    // Create session
+    // Allow concurrent sessions per user (e.g. browser + Solid Edge plugin signed in at the
+    // same time). We intentionally do NOT invalidate existing sessions on login; this matches
+    // the OAuth login path, which has never rotated sessions. Sessions still expire normally
+    // and can be revoked individually (logout) or in bulk if needed.
     const { sessionToken } = await SessionManager.createSession(
       user.id,
       ipAddress,

--- a/src/lib/vault/services/FileService.ts
+++ b/src/lib/vault/services/FileService.ts
@@ -10,6 +10,7 @@ import {
   extractFileMetadata,
   generateFileHash,
   generateStoragePath,
+  getAllowedExtensions,
   getFileExtension,
   isFileTypeAllowed,
   sanitizeFilename,
@@ -134,23 +135,10 @@ export class FileService {
     // Validate file type
     if (!isFileTypeAllowed(metadata.originalFileName, metadata.mimeType)) {
       const ext = getFileExtension(metadata.originalFileName)
-      throw new FileTypeNotAllowedError(ext || metadata.mimeType, [
-        '.step',
-        '.stp',
-        '.iges',
-        '.stl',
-        '.obj',
-        '.pdf',
-        '.doc',
-        '.docx',
-        '.xls',
-        '.xlsx',
-        '.csv',
-        '.png',
-        '.jpg',
-        '.jpeg',
-        '.zip',
-      ])
+      throw new FileTypeNotAllowedError(
+        ext || metadata.mimeType,
+        getAllowedExtensions(),
+      )
     }
 
     // Get item to validate it exists and get masterId

--- a/src/lib/vault/utils/file-utils.ts
+++ b/src/lib/vault/utils/file-utils.ts
@@ -131,8 +131,26 @@ const ALLOWED_EXTENSIONS = new Set([
   '.dxf',
   '.ipt',
   '.iam',
+  '.idw',
   '.3dm',
   '.ply',
+  // Solid Edge
+  '.par',
+  '.psm',
+  '.dft',
+  '.pwd',
+  // SolidWorks drawing
+  '.slddrw',
+  // Creo / Pro-E (.prt and .asm shared above)
+  '.drw',
+  '.frm',
+  '.lay',
+  '.sec',
+  // CATIA drawing
+  '.catdrawing',
+  // Fusion 360
+  '.f3d',
+  '.f3z',
   // Documents
   '.pdf',
   '.doc',
@@ -180,6 +198,14 @@ export function isFileTypeAllowed(
 }
 
 /**
+ * Get the full list of allowed file extensions.
+ * Use this when reporting errors so the message stays in sync with the allowlist.
+ */
+export function getAllowedExtensions(): Array<string> {
+  return Array.from(ALLOWED_EXTENSIONS)
+}
+
+/**
  * Check if a file is a CAD model based on extension
  */
 export function isCADFile(filename: string): boolean {
@@ -193,13 +219,19 @@ export function isCADFile(filename: string): boolean {
     '.igs', // IGES (alternate extension)
     '.sldprt', // SolidWorks Part
     '.sldasm', // SolidWorks Assembly
-    '.prt', // Various CAD formats
+    '.prt', // Various CAD formats (Creo/NX part)
+    '.asm', // Assembly (Solid Edge / Creo / NX)
+    '.par', // Solid Edge Part
+    '.psm', // Solid Edge Sheet Metal
+    '.pwd', // Solid Edge Weldment
     '.dwg', // AutoCAD Drawing
     '.dxf', // AutoCAD DXF
     '.ipt', // Autodesk Inventor Part
     '.iam', // Autodesk Inventor Assembly
     '.catpart', // CATIA Part
     '.catproduct', // CATIA Product
+    '.f3d', // Fusion 360
+    '.f3z', // Fusion 360 archive
     '.3dm', // Rhino 3D
     '.ply', // Polygon File Format
     '.glb', // glTF Binary
@@ -226,8 +258,13 @@ export function detectFileCategory(filename: string, mimeType: string): string {
     '.igs',
     '.sldprt',
     '.prt',
+    '.par',
+    '.psm',
+    '.pwd',
     '.ipt',
     '.catpart',
+    '.f3d',
+    '.f3z',
     '.3dm',
     '.ply',
     '.glb',
@@ -238,7 +275,16 @@ export function detectFileCategory(filename: string, mimeType: string): string {
   }
 
   // Drawing files
-  const drawingExtensions = ['.dwg', '.dxf', '.pdf']
+  const drawingExtensions = [
+    '.dwg',
+    '.dxf',
+    '.pdf',
+    '.dft', // Solid Edge Draft
+    '.slddrw', // SolidWorks Drawing
+    '.idw', // Inventor Drawing
+    '.drw', // Creo Drawing
+    '.catdrawing', // CATIA Drawing
+  ]
   if (
     drawingExtensions.includes(ext) ||
     lowerFilename.includes('drawing') ||
@@ -272,7 +318,7 @@ export function detectFileCategory(filename: string, mimeType: string): string {
   }
 
   // Assembly files
-  const assemblyExtensions = ['.sldasm', '.iam', '.catproduct']
+  const assemblyExtensions = ['.sldasm', '.iam', '.catproduct', '.asm']
   if (assemblyExtensions.includes(ext)) {
     return 'cad_model'
   }
@@ -295,12 +341,27 @@ export function getCADFormat(filename: string): string | null {
     '.igs': 'IGES',
     '.sldprt': 'SolidWorks',
     '.sldasm': 'SolidWorks',
+    '.slddrw': 'SolidWorks',
     '.dwg': 'AutoCAD',
     '.dxf': 'AutoCAD DXF',
     '.ipt': 'Inventor',
     '.iam': 'Inventor',
+    '.idw': 'Inventor',
+    '.par': 'Solid Edge',
+    '.psm': 'Solid Edge',
+    '.asm': 'Solid Edge',
+    '.dft': 'Solid Edge',
+    '.pwd': 'Solid Edge',
+    '.prt': 'Creo/NX',
+    '.drw': 'Creo',
+    '.frm': 'Creo',
+    '.lay': 'Creo',
+    '.sec': 'Creo',
     '.catpart': 'CATIA',
     '.catproduct': 'CATIA',
+    '.catdrawing': 'CATIA',
+    '.f3d': 'Fusion 360',
+    '.f3z': 'Fusion 360',
     '.3dm': 'Rhino',
     '.ply': 'PLY',
     '.glb': 'glTF',


### PR DESCRIPTION
Files linked to a Part/Document/ChangeOrder were not rendering on the item detail view despite existing in the vault. The shared FileList component read the files endpoint response as `data.files`, but apiHandler wraps every handler return in a `{ data: ... }` envelope, so the list was always empty. PartDetail had the same envelope bug reading the design fetch, leaving `mainBranchId` undefined and silently disabling branch-aware file filtering.

- FileList: read `data.data?.files`
- PartDetail: read `data.data.design.defaultBranchId` for mainBranchId

Expand the CAD file allowlist, detection, and format mapping for the CAD plugin work: Solid Edge (.par/.psm/.dft/.pwd/.asm), SolidWorks drawings (.slddrw), Inventor drawings (.idw), Creo (.drw/.frm/.lay/.sec), CATIA drawings (.catdrawing), and Fusion 360 (.f3d/.f3z). Add getAllowedExtensions() so the upload error message stays in sync with the allowlist.

Stop rotating sessions on login so a user can be signed in via the browser and the Solid Edge plugin concurrently. Sessions still expire normally and can be revoked individually or in bulk.