### PR TITLE
Wire tool-call events into design-engine stages so the resume summary…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,11 @@ src/
 │   ├── ai/           # AI chatbot tools, adapters, session service
 │   ├── design-engine/# Collaborative design engine (stages, tools, prompts, materialization)
 │   └── cad-generation/ # CAD generation pipeline (Zoo API, KCL, assembly)
-├── routes/           # TanStack Router routes & API endpoints
+├── routes/           # TanStack Router file-based routes (frontend SPA pages)
+├── server/           # Hono API server
+│   ├── index.ts      # Entry: mounts every route module under /api/v1/*
+│   ├── adapter.ts    # tagged() factory for consistent OpenAPI tags
+│   └── routes/       # API route modules — one file per resource (parts, items, …)
 └── __tests__/        # Test utilities and fixtures
 workers/
 ├── node/             # Node.js job worker Dockerfile
@@ -89,10 +93,13 @@ npm run db:push       # Push schema directly to database (dev only)
 npm run db:studio     # Open Drizzle Studio GUI
 npm run db:seed       # Minimal seed (admin, roles, program, standard library)
 npm run db:seed:catalog  # Generic component catalog (fasteners, raw stock)
+npm run db:seed:demo  # Full TDJ-25 demo robot-arm dataset (~88 parts, BOM, CAD)
 
 # Database Reset (truncates all tables, then optionally reseeds)
-npm run db:reset              # Truncate all tables only
+npm run db:reset              # Truncate all tables only (data gone, schema kept)
 npm run db:reset:seed         # Truncate + minimal seed
+npm run db:drop               # Drop all tables (schema gone, not just data)
+npm run db:drop:seed          # Drop + re-push schema + minimal seed
 
 # Testing
 npm run test          # Run Vitest tests
@@ -110,9 +117,11 @@ npx vitest run src/lib/services/BranchService.test.ts
 npx vitest run -t "should create branch"
 
 # Code Quality
-npm run lint          # ESLint
+npm run lint          # ESLint (--max-warnings 0)
 npm run format        # Prettier
 npm run check         # Format + lint fix
+npm run openapi:snapshot  # Regenerate docs/api/openapi.v1.json after route changes
+npm run openapi:check     # Verify the committed OpenAPI snapshot matches (CI gate)
 
 # Background Workers
 npm run workers:dev   # Start RabbitMQ + all workers (Node.js + Python)
@@ -123,17 +132,19 @@ npm run workers:logs  # Tail Python worker logs
 npm run jobs:worker:dev    # Node.js worker only (requires RabbitMQ)
 npm run cad:worker:dev     # CAD converter only (Docker)
 npm run cadgen:worker:dev  # CAD generator only (Docker)
+
+# Demo Stack (full pre-seeded environment via docker-compose.demo.yml)
+npm run demo:up       # Start the demo stack (Postgres, RabbitMQ, app, workers)
+npm run demo:down     # Stop the demo stack
+npm run demo:reset    # Recreate the demo stack from scratch (wipes demo volumes)
+npm run demo:logs     # Tail demo app logs
 ```
 
 ## Lint Warnings Baseline
 
-`npm run lint` runs `eslint --max-warnings N`, where `N` is the current warning count. This is a **ratchet**: the current baseline is the ceiling — any new warning fails lint. Most of these are `@typescript-eslint/no-unnecessary-condition` (over-defensive null/undefined guards that the type system already rules out).
+`npm run lint` runs `eslint --max-warnings 0` — the warning ratchet has reached its floor. **Zero warnings are tolerated**: any new warning fails lint (and CI). Historically the bulk were `@typescript-eslint/no-unnecessary-condition` (over-defensive null/undefined guards the type system already rules out).
 
-**Target: 20 warnings.** Legitimately-defensive code at system boundaries may still trip the rule; 20 is the rough floor we expect once over-guarding is cleaned up.
-
-**When you specifically address lint warnings** (as opposed to incidentally touching a file and fixing a few), and the total drops below the previous threshold, **update `--max-warnings` in `package.json` to the new count** in the same commit. The ratchet should only ever move down, never up. If a refactor legitimately adds a warning, fix one elsewhere to keep the ceiling flat.
-
-Do not raise the threshold to accommodate new warnings. If a warning cannot be fixed, disable it per-line with `// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- <reason>` so the suppression is visible and reviewable.
+Keep it at zero. **Do not raise `--max-warnings` in `package.json` to accommodate a new warning** — fix the warning instead. If a warning is genuinely unavoidable (legitimately-defensive code at a system boundary), disable it per-line with `// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- <reason>` so the suppression is visible and reviewable. The threshold may only ever move down, never up.
 
 ## Documentation Reference
 
@@ -492,17 +503,20 @@ SESSION_SECRET=your-secret-key    # Session encryption
 
 The design engine is a multi-stage AI workflow at `src/lib/design-engine/`:
 
-**Stages** (sequential): Requirements Drafting → Requirements Review → BOM Drafting → BOM Review → Materialization → CAD Generation → CAD Review → Assembly Composition → Assembly Review
+**Stages** (sequential): Toolset Establishment → Toolset Review → Requirements Drafting → Requirements Review → BOM Drafting → BOM Review → Materialization → CAD Generation → CAD Review → Assembly Composition → Assembly Review
+
+The canonical stage enum is `DesignSessionStage` in `src/lib/design-engine/types.ts`.
 
 **Key concepts:**
 
 - Sessions are persisted in `design_sessions` table with JSONB artifacts
-- Each stage has a file in `stages/` implementing the engine logic
+- Each drafting/review stage pairs into one file in `stages/` (`toolset-establishment.ts`, `requirements.ts`, `bom.ts`, `cad-generation.ts`, `assembly-composition.ts`); materialization lives in `materialize.ts`, not `stages/`
+- Toolset Establishment captures the available manufacturing processes/tools and a scope (`in_house_only` | `in_house_preferred` | `unconstrained`); selections become per-BOM-node `ManufacturingConstraints` (FDM, laser-cut, CNC, …) that constrain downstream BOM and CAD generation
 - BOM drafting uses LLM tool-calling with tools defined in `tools/bom-tools.ts`
 - Materialization creates actual PLM items (parts, requirements, relationships, ECO) from the draft
 - CAD generation submits prompts to Zoo's Text-to-CAD API, uploads STEP files to vault
 - Assembly composition uses KCL (KittyCAD Language) code generation
-- SSE streaming for real-time updates via `/api/design-engine/sessions/$id/stream`
+- SSE streaming for real-time updates via `POST /api/v1/design-engine/sessions/:id/stream`
 - UI workspace at `/designs/collaborative/$sessionId`
 
 **CAD converter** (`workers/cad-converter/`): Python worker using pythonocc-core. Processes STEP/IGES files into STL + GLB (with per-face color preservation). Connects to RabbitMQ for job processing.

--- a/src/components/design-engine/ActivityFeed.tsx
+++ b/src/components/design-engine/ActivityFeed.tsx
@@ -197,6 +197,7 @@ export function ActivityFeed({
                 questionId={event.questionId}
                 question={event.question}
                 options={event.options}
+                multiSelect={event.multiSelect}
                 onAnswer={onAnswer}
               />
             )

--- a/src/components/design-engine/ArtifactPanel.tsx
+++ b/src/components/design-engine/ArtifactPanel.tsx
@@ -25,6 +25,7 @@ import { cn } from '@/lib/utils'
 interface ArtifactPanelProps {
   artifacts: DesignArtifacts
   currentStage: DesignSessionStage
+  isStreaming?: boolean
   onUpdateDescription?: (description: string) => void
   onUpdateRequirement?: (
     tempId: string,
@@ -43,6 +44,7 @@ interface ArtifactPanelProps {
 export function ArtifactPanel({
   artifacts,
   currentStage,
+  isStreaming,
   onUpdateDescription,
   onUpdateRequirement,
   onRemoveRequirement,
@@ -161,6 +163,7 @@ export function ArtifactPanel({
         <RequirementsPanel
           requirements={artifacts.requirements}
           currentStage={currentStage}
+          isStreaming={isStreaming}
           onUpdate={onUpdateRequirement}
           onRemove={onRemoveRequirement}
           onAdd={onAddRequirement}

--- a/src/components/design-engine/ClarificationPrompt.tsx
+++ b/src/components/design-engine/ClarificationPrompt.tsx
@@ -3,6 +3,8 @@
  */
 
 import { useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import { HelpCircle, Send } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
@@ -11,6 +13,7 @@ interface ClarificationPromptProps {
   questionId: string
   question: string
   options?: Array<string>
+  multiSelect?: boolean
   onAnswer?: (questionId: string, answer: string) => void
 }
 
@@ -18,26 +21,104 @@ export function ClarificationPrompt({
   questionId,
   question,
   options,
+  multiSelect,
   onAnswer,
 }: ClarificationPromptProps) {
   const [freeText, setFreeText] = useState('')
+  const [selected, setSelected] = useState<Set<string>>(new Set())
   const [answered, setAnswered] = useState(false)
 
+  const hasOptions = !!options && options.length > 0
+  const useChecklist = hasOptions && multiSelect === true
+
   const handleAnswer = (answer: string) => {
+    if (!answer.trim()) return
     setAnswered(true)
-    onAnswer?.(questionId, answer)
+    onAnswer?.(questionId, answer.trim())
+  }
+
+  const toggle = (option: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(option)) next.delete(option)
+      else next.add(option)
+      return next
+    })
+  }
+
+  const submitChecklist = () => {
+    if (selected.size === 0 && !freeText.trim()) return
+    const parts: Array<string> = []
+    if (selected.size > 0 && options) {
+      for (const opt of options) {
+        if (selected.has(opt)) parts.push(opt)
+      }
+    }
+    if (freeText.trim()) parts.push(freeText.trim())
+    handleAnswer(parts.join(', '))
   }
 
   return (
-    <div className="border border-yellow-200 dark:border-yellow-800 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg p-3 space-y-2">
+    <div className="border border-yellow-200 dark:border-yellow-800 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg p-3 space-y-3">
       <div className="flex items-start gap-2">
-        <HelpCircle className="h-4 w-4 text-yellow-600 dark:text-yellow-400 mt-0.5 flex-shrink-0" />
-        <p className="text-sm text-slate-700 dark:text-slate-300">{question}</p>
+        <HelpCircle className="h-4 w-4 text-yellow-600 dark:text-yellow-400 mt-1 flex-shrink-0" />
+        <div className="text-sm text-slate-700 dark:text-slate-200 prose prose-sm dark:prose-invert max-w-none [&_p]:my-1 [&_ul]:my-1 [&_ol]:my-1">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{question}</ReactMarkdown>
+        </div>
       </div>
 
-      {!answered && (
+      {!answered && useChecklist && (
+        <div className="pl-6 space-y-2">
+          <div className="flex flex-col gap-1.5">
+            {options.map((option) => {
+              const isOn = selected.has(option)
+              return (
+                <label
+                  key={option}
+                  className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200 cursor-pointer select-none"
+                >
+                  <input
+                    type="checkbox"
+                    checked={isOn}
+                    onChange={() => toggle(option)}
+                    className="h-4 w-4 rounded border-slate-300 dark:border-slate-600 text-cyan-600 focus:ring-cyan-500"
+                  />
+                  <span>{option}</span>
+                </label>
+              )
+            })}
+          </div>
+
+          <div className="flex gap-2 items-center">
+            <Input
+              value={freeText}
+              onChange={(e) => setFreeText(e.target.value)}
+              placeholder="Add a note (optional)…"
+              className="text-sm h-8 flex-1"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  submitChecklist()
+                }
+              }}
+            />
+            <Button
+              variant="default"
+              size="sm"
+              onClick={submitChecklist}
+              disabled={selected.size === 0 && !freeText.trim()}
+              className="h-8"
+            >
+              Submit
+              <Send className="h-3 w-3 ml-1.5" />
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {!answered && !useChecklist && (
         <>
-          {options && options.length > 0 && (
+          {hasOptions && (
             <div className="flex flex-wrap gap-2 pl-6">
               {options.map((option) => (
                 <Button
@@ -61,14 +142,15 @@ export function ClarificationPrompt({
               className="text-sm h-8"
               onKeyDown={(e) => {
                 if (e.key === 'Enter' && freeText.trim()) {
-                  handleAnswer(freeText.trim())
+                  handleAnswer(freeText)
                 }
               }}
             />
             <Button
               variant="default"
               size="sm"
-              onClick={() => freeText.trim() && handleAnswer(freeText.trim())}
+              onClick={() => handleAnswer(freeText)}
+              disabled={!freeText.trim()}
               className="h-8 px-2"
             >
               <Send className="h-3 w-3" />

--- a/src/components/design-engine/CollaborativeWorkspace.tsx
+++ b/src/components/design-engine/CollaborativeWorkspace.tsx
@@ -326,6 +326,7 @@ export function CollaborativeWorkspace({
             <ArtifactPanel
               artifacts={stream.artifacts}
               currentStage={stream.currentStage}
+              isStreaming={stream.isStreaming}
               onUpdateDescription={handleUpdateDescription}
               onUpdateRequirement={handleUpdateRequirement}
               onRemoveRequirement={handleRemoveRequirement}
@@ -348,7 +349,7 @@ export function CollaborativeWorkspace({
             showStartBom ||
             showGenerateCad ||
             showStartAssembly) && (
-            <div className="p-4 border-b border-slate-200 dark:border-slate-700">
+            <div className="p-4 border-b border-slate-200 dark:border-slate-700 space-y-2">
               <Button
                 variant="default"
                 onClick={
@@ -381,6 +382,15 @@ export function CollaborativeWorkspace({
                         ? 'Generate CAD Files'
                         : 'Start Assembly Composition'}
               </Button>
+              {showStartToolset && (
+                <Button
+                  variant="ghost"
+                  onClick={handleStartRequirements}
+                  className="w-full text-xs text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+                >
+                  Skip toolset — go straight to Requirements
+                </Button>
+              )}
             </div>
           )}
 

--- a/src/components/design-engine/RequirementsPanel.tsx
+++ b/src/components/design-engine/RequirementsPanel.tsx
@@ -53,6 +53,7 @@ const TYPE_LABELS: Record<string, string> = {
 interface RequirementsPanelProps {
   requirements: Array<RequirementDraft>
   currentStage: DesignSessionStage
+  isStreaming?: boolean
   onUpdate?: (tempId: string, data: Partial<RequirementDraft>) => void
   onRemove?: (tempId: string) => void
   onAdd?: (data: Partial<RequirementDraft>) => void
@@ -62,6 +63,7 @@ interface RequirementsPanelProps {
 export function RequirementsPanel({
   requirements,
   currentStage,
+  isStreaming,
   onUpdate,
   onRemove,
   onAdd,
@@ -82,9 +84,10 @@ export function RequirementsPanel({
   const [newType, setNewType] =
     useState<RequirementDraft['requirementType']>('Functional')
 
-  const canEdit =
+  const inEditableStage =
     currentStage === 'requirements_review' ||
     currentStage === 'requirements_drafting'
+  const canEdit = inEditableStage && !isStreaming
   const canConfirm =
     currentStage === 'requirements_review' && requirements.length > 0
 
@@ -132,7 +135,7 @@ export function RequirementsPanel({
         </h3>
         {canEdit && (
           <Button
-            variant="ghost"
+            variant="outline"
             size="sm"
             onClick={() => setAddingNew(true)}
             className="h-7 text-xs gap-1"
@@ -142,6 +145,14 @@ export function RequirementsPanel({
           </Button>
         )}
       </div>
+
+      {inEditableStage && requirements.length > 0 && (
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          {canEdit
+            ? 'Use Edit to refine a requirement, or Reject to remove one.'
+            : 'Pause the AI to edit or reject requirements.'}
+        </p>
+      )}
 
       {requirements.length === 0 && !addingNew && (
         <p className="text-xs text-slate-400 dark:text-slate-500 py-2">
@@ -246,23 +257,35 @@ export function RequirementsPanel({
                       </p>
                     )}
                   </div>
-                  {canEdit && (
-                    <div className="flex gap-1 flex-shrink-0">
+                  {inEditableStage && (
+                    <div className="flex gap-1.5 flex-shrink-0">
                       <Button
-                        variant="ghost"
+                        variant="outline"
                         size="sm"
                         onClick={() => startEdit(req)}
-                        className="h-6 w-6 p-0"
+                        disabled={!canEdit}
+                        className="h-7 px-2 text-xs gap-1"
+                        title={
+                          canEdit ? 'Edit requirement' : 'Pause the AI to edit'
+                        }
                       >
                         <Pencil className="h-3 w-3" />
+                        Edit
                       </Button>
                       <Button
-                        variant="ghost"
+                        variant="outline"
                         size="sm"
                         onClick={() => onRemove?.(req.tempId)}
-                        className="h-6 w-6 p-0 text-red-500 hover:text-red-700"
+                        disabled={!canEdit}
+                        className="h-7 px-2 text-xs gap-1 text-red-600 border-red-200 hover:bg-red-50 hover:text-red-700 dark:text-red-400 dark:border-red-900 dark:hover:bg-red-950"
+                        title={
+                          canEdit
+                            ? 'Reject this requirement'
+                            : 'Pause the AI to reject'
+                        }
                       >
                         <Trash2 className="h-3 w-3" />
+                        Reject
                       </Button>
                     </div>
                   )}

--- a/src/lib/design-engine/prompts/bom-prompt.ts
+++ b/src/lib/design-engine/prompts/bom-prompt.ts
@@ -42,6 +42,7 @@ export function buildBomPrompt(
   existingBom?: BomDraft | null,
   schemaContext?: string,
   toolset?: DesignSessionToolset,
+  priorToolCalls?: string,
 ): string {
   const requirementsList = requirements
     .map(
@@ -249,6 +250,10 @@ apply_mechanism_template({
 
   if (schemaContext) {
     prompt += `\n## PLM Schema Context\n${schemaContext}\n`
+  }
+
+  if (priorToolCalls) {
+    prompt += `\n${priorToolCalls}\n`
   }
 
   const phaseCount =

--- a/src/lib/design-engine/prompts/requirements-prompt.ts
+++ b/src/lib/design-engine/prompts/requirements-prompt.ts
@@ -14,6 +14,7 @@ export function buildRequirementsPrompt(
   userMessages?: Array<UserMessage>,
   existingRequirements?: Array<RequirementDraft>,
   schemaContext?: string,
+  priorToolCalls?: string,
 ): string {
   let prompt = `You are a systems engineering assistant helping design a product. Your task is to analyze a product description and generate complete and fully detailed structured requirements.
 
@@ -75,6 +76,10 @@ ${description}
 
   if (schemaContext) {
     prompt += `\n## PLM Schema Context\n${schemaContext}\n`
+  }
+
+  if (priorToolCalls) {
+    prompt += `\n${priorToolCalls}\n`
   }
 
   prompt += `\nBegin by searching for similar designs, then propose requirements one at a time.`

--- a/src/lib/design-engine/prompts/tool-call-summary.test.ts
+++ b/src/lib/design-engine/prompts/tool-call-summary.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { summarizeToolCalls } from './tool-call-summary'
+import type { LlmHistoryEntry } from '../types'
+
+/** A recorded tool *call* history entry (args, no result). */
+function call(toolName: string, args: unknown): LlmHistoryEntry {
+  return { role: 'tool', content: JSON.stringify({ toolName, args }) }
+}
+
+/** A recorded tool *result* history entry (result, no args). */
+function result(toolName: string, res: unknown): LlmHistoryEntry {
+  return { role: 'tool', content: JSON.stringify({ toolName, result: res }) }
+}
+
+describe('summarizeToolCalls', () => {
+  it('returns empty string for missing / empty history', () => {
+    expect(summarizeToolCalls(undefined)).toBe('')
+    expect(summarizeToolCalls(null)).toBe('')
+    expect(summarizeToolCalls([])).toBe('')
+  })
+
+  it('returns empty string when there are no tool-role entries', () => {
+    const history: Array<LlmHistoryEntry> = [
+      { role: 'assistant', content: 'thinking out loud' },
+      { role: 'user', content: 'hello' },
+    ]
+    expect(summarizeToolCalls(history)).toBe('')
+  })
+
+  it('summarizes a search call + result as a "N results" line', () => {
+    const history = [
+      call('search_parts', { query: 'bearing' }),
+      result('search_parts', { items: [], total: 3 }),
+    ]
+    const out = summarizeToolCalls(history)
+    expect(out).toContain('## Prior Tool Calls')
+    expect(out).toContain('`search_parts(query: "bearing")` → 3 results')
+  })
+
+  it('uses singular "result" when total is 1', () => {
+    const history = [
+      call('search_parts', { query: 'motor' }),
+      result('search_parts', { items: [{}], total: 1 }),
+    ]
+    expect(summarizeToolCalls(history)).toContain('→ 1 result')
+  })
+
+  it('describes a mutation result via tempId (guards MUTATION_TOOLS names)', () => {
+    const history = [
+      call('propose_requirement', { name: 'Withstand 5G load' }),
+      result('propose_requirement', { tempId: 'req-1', added: true }),
+    ]
+    const out = summarizeToolCalls(history)
+    expect(out).toContain(
+      '`propose_requirement(name: "Withstand 5G load")` → tempId=req-1',
+    )
+  })
+
+  it('recognizes the corrected BOM mutation tool names', () => {
+    const history = [
+      call('propose_new_part', { name: 'Bracket' }),
+      result('propose_new_part', { tempId: 'part-9' }),
+    ]
+    expect(summarizeToolCalls(history)).toContain(
+      '`propose_new_part(name: "Bracket")` → tempId=part-9',
+    )
+  })
+
+  it('collapses duplicate identical call lines', () => {
+    const history = [
+      call('search_parts', { query: 'screw' }),
+      result('search_parts', { total: 2 }),
+      call('search_parts', { query: 'screw' }),
+      result('search_parts', { total: 2 }),
+    ]
+    const out = summarizeToolCalls(history)
+    const occurrences = out.split('`search_parts(query: "screw")`').length - 1
+    expect(occurrences).toBe(1)
+  })
+
+  it('marks a call with no matching result', () => {
+    const history = [call('search_parts', { query: 'orphan' })]
+    expect(summarizeToolCalls(history)).toContain('→ no result captured')
+  })
+
+  it('omits the header when nothing pairs into a line', () => {
+    // Only a result entry (no call) — nothing to summarize.
+    const history = [result('search_parts', { total: 5 })]
+    expect(summarizeToolCalls(history)).toBe('')
+  })
+})

--- a/src/lib/design-engine/prompts/tool-call-summary.ts
+++ b/src/lib/design-engine/prompts/tool-call-summary.ts
@@ -1,0 +1,165 @@
+/**
+ * Builds a markdown summary of prior tool calls from a session's llmHistory,
+ * for injection into stage system prompts on resume so the LLM does not
+ * redundantly re-run searches that already executed.
+ */
+
+import type { LlmHistoryEntry } from '../types'
+
+interface ParsedToolEntry {
+  toolName: string
+  args?: unknown
+  result?: unknown
+}
+
+const SEARCH_TOOLS = new Set([
+  'search_tool_library',
+  'search_existing_designs',
+  'search_parts_library',
+  'search_parts',
+  'lookup_component_catalog',
+])
+
+const MUTATION_TOOLS = new Set([
+  'add_session_tool',
+  'set_manufacturing_scope',
+  'propose_requirement',
+  'propose_new_part',
+  'add_existing_to_bom',
+  'set_bom_parent',
+  'set_part_interfaces',
+  'set_assembly_interface_mappings',
+  'link_requirement_to_part',
+  'assign_manufacturing',
+  'apply_mechanism_template',
+])
+
+function parseToolEntry(content: string): ParsedToolEntry | null {
+  try {
+    const parsed = JSON.parse(content) as unknown
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'toolName' in parsed &&
+      typeof (parsed as { toolName: unknown }).toolName === 'string'
+    ) {
+      return parsed as ParsedToolEntry
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+function formatArgs(args: unknown): string {
+  if (args === undefined || args === null) return ''
+  if (typeof args !== 'object') return JSON.stringify(args)
+  const obj = args as Record<string, unknown>
+  const pairs: Array<string> = []
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined) continue
+    if (typeof v === 'string') {
+      pairs.push(`${k}: ${JSON.stringify(v)}`)
+    } else if (typeof v === 'number' || typeof v === 'boolean') {
+      pairs.push(`${k}: ${String(v)}`)
+    } else if (Array.isArray(v)) {
+      pairs.push(`${k}: [${v.length} items]`)
+    } else {
+      pairs.push(`${k}: …`)
+    }
+  }
+  return pairs.join(', ')
+}
+
+function describeResult(toolName: string, result: unknown): string {
+  if (result === undefined || result === null) return 'no result'
+  if (typeof result !== 'object') return String(result)
+  const obj = result as Record<string, unknown>
+
+  if (SEARCH_TOOLS.has(toolName)) {
+    if (typeof obj.total === 'number') {
+      return `${obj.total} result${obj.total === 1 ? '' : 's'}`
+    }
+    for (const key of ['tools', 'items', 'parts', 'designs']) {
+      const v = obj[key]
+      if (Array.isArray(v)) {
+        return `${v.length} result${v.length === 1 ? '' : 's'}`
+      }
+    }
+    return 'unknown count'
+  }
+
+  if (MUTATION_TOOLS.has(toolName)) {
+    if (typeof obj.name === 'string') return `added "${obj.name}"`
+    if (typeof obj.tempId === 'string') return `tempId=${obj.tempId}`
+    if (obj.added === true || obj.acknowledged === true) return 'applied'
+    if (obj.linked === true) return 'linked'
+    if (typeof obj.scope === 'string') return `scope=${obj.scope}`
+    return 'applied'
+  }
+
+  if (typeof obj.acknowledged === 'boolean') {
+    return obj.acknowledged ? 'acknowledged' : 'declined'
+  }
+  return 'completed'
+}
+
+/**
+ * Walks llmHistory and produces a deduplicated, ordered bullet list of prior
+ * tool calls with their outcomes. Returns an empty string if there's nothing
+ * to summarize so callers can omit the prompt section entirely.
+ */
+export function summarizeToolCalls(
+  history: Array<LlmHistoryEntry> | null | undefined,
+): string {
+  if (!history || history.length === 0) return ''
+
+  const toolEntries: Array<ParsedToolEntry> = []
+  for (const entry of history) {
+    if (entry.role !== 'tool') continue
+    const parsed = parseToolEntry(entry.content)
+    if (parsed) toolEntries.push(parsed)
+  }
+
+  if (toolEntries.length === 0) return ''
+
+  // Pair each "call" (has args, no result) with the next entry sharing the
+  // same toolName that has a result.
+  const lines: Array<string> = []
+  const seen = new Set<string>()
+  const used = new Set<number>()
+
+  for (let i = 0; i < toolEntries.length; i++) {
+    if (used.has(i)) continue
+    const entry = toolEntries[i]
+    if (entry.result !== undefined) continue
+    if (entry.args === undefined) continue
+
+    let resultDesc = 'no result captured'
+    for (let j = i + 1; j < toolEntries.length; j++) {
+      if (used.has(j)) continue
+      const candidate = toolEntries[j]
+      if (candidate.toolName !== entry.toolName) continue
+      if (candidate.result === undefined) continue
+      resultDesc = describeResult(entry.toolName, candidate.result)
+      used.add(j)
+      break
+    }
+
+    const argsText = formatArgs(entry.args)
+    const line = `- \`${entry.toolName}(${argsText})\` → ${resultDesc}`
+    if (!seen.has(line)) {
+      lines.push(line)
+      seen.add(line)
+    }
+  }
+
+  if (lines.length === 0) return ''
+
+  return [
+    '## Prior Tool Calls',
+    'These tool calls already ran in this session. Their results still hold — do NOT repeat them. Use them as background instead of re-searching.',
+    '',
+    ...lines,
+  ].join('\n')
+}

--- a/src/lib/design-engine/prompts/toolset-prompt.ts
+++ b/src/lib/design-engine/prompts/toolset-prompt.ts
@@ -17,6 +17,7 @@ export function buildToolsetPrompt(
   clarifications?: Array<ClarificationEntry>,
   userMessages?: Array<UserMessage>,
   existingToolset?: DesignSessionToolset | null,
+  priorToolCalls?: string,
 ): string {
   let prompt = `You are a manufacturing engineer analyzing what tools and equipment are available for a product design session. Your task is to establish the manufacturing toolset that will be used during this design.
 
@@ -96,6 +97,10 @@ After searching and gathering information, present a summary:
     prompt += `\n## Current Toolset (Resume)\nThe following tools have already been added to the session:\n`
     prompt += formatToolsetSummary(existingToolset)
     prompt += `\nReview this existing toolset, incorporate any new clarification answers or user guidance, and continue the establishment process. Do not re-add tools that are already in the session.\n`
+  }
+
+  if (priorToolCalls) {
+    prompt += `\n${priorToolCalls}\n`
   }
 
   return prompt

--- a/src/lib/design-engine/stages/bom.ts
+++ b/src/lib/design-engine/stages/bom.ts
@@ -16,9 +16,11 @@ import {
   buildBomContinuationPrompt,
   buildBomPrompt,
 } from '../prompts/bom-prompt'
+import { summarizeToolCalls } from '../prompts/tool-call-summary'
 import { createBomTools } from '../tools/bom-tools'
 import { validateBomDraft } from '../validation/bom-validator'
 import { DesignSessionService } from '../session-service'
+import { createToolEventTracker } from './tool-event-tracker'
 import type { DesignSession } from '../session-service'
 import type {
   BomDraft,
@@ -157,6 +159,7 @@ export async function* runBomStage(
       questionId: string
       question: string
       options?: Array<string>
+      multiSelect?: boolean
     } | null
   } = { requested: false, data: null }
 
@@ -166,9 +169,11 @@ export async function* runBomStage(
     (bom) => {
       bomRef.current = bom
     },
-    (questionId, question, options) => {
+    (questionId, question, options, multiSelect) => {
+      // First clarification in a round wins — don't let a later one overwrite it.
+      if (clarificationRef.requested) return
       clarificationRef.requested = true
-      clarificationRef.data = { questionId, question, options }
+      clarificationRef.data = { questionId, question, options, multiSelect }
     },
   )
 
@@ -178,6 +183,9 @@ export async function* runBomStage(
     const adapter = getAdapter(providerConfig)
 
     // Build system prompt with clarification/user message context
+    const priorToolCalls = isResuming
+      ? summarizeToolCalls(session.llmHistory)
+      : ''
     const systemPrompt = buildBomPrompt(
       description,
       artifacts.requirements,
@@ -188,6 +196,7 @@ export async function* runBomStage(
       isResuming && artifacts.bom ? artifacts.bom : undefined,
       undefined, // schemaContext
       artifacts.toolset ?? undefined,
+      priorToolCalls || undefined,
     )
 
     // Build messages - cast to satisfy TanStack AI's constrained message types
@@ -209,6 +218,8 @@ export async function* runBomStage(
     ): AsyncGenerator<StageEvent, boolean> {
       let lastBomVersion = bomState.changeVersion
       let accumulatedText = ''
+      // Fresh tracker per stream — pending args are keyed by a per-call index.
+      const tracker = createToolEventTracker()
 
       for await (const chunk of streamIter) {
         if (clarificationRef.requested || signal?.aborted) break
@@ -220,6 +231,10 @@ export async function* runBomStage(
             yield { type: 'llm_text', text: delta }
           }
         }
+
+        // Translate SDK tool chunks into tool_call/tool_result events so they're
+        // captured into llmHistory (and shown in the activity feed).
+        for (const ev of tracker.handle(chunk)) yield ev
 
         if (bomRef.current && bomState.changeVersion > lastBomVersion) {
           artifacts.bom = bomRef.current
@@ -268,6 +283,7 @@ export async function* runBomStage(
         id: clarificationRef.data.questionId,
         question: clarificationRef.data.question,
         options: clarificationRef.data.options,
+        multiSelect: clarificationRef.data.multiSelect,
       }
       await DesignSessionService.updateArtifacts(session.id, artifacts)
 
@@ -276,6 +292,7 @@ export async function* runBomStage(
         questionId: clarificationRef.data.questionId,
         question: clarificationRef.data.question,
         options: clarificationRef.data.options,
+        multiSelect: clarificationRef.data.multiSelect,
       }
 
       yield { type: 'paused', reason: 'Waiting for your answer...' }
@@ -306,6 +323,7 @@ export async function* runBomStage(
         bomRef.current,
         undefined, // schemaContext
         artifacts.toolset ?? undefined,
+        priorToolCalls || undefined,
       )
 
       const contUserMessage = buildBomContinuationPrompt(gaps)
@@ -348,6 +366,7 @@ export async function* runBomStage(
           questionId: string
           question: string
           options?: Array<string>
+          multiSelect?: boolean
         }
         if (bomRef.current) {
           artifacts.bom = bomRef.current
@@ -357,6 +376,7 @@ export async function* runBomStage(
           id: clarData.questionId,
           question: clarData.question,
           options: clarData.options,
+          multiSelect: clarData.multiSelect,
         }
         await DesignSessionService.updateArtifacts(session.id, artifacts)
 
@@ -365,6 +385,7 @@ export async function* runBomStage(
           questionId: clarData.questionId,
           question: clarData.question,
           options: clarData.options,
+          multiSelect: clarData.multiSelect,
         }
 
         yield { type: 'paused', reason: 'Waiting for your answer...' }

--- a/src/lib/design-engine/stages/requirements.ts
+++ b/src/lib/design-engine/stages/requirements.ts
@@ -10,13 +10,18 @@
  * When the user answers, the stage is re-invoked with enriched context.
  */
 
-import { chat } from '@tanstack/ai'
+import { chat, maxIterations } from '@tanstack/ai'
 import { buildRequirementsPrompt } from '../prompts/requirements-prompt'
+import { summarizeToolCalls } from '../prompts/tool-call-summary'
 import { createRequirementsTools } from '../tools/requirements-tools'
 import { DesignSessionService } from '../session-service'
+import { createToolEventTracker } from './tool-event-tracker'
 import type { DesignSession } from '../session-service'
 import type { DesignArtifacts, RequirementDraft, StageEvent } from '../types'
 import { getAdapter, loadProviderConfig } from '@/lib/ai/adapters'
+
+/** Cap the tool-calling loop so a search-then-propose sequence isn't cut short. */
+const REQUIREMENTS_MAX_ITERATIONS = 20
 
 export async function* runRequirementsStage(
   session: DesignSession,
@@ -60,17 +65,28 @@ export async function* runRequirementsStage(
       questionId: string
       question: string
       options?: Array<string>
+      multiSelect?: boolean
     } | null
   } = { requested: false, data: null }
 
   const tools = createRequirementsTools(
     toolContext,
     (requirement) => {
+      // Structural dedup: same normalized name → return the existing tempId
+      // instead of adding a duplicate (guards re-proposes on resume).
+      const normalized = requirement.name.trim().toLowerCase()
+      const existing = proposedRequirements.find(
+        (r) => r.name.trim().toLowerCase() === normalized,
+      )
+      if (existing) return { tempId: existing.tempId, added: false }
       proposedRequirements.push(requirement)
+      return { tempId: requirement.tempId, added: true }
     },
-    (questionId, question, options) => {
+    (questionId, question, options, multiSelect) => {
+      // First clarification in a round wins — don't let a later one overwrite it.
+      if (clarificationRef.requested) return
       clarificationRef.requested = true
-      clarificationRef.data = { questionId, question, options }
+      clarificationRef.data = { questionId, question, options, multiSelect }
     },
   )
 
@@ -80,6 +96,9 @@ export async function* runRequirementsStage(
     const adapter = getAdapter(providerConfig)
 
     // Build system prompt with clarification/user message context
+    const priorToolCalls = isResuming
+      ? summarizeToolCalls(session.llmHistory)
+      : ''
     const systemPrompt = buildRequirementsPrompt(
       description,
       artifacts.clarifications.length > 0
@@ -89,6 +108,8 @@ export async function* runRequirementsStage(
       isResuming && artifacts.requirements.length > 0
         ? artifacts.requirements
         : undefined,
+      undefined,
+      priorToolCalls || undefined,
     )
 
     // Build messages - cast to satisfy TanStack AI's constrained message types
@@ -114,11 +135,13 @@ export async function* runRequirementsStage(
       messages,
       tools,
       maxTokens: 16384,
+      agentLoopStrategy: maxIterations(REQUIREMENTS_MAX_ITERATIONS),
       abortController,
     })
 
     let lastRequirementsCount = artifacts.requirements.length
     let accumulatedText = ''
+    const tracker = createToolEventTracker()
 
     for await (const chunk of stream) {
       // Check if clarification was requested or abort signalled — break out of loop
@@ -133,17 +156,12 @@ export async function* runRequirementsStage(
         }
       }
 
+      // Translate SDK tool chunks into tool_call/tool_result events so they're
+      // captured into llmHistory (and shown in the activity feed).
+      for (const ev of tracker.handle(chunk)) yield ev
+
       // Check for new requirements and yield artifact updates
       if (proposedRequirements.length > lastRequirementsCount) {
-        const newReqs = proposedRequirements.slice(lastRequirementsCount)
-        for (const req of newReqs) {
-          yield {
-            type: 'tool_result',
-            toolName: 'propose_requirement',
-            result: { tempId: req.tempId, name: req.name },
-          }
-        }
-
         artifacts.requirements = [...proposedRequirements]
         yield {
           type: 'artifact_update',
@@ -163,6 +181,7 @@ export async function* runRequirementsStage(
         id: clarificationRef.data.questionId,
         question: clarificationRef.data.question,
         options: clarificationRef.data.options,
+        multiSelect: clarificationRef.data.multiSelect,
       }
       await DesignSessionService.updateArtifacts(session.id, artifacts)
 
@@ -171,6 +190,7 @@ export async function* runRequirementsStage(
         questionId: clarificationRef.data.questionId,
         question: clarificationRef.data.question,
         options: clarificationRef.data.options,
+        multiSelect: clarificationRef.data.multiSelect,
       }
 
       yield { type: 'paused', reason: 'Waiting for your answer...' }

--- a/src/lib/design-engine/stages/tool-event-tracker.test.ts
+++ b/src/lib/design-engine/stages/tool-event-tracker.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import { createToolEventTracker } from './tool-event-tracker'
+
+function callChunk(index: number, id: string, name: string, args: string) {
+  return {
+    type: 'tool_call',
+    index,
+    toolCall: { id, type: 'function', function: { name, arguments: args } },
+  }
+}
+
+function resultChunk(toolCallId: string, content: string) {
+  return { type: 'tool_result', toolCallId, content }
+}
+
+function doneChunk(finishReason: string) {
+  return { type: 'done', finishReason }
+}
+
+describe('createToolEventTracker', () => {
+  it('ignores non-tool chunks', () => {
+    const t = createToolEventTracker()
+    expect(t.handle({ type: 'content', content: 'hi' })).toEqual([])
+    expect(t.handle({ type: 'thinking', content: '...' })).toEqual([])
+    expect(t.handle('not even an object')).toEqual([])
+  })
+
+  it('reassembles incrementally streamed arguments and pairs the result', () => {
+    const t = createToolEventTracker()
+    // id + name arrive on the first fragment; args stream in pieces (same index).
+    expect(t.handle(callChunk(0, 'c1', 'search_parts', '{"query":'))).toEqual([])
+    expect(t.handle(callChunk(0, '', '', '"bear'))).toEqual([])
+    expect(t.handle(callChunk(0, '', '', 'ing"}'))).toEqual([])
+
+    const events = t.handle(resultChunk('c1', '{"items":[],"total":2}'))
+    expect(events).toEqual([
+      { type: 'tool_call', toolName: 'search_parts', args: { query: 'bearing' } },
+      {
+        type: 'tool_result',
+        toolName: 'search_parts',
+        result: { items: [], total: 2 },
+      },
+    ])
+  })
+
+  it('emits the tool_call before its tool_result', () => {
+    const t = createToolEventTracker()
+    t.handle(callChunk(0, 'c1', 'search_parts', '{}'))
+    const events = t.handle(resultChunk('c1', '{"total":0}'))
+    expect(events.map((e) => e.type)).toEqual(['tool_call', 'tool_result'])
+  })
+
+  it('maps parallel calls to the correct result names', () => {
+    const t = createToolEventTracker()
+    t.handle(callChunk(0, 'a', 'search_parts', '{"q":"x"}'))
+    t.handle(callChunk(1, 'b', 'lookup_component_catalog', '{"q":"y"}'))
+
+    // done flush emits both tool_call events, in index order.
+    const flushed = t.handle(doneChunk('tool_calls'))
+    expect(flushed.map((e) => e.type)).toEqual(['tool_call', 'tool_call'])
+
+    const resA = t.handle(resultChunk('a', '{"total":1}'))
+    const resB = t.handle(resultChunk('b', '{"total":2}'))
+    expect(resA).toEqual([
+      { type: 'tool_result', toolName: 'search_parts', result: { total: 1 } },
+    ])
+    expect(resB).toEqual([
+      {
+        type: 'tool_result',
+        toolName: 'lookup_component_catalog',
+        result: { total: 2 },
+      },
+    ])
+  })
+
+  it('does not emit a tool_call twice (done flush + result flush)', () => {
+    const t = createToolEventTracker()
+    t.handle(callChunk(0, 'a', 'search_parts', '{}'))
+    expect(t.handle(doneChunk('tool_calls')).map((e) => e.type)).toEqual([
+      'tool_call',
+    ])
+    // The result must NOT re-emit the already-flushed tool_call.
+    const events = t.handle(resultChunk('a', '{"total":0}'))
+    expect(events.map((e) => e.type)).toEqual(['tool_result'])
+  })
+
+  it('ignores a done chunk that is not a tool round', () => {
+    const t = createToolEventTracker()
+    t.handle(callChunk(0, 'a', 'search_parts', '{}'))
+    expect(t.handle(doneChunk('stop'))).toEqual([])
+  })
+
+  it('wraps non-object result payloads as { value }', () => {
+    const t = createToolEventTracker()
+    t.handle(callChunk(0, 'a', 'get_item_details', '{}'))
+    const strResult = t.handle(resultChunk('a', '"just text"'))
+    expect(strResult).toContainEqual({
+      type: 'tool_result',
+      toolName: 'get_item_details',
+      result: { value: 'just text' },
+    })
+  })
+
+  it('handles non-JSON result content gracefully', () => {
+    const t = createToolEventTracker()
+    t.handle(callChunk(0, 'a', 'get_item_details', '{}'))
+    const events = t.handle(resultChunk('a', 'totally not json'))
+    expect(events).toContainEqual({
+      type: 'tool_result',
+      toolName: 'get_item_details',
+      result: { value: 'totally not json' },
+    })
+  })
+
+  it('falls back to "unknown" when a result has no known tool_call', () => {
+    const t = createToolEventTracker()
+    const events = t.handle(resultChunk('ghost', '{"total":0}'))
+    expect(events).toEqual([
+      { type: 'tool_result', toolName: 'unknown', result: { total: 0 } },
+    ])
+  })
+})

--- a/src/lib/design-engine/stages/tool-event-tracker.ts
+++ b/src/lib/design-engine/stages/tool-event-tracker.ts
@@ -1,0 +1,153 @@
+/**
+ * Tool-event tracker
+ *
+ * Translates the raw stream chunks emitted by TanStack AI's `chat()` into
+ * design-engine `StageEvent`s of type `tool_call` / `tool_result`.
+ *
+ * Why this exists: the SDK streams tool arguments incrementally as JSON string
+ * fragments (multiple `tool_call` chunks share an `index`), and `tool_result`
+ * chunks carry only a `toolCallId` — never the tool name. This helper
+ * reassembles the arguments, maps `toolCallId → name`, and emits one
+ * `tool_call` event (with parsed args) immediately before its matching
+ * `tool_result` event. Those events feed `wrapWithHistoryCapture` in
+ * `engine.ts`, which is what populates `llmHistory` for the resume-time
+ * `summarizeToolCalls` prompt.
+ *
+ * SDK chunk shapes (see `@tanstack/ai` `types.ts`):
+ *   tool_call   → { type, index, toolCall: { id, function: { name, arguments } } }
+ *   tool_result → { type, toolCallId, content }   (content = JSON.stringify(result))
+ *   done        → { type, finishReason }           ('tool_calls' ends a round)
+ */
+
+import type { StageEvent } from '../types'
+
+interface PendingCall {
+  id: string
+  name: string
+  args: string
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null
+}
+
+/** Parse accumulated argument fragments into an object (empty on failure). */
+function parseArgs(raw: string): Record<string, unknown> {
+  if (!raw) return {}
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return isRecord(parsed) ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+/** Parse a tool_result payload; wrap non-object results as `{ value }`. */
+function parseResult(content: string): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(content)
+    return isRecord(parsed) ? parsed : { value: parsed }
+  } catch {
+    return { value: content }
+  }
+}
+
+export interface ToolEventTracker {
+  /** Feed one raw SDK chunk; returns 0+ StageEvents to yield for it. */
+  handle: (chunk: unknown) => Array<StageEvent>
+}
+
+export function createToolEventTracker(): ToolEventTracker {
+  // Accumulate incremental tool_call fragments, keyed by the SDK's `index`.
+  const pending = new Map<number, PendingCall>()
+  // Resolve a tool_result's `toolCallId` back to its tool name.
+  const idToName = new Map<string, string>()
+  // Guard against emitting the same tool_call twice (done-flush + result-flush).
+  const emitted = new Set<string>()
+
+  function emitCall(entry: PendingCall): StageEvent | null {
+    if (!entry.id || !entry.name) return null
+    if (emitted.has(entry.id)) return null
+    emitted.add(entry.id)
+    idToName.set(entry.id, entry.name)
+    return {
+      type: 'tool_call',
+      toolName: entry.name,
+      args: parseArgs(entry.args),
+    }
+  }
+
+  /** Emit tool_call events for every complete pending entry. */
+  function flushAll(): Array<StageEvent> {
+    const events: Array<StageEvent> = []
+    for (const index of Array.from(pending.keys())) {
+      const entry = pending.get(index)
+      if (!entry) continue
+      const ev = emitCall(entry)
+      if (ev) {
+        events.push(ev)
+        pending.delete(index)
+      }
+    }
+    return events
+  }
+
+  /** Emit the tool_call for a specific id (so it precedes its result). */
+  function flushForId(id: string): Array<StageEvent> {
+    for (const index of Array.from(pending.keys())) {
+      const entry = pending.get(index)
+      if (!entry || entry.id !== id) continue
+      const ev = emitCall(entry)
+      pending.delete(index)
+      return ev ? [ev] : []
+    }
+    return []
+  }
+
+  return {
+    handle(chunk: unknown): Array<StageEvent> {
+      if (!isRecord(chunk) || typeof chunk.type !== 'string') return []
+
+      if (chunk.type === 'tool_call') {
+        const toolCall = chunk.toolCall
+        if (!isRecord(toolCall)) return []
+        const index = typeof chunk.index === 'number' ? chunk.index : 0
+        const entry = pending.get(index) ?? { id: '', name: '', args: '' }
+        if (typeof toolCall.id === 'string' && toolCall.id) {
+          entry.id = toolCall.id
+        }
+        const fn = toolCall.function
+        if (isRecord(fn)) {
+          if (typeof fn.name === 'string' && fn.name) entry.name = fn.name
+          if (typeof fn.arguments === 'string') entry.args += fn.arguments
+        }
+        pending.set(index, entry)
+        if (entry.id && entry.name) idToName.set(entry.id, entry.name)
+        return []
+      }
+
+      if (chunk.type === 'done') {
+        return chunk.finishReason === 'tool_calls' ? flushAll() : []
+      }
+
+      if (chunk.type === 'tool_result') {
+        const toolCallId =
+          typeof chunk.toolCallId === 'string' ? chunk.toolCallId : ''
+        // Ensure the matching tool_call is emitted before its result.
+        const events = toolCallId ? flushForId(toolCallId) : []
+        const content =
+          typeof chunk.content === 'string'
+            ? chunk.content
+            : JSON.stringify(chunk.content ?? null)
+        events.push({
+          type: 'tool_result',
+          toolName: idToName.get(toolCallId) ?? 'unknown',
+          result: parseResult(content),
+        })
+        return events
+      }
+
+      return []
+    },
+  }
+}

--- a/src/lib/design-engine/stages/toolset-establishment.ts
+++ b/src/lib/design-engine/stages/toolset-establishment.ts
@@ -10,10 +10,12 @@
  * When the user answers, the stage is re-invoked with enriched context.
  */
 
-import { chat } from '@tanstack/ai'
+import { chat, maxIterations } from '@tanstack/ai'
 import { buildToolsetPrompt } from '../prompts/toolset-prompt'
+import { summarizeToolCalls } from '../prompts/tool-call-summary'
 import { createToolsetTools } from '../tools/toolset-tools'
 import { DesignSessionService } from '../session-service'
+import { createToolEventTracker } from './tool-event-tracker'
 import type { DesignSession } from '../session-service'
 import type {
   DesignArtifacts,
@@ -21,6 +23,9 @@ import type {
   StageEvent,
 } from '../types'
 import { getAdapter, loadProviderConfig } from '@/lib/ai/adapters'
+
+/** Cap the tool-calling loop so a search-then-add sequence isn't cut short. */
+const TOOLSET_MAX_ITERATIONS = 15
 
 export async function* runToolsetEstablishmentStage(
   session: DesignSession,
@@ -55,6 +60,7 @@ export async function* runToolsetEstablishmentStage(
       questionId: string
       question: string
       options?: Array<string>
+      multiSelect?: boolean
     } | null
   } = { requested: false, data: null }
 
@@ -64,9 +70,11 @@ export async function* runToolsetEstablishmentStage(
     (toolset) => {
       currentToolset = toolset
     },
-    (questionId, question, options) => {
+    (questionId, question, options, multiSelect) => {
+      // First clarification in a round wins — don't let a later one overwrite it.
+      if (clarificationRef.requested) return
       clarificationRef.requested = true
-      clarificationRef.data = { questionId, question, options }
+      clarificationRef.data = { questionId, question, options, multiSelect }
     },
   )
 
@@ -76,6 +84,9 @@ export async function* runToolsetEstablishmentStage(
     const adapter = getAdapter(providerConfig)
 
     // Build system prompt
+    const priorToolCalls = isResuming
+      ? summarizeToolCalls(session.llmHistory)
+      : ''
     const systemPrompt = buildToolsetPrompt(
       description,
       artifacts.clarifications.length > 0
@@ -85,6 +96,7 @@ export async function* runToolsetEstablishmentStage(
       isResuming && artifacts.toolset?.tools.length
         ? artifacts.toolset
         : undefined,
+      priorToolCalls || undefined,
     )
 
     // Build messages
@@ -110,11 +122,13 @@ export async function* runToolsetEstablishmentStage(
       messages,
       tools,
       maxTokens: 8192,
+      agentLoopStrategy: maxIterations(TOOLSET_MAX_ITERATIONS),
       abortController,
     })
 
     let lastToolCount = artifacts.toolset?.tools.length ?? 0
     let accumulatedText = ''
+    const tracker = createToolEventTracker()
 
     for await (const chunk of stream) {
       if (clarificationRef.requested || signal?.aborted) break
@@ -128,17 +142,12 @@ export async function* runToolsetEstablishmentStage(
         }
       }
 
+      // Translate SDK tool chunks into tool_call/tool_result events so they're
+      // captured into llmHistory (and shown in the activity feed).
+      for (const ev of tracker.handle(chunk)) yield ev
+
       // Check for toolset changes and yield artifact updates
       if (currentToolset.tools.length !== lastToolCount) {
-        const newTools = currentToolset.tools.slice(lastToolCount)
-        for (const tool of newTools) {
-          yield {
-            type: 'tool_result',
-            toolName: 'add_session_tool',
-            result: { sessionToolId: tool.id, name: tool.name },
-          }
-        }
-
         artifacts.toolset = { ...currentToolset }
         yield {
           type: 'artifact_update',
@@ -157,6 +166,7 @@ export async function* runToolsetEstablishmentStage(
         id: clarificationRef.data.questionId,
         question: clarificationRef.data.question,
         options: clarificationRef.data.options,
+        multiSelect: clarificationRef.data.multiSelect,
       }
       await DesignSessionService.updateArtifacts(session.id, artifacts)
 
@@ -165,6 +175,7 @@ export async function* runToolsetEstablishmentStage(
         questionId: clarificationRef.data.questionId,
         question: clarificationRef.data.question,
         options: clarificationRef.data.options,
+        multiSelect: clarificationRef.data.multiSelect,
       }
 
       yield { type: 'paused', reason: 'Waiting for your answer...' }

--- a/src/lib/design-engine/tools/bom-tools.ts
+++ b/src/lib/design-engine/tools/bom-tools.ts
@@ -11,6 +11,7 @@ import {
   getMechanismRoles,
   validateMechanismParameters,
 } from '../validation/mechanism-schemas'
+import { toolErrorMessage } from './tool-utils'
 import type { ToolContext } from '@/lib/ai/tools/permission-wrapper'
 import type {
   BomDraft,
@@ -43,6 +44,7 @@ export function createBomTools(
     questionId: string,
     question: string,
     options?: Array<string>,
+    multiSelect?: boolean,
   ) => void,
 ) {
   const searchParts = toolDefinition({
@@ -60,16 +62,21 @@ export function createBomTools(
     outputSchema: z.object({
       items: z.array(z.record(z.string(), z.unknown())),
       total: z.number(),
+      error: z.string().optional(),
     }),
   }).server(async (input) => {
-    return (await searchItemsHandler(
-      {
-        query: input.query,
-        itemType: input.itemType,
-        limit: input.limit ?? 10,
-      },
-      context,
-    )) as { items: Array<Record<string, unknown>>; total: number }
+    try {
+      return (await searchItemsHandler(
+        {
+          query: input.query,
+          itemType: input.itemType,
+          limit: input.limit ?? 10,
+        },
+        context,
+      )) as { items: Array<Record<string, unknown>>; total: number }
+    } catch (err) {
+      return { items: [], total: 0, error: toolErrorMessage(err) }
+    }
   })
 
   const lookupComponentCatalog = toolDefinition({
@@ -99,27 +106,32 @@ export function createBomTools(
       results: z.array(z.record(z.string(), z.unknown())),
       total: z.number(),
       message: z.string().optional(),
+      error: z.string().optional(),
     }),
   }).server(async (input) => {
-    const { results, total } = await CatalogService.search(input.query, {
-      categorySlug: input.category,
-      entryType: input.entryType,
-      limit: input.limit ?? 5,
-    })
+    try {
+      const { results, total } = await CatalogService.search(input.query, {
+        categorySlug: input.category,
+        entryType: input.entryType,
+        limit: input.limit ?? 5,
+      })
 
-    if (results.length === 0) {
-      return {
-        results: [],
-        total: 0,
-        message:
-          'No catalog matches found. Propose the part with your best knowledge of specs ' +
-          'and set requiresManualSourcing = true so engineers can source it manually.',
+      if (results.length === 0) {
+        return {
+          results: [],
+          total: 0,
+          message:
+            'No catalog matches found. Propose the part with your best knowledge of specs ' +
+            'and set requiresManualSourcing = true so engineers can source it manually.',
+        }
       }
-    }
 
-    return {
-      results: results as unknown as Array<Record<string, unknown>>,
-      total,
+      return {
+        results: results as unknown as Array<Record<string, unknown>>,
+        total,
+      }
+    } catch (err) {
+      return { results: [], total: 0, error: toolErrorMessage(err) }
     }
   })
 
@@ -132,10 +144,14 @@ export function createBomTools(
     }),
     outputSchema: z.record(z.string(), z.unknown()),
   }).server(async (input) => {
-    return (await getBomHandler(
-      { itemId: input.itemId, depth: input.depth },
-      context,
-    )) as Record<string, unknown>
+    try {
+      return (await getBomHandler(
+        { itemId: input.itemId, depth: input.depth },
+        context,
+      )) as Record<string, unknown>
+    } catch (err) {
+      return { error: toolErrorMessage(err) }
+    }
   })
 
   const getItemDetails = toolDefinition({
@@ -146,10 +162,14 @@ export function createBomTools(
     }),
     outputSchema: z.record(z.string(), z.unknown()),
   }).server(async (input) => {
-    return (await getItemDetailsHandler({ id: input.id }, context)) as Record<
-      string,
-      unknown
-    >
+    try {
+      return (await getItemDetailsHandler({ id: input.id }, context)) as Record<
+        string,
+        unknown
+      >
+    } catch (err) {
+      return { error: toolErrorMessage(err) }
+    }
   })
 
   const proposeNewPart = toolDefinition({
@@ -298,6 +318,14 @@ export function createBomTools(
       tempId: z.string(),
     }),
   }).server((input) => {
+    // Structural dedup: same name under the same parent → return the existing
+    // node instead of adding a duplicate (guards re-proposes on resume).
+    const normalizedName = input.name.trim().toLowerCase()
+    const duplicate = siblingsFor(input.parentTempId).find(
+      (n) => n.name.trim().toLowerCase() === normalizedName,
+    )
+    if (duplicate) return { tempId: duplicate.tempId }
+
     const tempId = crypto.randomUUID()
 
     const proposedPart: ProposedPart = {
@@ -383,6 +411,13 @@ export function createBomTools(
       tempId: z.string(),
     }),
   }).server((input) => {
+    // Structural dedup: same existing item under the same parent → return the
+    // existing node instead of adding a duplicate (guards re-adds on resume).
+    const duplicate = siblingsFor(input.parentTempId).find(
+      (n) => n.existingItemId === input.existingItemId,
+    )
+    if (duplicate) return { tempId: duplicate.tempId }
+
     const tempId = crypto.randomUUID()
     const bomNode: BomNodeDraft = {
       tempId,
@@ -468,17 +503,33 @@ export function createBomTools(
 
   const askBomClarification = toolDefinition({
     name: 'ask_bom_clarification',
-    description: 'Ask the user for clarification about the BOM structure.',
+    description:
+      'Ask the user for clarification about the BOM structure. ALWAYS provide `options` when the answer is a known choice from a finite set. Set `multiSelect: true` when more than one option can apply ("select all that apply").',
     inputSchema: z.object({
-      question: z.string(),
-      options: z.array(z.string()).optional(),
+      question: z
+        .string()
+        .describe(
+          'The question to ask the user. Keep it concise — options are rendered separately, so do not embed an inline list of choices in the question text.',
+        ),
+      options: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Suggested answers, presented as buttons or checkboxes. Provide these whenever the answer is a known choice from a finite set.',
+        ),
+      multiSelect: z
+        .boolean()
+        .optional()
+        .describe(
+          'True when the user can pick more than one option ("select all that apply"). Defaults to false (single choice).',
+        ),
     }),
     outputSchema: z.object({
       acknowledged: z.boolean(),
     }),
   }).server((input) => {
     const questionId = crypto.randomUUID()
-    onClarification(questionId, input.question, input.options)
+    onClarification(questionId, input.question, input.options, input.multiSelect)
     return { acknowledged: true }
   })
 
@@ -820,6 +871,22 @@ export function createBomTools(
     state.changeVersion++
     const bom = buildBomDraft(state)
     onUpdate(bom)
+  }
+
+  /**
+   * The sibling nodes a new node would join under `parentTempId` (or the root
+   * level when no parent is given). Used for structural dedup so a re-run after
+   * a resume doesn't append duplicate nodes under the same parent.
+   */
+  function siblingsFor(parentTempId?: string): Array<BomNodeDraft> {
+    if (parentTempId) {
+      const parent = state.nodes.get(parentTempId)
+      return parent ? parent.children : []
+    }
+    const root = state.rootTempId
+      ? state.nodes.get(state.rootTempId)
+      : undefined
+    return root ? [root] : []
   }
 
   return [

--- a/src/lib/design-engine/tools/requirements-tools.ts
+++ b/src/lib/design-engine/tools/requirements-tools.ts
@@ -7,6 +7,7 @@
 
 import { toolDefinition } from '@tanstack/ai'
 import { z } from 'zod'
+import { toolErrorMessage } from './tool-utils'
 import type { ToolContext } from '@/lib/ai/tools/permission-wrapper'
 import type { RequirementDraft } from '../types'
 import {
@@ -17,11 +18,17 @@ import {
 /** Create tool definitions for the requirements stage */
 export function createRequirementsTools(
   context: ToolContext,
-  onPropose: (requirement: RequirementDraft) => void,
+  // Returns the resulting tempId and whether a new requirement was added; the
+  // stage owns dedup (a re-proposed name returns the existing tempId).
+  onPropose: (requirement: RequirementDraft) => {
+    tempId: string
+    added: boolean
+  },
   onClarification: (
     questionId: string,
     question: string,
     options?: Array<string>,
+    multiSelect?: boolean,
   ) => void,
 ) {
   const searchExistingDesigns = toolDefinition({
@@ -35,13 +42,21 @@ export function createRequirementsTools(
     outputSchema: z.object({
       designs: z.array(z.record(z.string(), z.unknown())),
       total: z.number(),
+      error: z.string().optional(),
     }),
   }).server(async (input) => {
-    const result = await searchDesignsHandler(
-      { query: input.query, limit: input.limit ?? 10 },
-      context,
-    )
-    return result as { designs: Array<Record<string, unknown>>; total: number }
+    try {
+      const result = await searchDesignsHandler(
+        { query: input.query, limit: input.limit ?? 10 },
+        context,
+      )
+      return result as {
+        designs: Array<Record<string, unknown>>
+        total: number
+      }
+    } catch (err) {
+      return { designs: [], total: 0, error: toolErrorMessage(err) }
+    }
   })
 
   const searchPartsLibrary = toolDefinition({
@@ -59,17 +74,22 @@ export function createRequirementsTools(
     outputSchema: z.object({
       items: z.array(z.record(z.string(), z.unknown())),
       total: z.number(),
+      error: z.string().optional(),
     }),
   }).server(async (input) => {
-    const result = await searchItemsHandler(
-      {
-        query: input.query,
-        itemType: input.itemType,
-        limit: input.limit ?? 10,
-      },
-      context,
-    )
-    return result as { items: Array<Record<string, unknown>>; total: number }
+    try {
+      const result = await searchItemsHandler(
+        {
+          query: input.query,
+          itemType: input.itemType,
+          limit: input.limit ?? 10,
+        },
+        context,
+      )
+      return result as { items: Array<Record<string, unknown>>; total: number }
+    } catch (err) {
+      return { items: [], total: 0, error: toolErrorMessage(err) }
+    }
   })
 
   const proposeRequirement = toolDefinition({
@@ -102,9 +122,8 @@ export function createRequirementsTools(
       added: z.boolean(),
     }),
   }).server((input) => {
-    const tempId = crypto.randomUUID()
     const requirement: RequirementDraft = {
-      tempId,
+      tempId: crypto.randomUUID(),
       name: input.name,
       description: input.description,
       requirementType: input.requirementType,
@@ -114,27 +133,39 @@ export function createRequirementsTools(
       confidence: input.confidence,
       source: 'ai',
     }
-    onPropose(requirement)
-    return { tempId, added: true }
+    // Stage-owned dedup: a re-proposed name returns the existing tempId.
+    return onPropose(requirement)
   })
 
   const askClarification = toolDefinition({
     name: 'ask_clarification',
     description:
-      'Ask the user a clarification question about the design when more information is needed to generate accurate requirements.',
+      'Ask the user a clarification question about the design when more information is needed to generate accurate requirements. ALWAYS provide `options` when the answer is a known choice from a finite set. Set `multiSelect: true` when more than one option can apply ("select all that apply").',
     inputSchema: z.object({
-      question: z.string().describe('The question to ask the user'),
+      question: z
+        .string()
+        .describe(
+          'The question to ask the user. Keep it concise — options are rendered separately, so do not embed an inline list of choices in the question text.',
+        ),
       options: z
         .array(z.string())
         .optional()
-        .describe('Optional list of suggested answers'),
+        .describe(
+          'Suggested answers, presented as buttons or checkboxes. Provide these whenever the answer is a known choice from a finite set.',
+        ),
+      multiSelect: z
+        .boolean()
+        .optional()
+        .describe(
+          'True when the user can pick more than one option ("select all that apply"). Defaults to false (single choice).',
+        ),
     }),
     outputSchema: z.object({
       acknowledged: z.boolean(),
     }),
   }).server((input) => {
     const questionId = crypto.randomUUID()
-    onClarification(questionId, input.question, input.options)
+    onClarification(questionId, input.question, input.options, input.multiSelect)
     return { acknowledged: true }
   })
 

--- a/src/lib/design-engine/tools/tool-utils.ts
+++ b/src/lib/design-engine/tools/tool-utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared helpers for design-engine stage tools.
+ */
+
+/**
+ * Extract a safe, model-facing message from a thrown tool error.
+ *
+ * I/O tools (searches, catalog/BOM lookups) wrap their body in try/catch and
+ * return a schema-valid empty result carrying this message under an `error`
+ * field, so a transient failure lets the model recover instead of failing the
+ * whole design session.
+ */
+export function toolErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : 'Tool execution failed'
+}

--- a/src/lib/design-engine/tools/toolset-tools.ts
+++ b/src/lib/design-engine/tools/toolset-tools.ts
@@ -9,6 +9,7 @@
 import { toolDefinition } from '@tanstack/ai'
 import { z } from 'zod'
 import { and, eq, ilike, or } from 'drizzle-orm'
+import { toolErrorMessage } from './tool-utils'
 import type {
   DesignSessionToolset,
   ManufacturingScope,
@@ -31,6 +32,7 @@ export function createToolsetTools(
     questionId: string,
     question: string,
     options?: Array<string>,
+    multiSelect?: boolean,
   ) => void,
 ) {
   const state: ToolsetBuildState = {
@@ -67,61 +69,66 @@ export function createToolsetTools(
     outputSchema: z.object({
       tools: z.array(z.record(z.string(), z.unknown())),
       total: z.number(),
+      error: z.string().optional(),
     }),
   }).server(async (input) => {
-    const conditions = [
-      eq(items.itemType, 'Tool'),
-      eq(items.isCurrent, true),
-      eq(items.isDeleted, false),
-    ]
+    try {
+      const conditions = [
+        eq(items.itemType, 'Tool'),
+        eq(items.isCurrent, true),
+        eq(items.isDeleted, false),
+      ]
 
-    // Search across name, manufacturer, model
-    if (input.query) {
-      const pattern = `%${input.query}%`
-      conditions.push(
-        or(
-          ilike(items.name, pattern),
-          ilike(tools.manufacturer, pattern),
-          ilike(tools.model, pattern),
-        )!,
+      // Search across name, manufacturer, model
+      if (input.query) {
+        const pattern = `%${input.query}%`
+        conditions.push(
+          or(
+            ilike(items.name, pattern),
+            ilike(tools.manufacturer, pattern),
+            ilike(tools.model, pattern),
+          )!,
+        )
+      }
+
+      if (input.toolType) {
+        conditions.push(eq(tools.toolType, input.toolType))
+      }
+      if (input.toolSubtype) {
+        conditions.push(eq(tools.toolSubtype, input.toolSubtype))
+      }
+
+      const results = await db
+        .select({
+          id: items.id,
+          itemNumber: items.itemNumber,
+          name: items.name,
+          state: items.state,
+          toolType: tools.toolType,
+          toolSubtype: tools.toolSubtype,
+          manufacturer: tools.manufacturer,
+          model: tools.model,
+          capabilities: tools.capabilities,
+          toolStatus: tools.toolStatus,
+          location: tools.location,
+          notes: tools.notes,
+        })
+        .from(items)
+        .innerJoin(tools, eq(items.id, tools.itemId))
+        .where(and(...conditions))
+        .limit(20)
+
+      // Only return active tools (toolStatus = available or in_use)
+      const activeTools = results.filter(
+        (t) => t.toolStatus === 'available' || t.toolStatus === 'in_use',
       )
-    }
 
-    if (input.toolType) {
-      conditions.push(eq(tools.toolType, input.toolType))
-    }
-    if (input.toolSubtype) {
-      conditions.push(eq(tools.toolSubtype, input.toolSubtype))
-    }
-
-    const results = await db
-      .select({
-        id: items.id,
-        itemNumber: items.itemNumber,
-        name: items.name,
-        state: items.state,
-        toolType: tools.toolType,
-        toolSubtype: tools.toolSubtype,
-        manufacturer: tools.manufacturer,
-        model: tools.model,
-        capabilities: tools.capabilities,
-        toolStatus: tools.toolStatus,
-        location: tools.location,
-        notes: tools.notes,
-      })
-      .from(items)
-      .innerJoin(tools, eq(items.id, tools.itemId))
-      .where(and(...conditions))
-      .limit(20)
-
-    // Only return active tools (toolStatus = available or in_use)
-    const activeTools = results.filter(
-      (t) => t.toolStatus === 'available' || t.toolStatus === 'in_use',
-    )
-
-    return {
-      tools: activeTools as Array<Record<string, unknown>>,
-      total: activeTools.length,
+      return {
+        tools: activeTools as Array<Record<string, unknown>>,
+        total: activeTools.length,
+      }
+    } catch (err) {
+      return { tools: [], total: 0, error: toolErrorMessage(err) }
     }
   })
 
@@ -269,24 +276,32 @@ export function createToolsetTools(
   const askToolsetClarification = toolDefinition({
     name: 'ask_toolset_clarification',
     description:
-      "Ask the user a question about their manufacturing capabilities, equipment, or preferences. Use this when the product description mentions manufacturing methods but you're unsure about specifics.",
+      "Ask the user a question about their manufacturing capabilities, equipment, or preferences. Use this when the product description mentions manufacturing methods but you're unsure about specifics. ALWAYS provide `options` when the answer is a known choice from a finite set (yes/no, list of tools, list of processes). Set `multiSelect: true` when more than one option can apply (e.g., \"which of these tools do you have?\"). Set `multiSelect: false` (or omit) when exactly one option should be picked.",
     inputSchema: z.object({
       question: z
         .string()
         .describe(
-          'The question to ask the user about their manufacturing setup',
+          'The question to ask the user about their manufacturing setup. Keep it concise — the UI will render the options separately, so do not embed an inline list of choices in the question text.',
         ),
       options: z
         .array(z.string())
         .optional()
-        .describe('Optional list of suggested answers'),
+        .describe(
+          'Suggested answers, presented as buttons or checkboxes. Provide these whenever the answer is a known choice from a finite set.',
+        ),
+      multiSelect: z
+        .boolean()
+        .optional()
+        .describe(
+          'True when the user can pick more than one option ("select all that apply"). Defaults to false (single choice).',
+        ),
     }),
     outputSchema: z.object({
       acknowledged: z.boolean(),
     }),
   }).server((input) => {
     const questionId = crypto.randomUUID()
-    onClarification(questionId, input.question, input.options)
+    onClarification(questionId, input.question, input.options, input.multiSelect)
     return { acknowledged: true }
   })
 

--- a/src/lib/design-engine/types.ts
+++ b/src/lib/design-engine/types.ts
@@ -41,6 +41,7 @@ export interface ClarificationEntry {
   questionId: string
   question: string
   options?: Array<string>
+  multiSelect?: boolean
   answer: string
   answeredAt: string // ISO timestamp
   stage: DesignSessionStage
@@ -151,6 +152,7 @@ export type StageEvent =
       questionId: string
       question: string
       options?: Array<string>
+      multiSelect?: boolean
     }
   | { type: 'stage_complete'; stage: DesignSessionStage; summary: string }
   | { type: 'error'; message: string }
@@ -386,6 +388,7 @@ export interface DesignArtifacts {
     id: string
     question: string
     options?: Array<string>
+    multiSelect?: boolean
   }
   materializationResult?: MaterializationResult
   cadGenerationState?: CadGenerationState
@@ -499,6 +502,7 @@ const clarificationEntrySchema = z.object({
   questionId: z.string(),
   question: z.string(),
   options: z.array(z.string()).optional(),
+  multiSelect: z.boolean().optional(),
   answer: z.string(),
   answeredAt: z.string(),
   stage: z.string(),
@@ -608,6 +612,7 @@ export const designArtifactsPatchSchema = z
         id: z.string(),
         question: z.string(),
         options: z.array(z.string()).optional(),
+        multiSelect: z.boolean().optional(),
       })
       .optional(),
     materializationResult: z

--- a/src/server/routes/ai.ts
+++ b/src/server/routes/ai.ts
@@ -211,11 +211,14 @@ app.post(
 
       // Track assistant response for persistence
       let fullResponse = ''
-      const collectedToolCalls: Array<{
-        id: string
-        name: string
-        arguments: Record<string, unknown>
-      }> = []
+      // Tool-call arguments stream in incrementally as JSON fragments keyed by
+      // `chunk.index`; accumulate them and finalize once the stream completes.
+      const toolCallAccum = new Map<
+        number,
+        { id: string; name: string; args: string }
+      >()
+      // tool_result chunks carry no tool name — resolve it from the tool_call.
+      const toolCallIdToName = new Map<string, string>()
       const collectedToolResults: Array<{
         toolCallId: string
         toolName: string
@@ -231,33 +234,53 @@ app.post(
               fullResponse = chunk.content // Replace, not append - content is cumulative
             }
 
-            // Track tool calls made by assistant
-            if (chunk.type === 'tool-call') {
-              collectedToolCalls.push({
-                id: chunk.id,
-                name: chunk.name,
-                arguments:
-                  typeof chunk.arguments === 'string'
-                    ? JSON.parse(chunk.arguments)
-                    : chunk.arguments,
-              })
+            // Accumulate streamed tool-call fragments (id/name arrive on the
+            // first fragment; arguments concatenate across fragments per index).
+            if (chunk.type === 'tool_call') {
+              const entry = toolCallAccum.get(chunk.index) ?? {
+                id: '',
+                name: '',
+                args: '',
+              }
+              if (chunk.toolCall.id) entry.id = chunk.toolCall.id
+              if (chunk.toolCall.function.name) {
+                entry.name = chunk.toolCall.function.name
+              }
+              entry.args += chunk.toolCall.function.arguments
+              toolCallAccum.set(chunk.index, entry)
+              if (entry.id && entry.name) {
+                toolCallIdToName.set(entry.id, entry.name)
+              }
             }
 
-            // Track tool results
-            if (chunk.type === 'tool-result') {
+            // Track tool results (name looked up via the toolCallId map).
+            if (chunk.type === 'tool_result') {
               collectedToolResults.push({
                 toolCallId: chunk.toolCallId,
-                toolName: chunk.toolName || '',
-                content:
-                  typeof chunk.content === 'string'
-                    ? chunk.content
-                    : JSON.stringify(chunk.content),
+                toolName: toolCallIdToName.get(chunk.toolCallId) ?? '',
+                content: chunk.content,
               })
             }
 
             yield chunk
           }
         } finally {
+          // Finalize accumulated tool calls (parse the completed argument JSON).
+          const collectedToolCalls = Array.from(toolCallAccum.values())
+            .filter((e) => e.id && e.name)
+            .map((e) => {
+              let args: Record<string, unknown> = {}
+              try {
+                const parsed: unknown = JSON.parse(e.args || '{}')
+                if (typeof parsed === 'object' && parsed !== null) {
+                  args = parsed as Record<string, unknown>
+                }
+              } catch {
+                args = {}
+              }
+              return { id: e.id, name: e.name, arguments: args }
+            })
+
           // Save assistant message with tool calls after stream completes
           if (fullResponse || collectedToolCalls.length > 0) {
             await sessionService.addMessage(session.id, {

--- a/src/server/routes/design-engine.ts
+++ b/src/server/routes/design-engine.ts
@@ -33,12 +33,14 @@ const createSessionSchema = z.object({
 
 const streamActionSchema = z.object({
   action: z.enum([
+    'start_toolset',
     'start_requirements',
     'start_bom',
     'start_cad_generation',
     'start_assembly_composition',
     'regenerate_part',
     'resume',
+    'confirm_toolset',
     'confirm_requirements',
     'confirm_bom',
     'confirm_cad',
@@ -67,16 +69,13 @@ function determineStageForResume(stage: string): 'requirements' | 'bom' | null {
   return null
 }
 
-/**
- * Try to find the question text for a pending clarification from events stored in the session.
- * Falls back to the questionId itself if not found.
- */
 function findPendingQuestion(
-  _artifacts: DesignArtifacts,
+  artifacts: DesignArtifacts,
   questionId: string,
 ): string {
-  // The question text isn't stored in artifacts — it was streamed as a StageEvent.
-  // We use the questionId as a fallback. The prompt builder uses the answer anyway.
+  if (artifacts.pendingClarification?.id === questionId) {
+    return artifacts.pendingClarification.question
+  }
   return questionId
 }
 
@@ -380,6 +379,12 @@ app.post(
       })
 
       // Handle stage confirmations (non-streaming)
+      if (action === 'confirm_toolset') {
+        await designEngine.confirmStage(params.id, 'toolset')
+        const updated = await DesignSessionService.getById(params.id)
+        return { session: updated, confirmed: 'toolset' }
+      }
+
       if (action === 'confirm_requirements') {
         await designEngine.confirmStage(params.id, 'requirements')
         const updated = await DesignSessionService.getById(params.id)
@@ -415,6 +420,10 @@ app.post(
 
         const current = await DesignSessionService.getById(params.id)
         if (current?.artifacts) {
+          const pending =
+            current.artifacts.pendingClarification?.id === questionId
+              ? current.artifacts.pendingClarification
+              : undefined
           const artifacts: DesignArtifacts = {
             ...current.artifacts,
             clarifications: [
@@ -422,17 +431,18 @@ app.post(
               {
                 questionId,
                 question:
-                  current.artifacts.pendingClarificationId === questionId
-                    ? findPendingQuestion(current.artifacts, questionId)
-                    : questionId,
+                  pending?.question ??
+                  findPendingQuestion(current.artifacts, questionId),
+                options: pending?.options,
+                multiSelect: pending?.multiSelect,
                 answer,
                 answeredAt: new Date().toISOString(),
                 stage: current.stage as DesignSessionStage,
-                options: undefined,
               },
             ],
             userMessages: current.artifacts.userMessages,
             pendingClarificationId: undefined,
+            pendingClarification: undefined,
           }
           await DesignSessionService.updateArtifacts(params.id, artifacts)
         }
@@ -531,7 +541,12 @@ app.post(
       // Handle streaming stages
       let eventSource: AsyncIterable<StageEvent>
 
-      if (action === 'start_requirements') {
+      if (action === 'start_toolset') {
+        eventSource = designEngine.runToolsetEstablishmentStage(
+          params.id,
+          abortController.signal,
+        )
+      } else if (action === 'start_requirements') {
         eventSource = designEngine.runRequirementsStage(
           params.id,
           abortController.signal,


### PR DESCRIPTION
… works

The resume-time "prior tool calls" summary (summarizeToolCalls) never fired: llmHistory only gains a call entry (with args) from a `tool_call` StageEvent, but no stage ever emitted one. Stages emitted only synthetic tool_result events (BOM emitted none), so searches were never captured and the summary was always empty — resumed stages redundantly re-searched.

Core fix:
- Add createToolEventTracker() to translate TanStack AI stream chunks into tool_call/tool_result StageEvents (reassembles incrementally-streamed args by index, maps toolCallId -> name since results carry no name, emits each call before its result without double-emitting).
- Weave it into the toolset, requirements, and BOM stage stream loops; drop the synthetic tool_result diff-yields (keep the artifact_update yields). wrapWithHistoryCapture now records real tool_call args into llmHistory, so summarizeToolCalls populates and is injected into the resumed prompt.
- Correct the summary's MUTATION_TOOLS/SEARCH_TOOLS name sets (real BOM tools are propose_new_part / add_existing_to_bom, etc.; add lookup_component_catalog).

Gap fixes vs. standard tool-calling loops:
- Explicit maxIterations on toolset (15) and requirements (20); BOM stays 30.
- I/O tools wrap their body in try/catch and return a schema-valid empty result with an optional `error` field, so a transient failure lets the model recover instead of failing the whole session.
- First clarification in a round wins (guard against a later one overwriting).
- Structural dedup for propose_new_part / add_existing_to_bom (by name/itemId under the same parent) and propose_requirement (by normalized name), so a re-run after resume doesn't duplicate nodes.

Also fix the AI chatbot's own tool-history capture (server/routes/ai.ts): it matched hyphenated tool-call/tool-result and read fields absent in this SDK version, so chatbot tool calls were never persisted. Now reads the real underscored chunk shapes with incremental args + a toolCallId -> name map.

Adds unit tests for summarizeToolCalls and the tracker (18 cases). Builds on the in-progress toolset stage + multi-select clarification work in the same files. Verified end-to-end: real streaming captures tool_call args into llm_history and the summary block is injected on resume.