### PR TITLE
Support ECO-based materialization and flexible program selection in t…

### DIFF
--- a/cascadia-feature-list.md
+++ b/cascadia-feature-list.md
@@ -369,15 +369,15 @@ Bulk data import from spreadsheets with intelligent BOM parsing.
 
 Standards-based interoperability layer.
 
-| Feature                                          | Status | Notes                          |
-| ------------------------------------------------ | ------ | ------------------------------ |
+| Feature                                             | Status | Notes                          |
+| --------------------------------------------------- | ------ | ------------------------------ |
 | `/api/v1/sysml/projects`                            | ✅     | List designs as SysML projects |
 | `/api/v1/sysml/projects/:id`                        | ✅     | Get single project             |
 | `/api/v1/sysml/projects/:id/commits`                | ✅     | Commit history                 |
 | `/api/v1/sysml/projects/:id/branches/:bid/elements` | ✅     | Elements on branch             |
 | `/api/v1/sysml/projects/:id/commits/:cid/elements`  | ✅     | Elements at commit             |
-| SysML element serialization                      | ✅     | Convert items to SysML format  |
-| SysML relationship mapping                       | ✅     | BOM, Satisfy, Verify, etc.     |
+| SysML element serialization                         | ✅     | Convert items to SysML format  |
+| SysML relationship mapping                          | ✅     | BOM, Satisfy, Verify, etc.     |
 
 ### SysML Relationship Types ✅
 
@@ -514,7 +514,7 @@ Production-ready infrastructure.
 | ----------------------- | ------ | ------------------------ |
 | Environment variables   | ✅     | All config via env       |
 | .env file support       | ✅     | Local development        |
-| Health check endpoint   | ✅     | `/api/v1/health`            |
+| Health check endpoint   | ✅     | `/api/v1/health`         |
 | Secrets management docs | ✅     | Kubernetes secrets, etc. |
 
 ---
@@ -562,17 +562,17 @@ AI-assisted product design workflow that generates requirements, BOMs, CAD, and 
 
 ### Design Stages ✅
 
-| Stage                 | Status | Notes                                                              |
-| --------------------- | ------ | ------------------------------------------------------------------ |
-| Requirements drafting | ✅     | LLM analyzes description, proposes structured requirements         |
-| Requirements review   | ✅     | User edits/approves proposed requirements                          |
-| BOM drafting          | ✅     | LLM decomposes into hierarchical BOM, searches for reuse           |
-| BOM review            | ✅     | User validates BOM structure and requirement coverage              |
-| Materialization       | ✅     | Creates actual items, relationships, and ECO in PLM                |
-| CAD generation        | 🟡     | Generates STEP files via Zoo Text-to-CAD API for Manufacture parts |
-| CAD review            | 🟡     | 3D viewer for reviewing generated models                           |
-| Assembly composition  | 🟡     | Bottom-up assembly via KCL code generation                         |
-| Assembly review       | 🟡     | Final assembly validation                                          |
+| Stage                 | Status | Notes                                                                                                |
+| --------------------- | ------ | ---------------------------------------------------------------------------------------------------- |
+| Requirements drafting | ✅     | LLM analyzes description, proposes structured requirements                                           |
+| Requirements review   | ✅     | User edits/approves proposed requirements                                                            |
+| BOM drafting          | ✅     | LLM decomposes into hierarchical BOM, searches for reuse                                             |
+| BOM review            | ✅     | User validates BOM structure and requirement coverage                                                |
+| Materialization       | ✅     | Creates items + BOM relationships in Draft (pre-release designs on main; released designs via an ECO) |
+| CAD generation        | 🟡     | Generates STEP files via Zoo Text-to-CAD API for Manufacture parts                                   |
+| CAD review            | 🟡     | 3D viewer for reviewing generated models                                                             |
+| Assembly composition  | 🟡     | Bottom-up assembly via KCL code generation                                                           |
+| Assembly review       | 🟡     | Final assembly validation                                                                            |
 
 ### BOM Drafting Tools ✅
 

--- a/docs/api/design-engine.md
+++ b/docs/api/design-engine.md
@@ -299,7 +299,13 @@ data: {"finished":true}
 
 ## GET /api/design-engine/sessions/:id/materialize
 
-Preview what items would be created if materialization were executed. Requires a BOM to be present in the session artifacts.
+Preview what materialization would do. Returns the materialization **plan** (the exact contract execution will follow) plus item counts. Requires a BOM to be present in the session artifacts.
+
+The plan's `mode` is one of:
+
+- `create_design` -- a new design will be created in the session's program; all items land on its `main` branch in `Draft` state
+- `add_to_design` -- items are added to the existing pre-release target design's `main` branch in `Draft` state
+- `eco_required` -- the target design has released items; an ECO (named in `ecoName`) is created and the new items are added to its branch, releasing when the ECO is approved and merged
 
 ### Response
 
@@ -307,12 +313,21 @@ Preview what items would be created if materialization were executed. Requires a
 {
   "data": {
     "preview": {
+      "plan": {
+        "mode": "create_design",
+        "supported": true,
+        "programId": "program-uuid",
+        "programName": "Sensor Platform",
+        "targetDesignId": null,
+        "targetDesignName": null,
+        "newDesignName": "Bracket assembly for mounting sensors",
+        "initialState": "Draft",
+        "targetBranch": "main"
+      },
       "newPartsCount": 8,
       "reusedPartsCount": 2,
       "newRequirementsCount": 5,
       "bomRelationshipsCount": 10,
-      "requiresEco": true,
-      "targetDesignId": "design-uuid",
       "items": [
         {
           "tempId": "part-1",
@@ -337,7 +352,9 @@ Preview what items would be created if materialization were executed. Requires a
 
 ## POST /api/design-engine/sessions/:id/materialize
 
-Execute materialization -- creates actual PLM items (parts, requirements, BOM relationships) from the session's draft artifacts. Creates an ECO if the target design is post-release.
+Execute materialization -- creates actual PLM items (parts, requirements, BOM relationships) from the session's draft artifacts, following the plan returned by the GET preview. For the `create_design`/`add_to_design` modes all items are created in `Draft` state on the target design's `main` branch; no ECO is involved.
+
+If the target design has released items (plan mode `eco_required`), an ECO is created and the new items are added to its branch instead of `main`. The response includes `ecoId`/`ecoNumber`; the items are released with revision letters only when that ECO is approved and merged.
 
 Can only be executed once per session. After successful materialization the session status changes to `completed`.
 
@@ -347,9 +364,10 @@ Can only be executed once per session. After successful materialization the sess
 {
   "data": {
     "result": {
+      "mode": "create_design",
       "designId": "design-uuid",
-      "ecoId": "eco-uuid",
-      "ecoNumber": "ECO-0042",
+      "designName": "Bracket assembly for mounting sensors",
+      "initialState": "Draft",
       "createdItems": [
         {
           "tempId": "part-1",
@@ -367,10 +385,10 @@ Can only be executed once per session. After successful materialization the sess
 
 ### Errors
 
-| Status | Condition                                                     |
-| ------ | ------------------------------------------------------------- |
-| 404    | Session not found                                             |
-| 403    | User is not the session owner                                 |
+| Status | Condition                                                                                    |
+| ------ | -------------------------------------------------------------------------------------------- |
+| 404    | Session not found                             |
+| 403    | User is not the session owner                 |
 | 422    | No BOM artifacts to materialize, or session already completed |
 
 ---

--- a/docs/features/design-engine.md
+++ b/docs/features/design-engine.md
@@ -127,26 +127,37 @@ When satisfied, the user clicks **Confirm BOM** to advance to materialization.
 
 **Stage key**: `materialization`
 
-This stage converts the draft BOM into real PLM data. It has two phases: preview and execution.
+This stage converts the draft BOM into real PLM data. It has three phases: plan, preview, and execution.
 
-**Preview** (automatic on entering the stage): The `MaterializationService.preview()` method walks the BOM tree and counts:
+**Plan**: `MaterializationService.plan()` computes the materialization contract — exactly what executing will do. Both the preview and the execution derive from this shared plan, so the message shown to the user cannot drift from the actual behavior. The plan has one of three modes:
+
+| Mode            | When                                                | What happens                                                                                                                                                        |
+| --------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `create_design` | Session has no target design                        | A new design is created in the session's program; all items are created in `Draft` state on its `main` branch                                                       |
+| `add_to_design` | Target design exists and is pre-release             | Items are created in `Draft` state directly on the design's `main` branch                                                                                            |
+| `eco_required`  | Target design has released items (branch-protected) | An ECO is created and the new items are added to its branch (as `added` working copies, registered with the `release` change action); they release when it's merged |
+
+No ECO is created in the `create_design`/`add_to_design` modes: pre-release designs are directly editable, and revision letters are assigned later when the design is first released through an ECO. In `eco_required` mode the ECO is the mechanism for releasing the new items — revision letters are assigned when the ECO is approved and merged to `main`.
+
+**Preview** (automatic on entering the stage): `MaterializationService.preview()` returns the plan plus counts from walking the BOM tree:
 
 - New parts to create
 - Existing parts to reuse
 - New requirements to create
 - BOM relationships to establish
-- Whether an ECO is required (based on branch protection)
 
-The preview is shown in the `MaterializationPreview` component with summary cards and a scrollable item list.
+The `MaterializationPreview` component renders the plan as a "What will happen" summary, with summary cards and a scrollable item list.
 
-**Execution** (on user confirmation): The `MaterializationService.execute()` method:
+**Execution** (on user confirmation): `MaterializationService.execute()` re-derives the plan, then:
 
-1. Creates or resolves the target Design
-2. Checks branch protection and creates an ECO with workflow if needed
-3. Creates Requirement items (mapping priority and type enums to PLM equivalents)
-4. Creates Part items depth-first (leaves before parents) so BOM relationships can be established bottom-up
+1. Creates the target Design if the session has none (mode `create_design`)
+2. In `eco_required` mode, creates the ECO (`ItemService.create('ChangeOrder', …)`), starts its workflow, and creates its branch (`ChangeOrderService.addDesignToEco`); items are then created on that branch instead of `main`
+3. Creates Requirement items in `Draft` state (mapping priority and type enums to PLM equivalents)
+4. Creates Part items in `Draft` state depth-first (leaves before parents) so BOM relationships can be established bottom-up
 5. Creates BOM relationships between parent and child parts
 6. Updates the session with the materialization result
+
+In `eco_required` mode, items are created via `ItemService.createOnBranch()` (as `added` working copies) and each is registered on the ECO with the `release` change action so it appears in the Affected Items tab. Nothing is written to `main` until the ECO is approved and merged.
 
 The materialization result is persisted in `artifacts.materializationResult` and provides the `tempId -> itemId` mapping needed by subsequent CAD generation.
 
@@ -607,8 +618,8 @@ Connecting lines between stages are cyan (completed) or gray (pending).
 
 ### Session Management
 
-| Method  | Endpoint                          | Description                             |
-| ------- | --------------------------------- | --------------------------------------- |
+| Method  | Endpoint                             | Description                             |
+| ------- | ------------------------------------ | --------------------------------------- |
 | `GET`   | `/api/v1/design-engine/sessions`     | List current user's sessions            |
 | `POST`  | `/api/v1/design-engine/sessions`     | Create a new session                    |
 | `GET`   | `/api/v1/design-engine/sessions/:id` | Get session by ID                       |
@@ -627,14 +638,14 @@ Connecting lines between stages are cyan (completed) or gray (pending).
 
 ### Streaming
 
-| Method | Endpoint                                 | Description                        |
-| ------ | ---------------------------------------- | ---------------------------------- |
+| Method | Endpoint                                    | Description                        |
+| ------ | ------------------------------------------- | ---------------------------------- |
 | `POST` | `/api/v1/design-engine/sessions/:id/stream` | Send action and receive SSE stream |
 
 ### Materialization
 
-| Method | Endpoint                                      | Description             |
-| ------ | --------------------------------------------- | ----------------------- |
+| Method | Endpoint                                         | Description             |
+| ------ | ------------------------------------------------ | ----------------------- |
 | `GET`  | `/api/v1/design-engine/sessions/:id/materialize` | Generate preview        |
 | `POST` | `/api/v1/design-engine/sessions/:id/materialize` | Execute materialization |
 

--- a/src/components/design-engine/MaterializationPreview.tsx
+++ b/src/components/design-engine/MaterializationPreview.tsx
@@ -1,5 +1,6 @@
 /**
- * MaterializationPreview - Shows what will be created before executing
+ * MaterializationPreview - States exactly what materialization will do
+ * (driven by the MaterializationPlan) before the user confirms execution.
  */
 
 import { useState } from 'react'
@@ -8,6 +9,7 @@ import {
   FileText,
   GitBranch,
   Link,
+  ListChecks,
   Loader2,
   Package,
 } from 'lucide-react'
@@ -21,6 +23,40 @@ interface MaterializationPreviewProps {
   isLoading: boolean
   onMaterialize: () => void
   isMaterializing: boolean
+}
+
+/** Plain-language description of what executing the plan will do */
+function planSummary(preview: PreviewType): Array<string> {
+  const { plan } = preview
+  const programLabel = plan.programName
+    ? `program "${plan.programName}"`
+    : 'the session program'
+
+  if (plan.mode === 'create_design') {
+    return [
+      `A new design "${plan.newDesignName ?? 'Collaborative Design'}" will be created in ${programLabel}.`,
+      `${preview.newRequirementsCount} requirements and ${preview.newPartsCount} new parts will be created in the "${plan.initialState}" state on the design's ${plan.targetBranch} branch.`,
+      `${preview.bomRelationshipsCount} BOM relationships will link the parts into the assembly structure.`,
+      'No ECO is needed — the design has no released items yet. Revision letters are assigned later, when the design is first released through an ECO.',
+    ]
+  }
+
+  if (plan.mode === 'eco_required') {
+    return [
+      `Design "${plan.targetDesignName ?? 'design'}" has released items, so a new change order (${plan.ecoName ?? 'ECO'}) will be created in ${programLabel}.`,
+      `${preview.newRequirementsCount} requirements and ${preview.newPartsCount} new parts will be added to the ECO's branch in the "${plan.initialState}" state.`,
+      `${preview.bomRelationshipsCount} BOM relationships will link the parts into the assembly structure.`,
+      'The items are released with revision letters when the ECO is reviewed and approved.',
+    ]
+  }
+
+  // add_to_design
+  return [
+    `Items will be added to the existing design "${plan.targetDesignName ?? 'design'}" in ${programLabel}.`,
+    `${preview.newRequirementsCount} requirements and ${preview.newPartsCount} new parts will be created in the "${plan.initialState}" state on the design's ${plan.targetBranch} branch.`,
+    `${preview.bomRelationshipsCount} BOM relationships will link the parts into the assembly structure.`,
+    'No ECO is needed — this design has no released items yet. Revision letters are assigned later, when the design is first released through an ECO.',
+  ]
 }
 
 export function MaterializationPreview({
@@ -42,11 +78,44 @@ export function MaterializationPreview({
     )
   }
 
+  const blocked = !preview.plan.supported
+
   return (
     <div className="space-y-4">
       <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300">
         Materialization Preview
       </h3>
+
+      {/* Blocked notice (e.g. target design requires an ECO) */}
+      {blocked ? (
+        <div className="flex items-start gap-2 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-3">
+          <GitBranch className="h-4 w-4 text-yellow-600 mt-0.5" />
+          <div>
+            <p className="text-sm font-medium text-yellow-700 dark:text-yellow-400">
+              Materialization not available
+            </p>
+            <p className="text-xs text-yellow-600 dark:text-yellow-500 mt-0.5">
+              {preview.plan.blockedReason ??
+                'This target design cannot be materialized into.'}
+            </p>
+          </div>
+        </div>
+      ) : (
+        /* What will happen */
+        <div className="bg-cyan-50 dark:bg-cyan-900/20 border border-cyan-200 dark:border-cyan-800 rounded-lg p-3 space-y-1.5">
+          <div className="flex items-center gap-2">
+            <ListChecks className="h-4 w-4 text-cyan-600" />
+            <p className="text-sm font-medium text-cyan-800 dark:text-cyan-300">
+              What will happen
+            </p>
+          </div>
+          <ul className="text-xs text-cyan-700 dark:text-cyan-400 space-y-1 list-disc pl-5">
+            {planSummary(preview).map((line, i) => (
+              <li key={i}>{line}</li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {/* Summary cards */}
       <div className="grid grid-cols-2 gap-3">
@@ -96,22 +165,6 @@ export function MaterializationPreview({
         </Card>
       </div>
 
-      {/* ECO notice */}
-      {preview.requiresEco && (
-        <div className="flex items-start gap-2 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-3">
-          <GitBranch className="h-4 w-4 text-yellow-600 mt-0.5" />
-          <div>
-            <p className="text-sm font-medium text-yellow-700 dark:text-yellow-400">
-              ECO Required
-            </p>
-            <p className="text-xs text-yellow-600 dark:text-yellow-500 mt-0.5">
-              The target design has released items. An Engineering Change Order
-              will be created automatically to manage this change.
-            </p>
-          </div>
-        </div>
-      )}
-
       {/* Items to create */}
       <div className="space-y-1">
         <h4 className="text-xs font-semibold text-slate-600 dark:text-slate-400">
@@ -147,55 +200,62 @@ export function MaterializationPreview({
       </div>
 
       {/* Materialize button */}
-      <div className="space-y-2">
-        {!confirmed ? (
-          <Button
-            variant="default"
-            onClick={() => setConfirmed(true)}
-            className="w-full"
-          >
-            Review & Materialize
-          </Button>
-        ) : (
-          <div className="space-y-2">
-            <div className="flex items-start gap-2 bg-slate-50 dark:bg-slate-800 rounded-lg p-3">
-              <AlertTriangle className="h-4 w-4 text-yellow-500 mt-0.5" />
-              <p className="text-xs text-slate-600 dark:text-slate-400">
-                This will create {preview.newPartsCount} new parts,{' '}
-                {preview.newRequirementsCount} requirements, and{' '}
-                {preview.bomRelationshipsCount} BOM relationships in the
-                database.
-                {preview.requiresEco &&
-                  ' An ECO will be created for change management.'}
-              </p>
+      {!blocked && (
+        <div className="space-y-2">
+          {!confirmed ? (
+            <Button
+              variant="default"
+              onClick={() => setConfirmed(true)}
+              className="w-full"
+            >
+              Review & Materialize
+            </Button>
+          ) : (
+            <div className="space-y-2">
+              <div className="flex items-start gap-2 bg-slate-50 dark:bg-slate-800 rounded-lg p-3">
+                <AlertTriangle className="h-4 w-4 text-yellow-500 mt-0.5" />
+                <p className="text-xs text-slate-600 dark:text-slate-400">
+                  {preview.plan.mode === 'create_design'
+                    ? `This will create the design "${preview.plan.newDesignName ?? 'Collaborative Design'}" plus `
+                    : preview.plan.mode === 'eco_required'
+                      ? `This will create a change order (${preview.plan.ecoName ?? 'ECO'}) and add `
+                      : `This will add to design "${preview.plan.targetDesignName ?? 'design'}": `}
+                  {preview.newPartsCount} new parts,{' '}
+                  {preview.newRequirementsCount} requirements, and{' '}
+                  {preview.bomRelationshipsCount} BOM relationships
+                  {preview.plan.mode === 'eco_required'
+                    ? ` to the ECO's branch — released with revision letters once the ECO is approved.`
+                    : ` — all in the "${preview.plan.initialState}" state on the ${preview.plan.targetBranch} branch.`}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  variant="default"
+                  onClick={onMaterialize}
+                  disabled={isMaterializing}
+                  className="flex-1"
+                >
+                  {isMaterializing ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      Creating...
+                    </>
+                  ) : (
+                    'Confirm & Create'
+                  )}
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => setConfirmed(false)}
+                  disabled={isMaterializing}
+                >
+                  Cancel
+                </Button>
+              </div>
             </div>
-            <div className="flex gap-2">
-              <Button
-                variant="default"
-                onClick={onMaterialize}
-                disabled={isMaterializing}
-                className="flex-1"
-              >
-                {isMaterializing ? (
-                  <>
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    Creating...
-                  </>
-                ) : (
-                  'Confirm & Create'
-                )}
-              </Button>
-              <Button
-                variant="outline"
-                onClick={() => setConfirmed(false)}
-                disabled={isMaterializing}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/design-engine/MaterializationResult.tsx
+++ b/src/components/design-engine/MaterializationResult.tsx
@@ -25,11 +25,24 @@ export function MaterializationResult({
         <CheckCircle className="h-6 w-6 text-green-500 flex-shrink-0" />
         <div>
           <h3 className="text-sm font-semibold text-green-800 dark:text-green-300">
-            Design Materialized Successfully
+            {result.mode === 'eco_required'
+              ? 'Change Order Created'
+              : 'Design Materialized Successfully'}
           </h3>
           <p className="text-xs text-green-600 dark:text-green-400 mt-0.5">
-            Created {result.createdItems.length} items and{' '}
-            {result.bomRelationshipsCreated} BOM relationships
+            {result.mode === 'eco_required'
+              ? `Added ${result.createdItems.length} items and ${result.bomRelationshipsCreated} BOM relationships to ${result.ecoNumber ?? 'the ECO'}. They will be released with revision letters once the ECO is reviewed and approved.`
+              : `${
+                  result.mode === 'create_design'
+                    ? `Created design "${result.designName ?? 'Collaborative Design'}" with `
+                    : result.designName
+                      ? `Added to design "${result.designName}": `
+                      : 'Created '
+                }${result.createdItems.length} items and ${result.bomRelationshipsCreated} BOM relationships${
+                  result.initialState
+                    ? `, all in the "${result.initialState}" state`
+                    : ''
+                }`}
           </p>
         </div>
       </div>

--- a/src/lib/ai/KnowledgeService.ts
+++ b/src/lib/ai/KnowledgeService.ts
@@ -436,14 +436,22 @@ All write tools use a two-step confirmation flow. When called, they first return
     - Use when the user needs to modify released items or manage a set of related changes
     - Creates the ECO with branches for isolated changes that merge when approved
 
+14. **create_program** - Create a new program (top-level container and permission boundary)
+    - Use when the user needs a program that doesn't exist yet — most commonly when starting a design session and none of their programs fit
+    - The user becomes the program's admin; requires the programs:create permission (the tool returns an error if they lack it)
+    - Code is auto-generated from the name unless the user provides one
+
 ### Design Engine
 
-14. **initiate_collaborative_design** - Start an interactive design workspace
+15. **initiate_collaborative_design** - Start an interactive design workspace
     - Use when the user wants to design something new (a product, assembly, or system) and needs help breaking it down into requirements and a BOM
-    - The workspace guides through: requirements gathering → BOM structure → materialization into real PLM items
-    - IMPORTANT: You MUST pass the programId (UUID from search_programs) so the session is created in the correct program
-    - If the user mentions a program by name or code, call search_programs first to get its UUID, then pass that UUID as programId
-    - No confirmation step needed — just call it directly with the description and programId
+    - The workspace guides through: requirements gathering → BOM structure → materialization, which creates the real PLM items (parts, requirements, BOM relationships) in Draft state in the chosen program
+    - Every session belongs to a program. Choosing one:
+      - If the user named a program, call search_programs to resolve its UUID, then pass it as programId
+      - If no program is known, call this tool WITHOUT programId — it returns availablePrograms and canCreateProgram. Present those programs to the user and ask them to pick (do NOT pick silently when several are plausible; if exactly one exists, suggest it)
+      - If the user wants a new program and canCreateProgram is true, use create_program first (it has its own confirmation), then call this tool again with the new program's id
+      - Never invent or guess a programId
+    - No confirmation step needed for the session itself — it's lightweight and non-destructive
     - On success, returns a workspace URL — the UI renders an "Open Design Workspace" button automatically
 
 ## Guidelines

--- a/src/lib/ai/tools/design-engine-definitions.ts
+++ b/src/lib/ai/tools/design-engine-definitions.ts
@@ -4,6 +4,10 @@
  * Triggers the collaborative design workflow when a user wants to
  * design something new or substantially modify an existing design.
  * Creates the session immediately (no confirmation step needed).
+ *
+ * Program selection is flexible: when called without a programId, the tool
+ * returns the user's accessible programs (and whether they may create a new
+ * one) so the assistant can suggest options instead of failing.
  */
 
 import { toolDefinition } from '@tanstack/ai'
@@ -11,7 +15,10 @@ import { z } from 'zod'
 
 export const initiateCollaborativeDesignDef = toolDefinition({
   name: 'initiate_collaborative_design',
-  description: `Start a collaborative design session when the user wants to design something new or substantially modify an existing design. This launches an interactive workspace that guides the user through: requirements gathering -> BOM structure -> materialization into real PLM data. Use this when the user describes a product, assembly, or system they want to design and needs help breaking it down into requirements and a bill of materials. IMPORTANT: Always pass the programId (UUID from search_programs). Call search_programs first if needed.`,
+  description: `Start a collaborative design session when the user wants to design something new or substantially modify an existing design. This launches an interactive workspace that guides the user through: requirements gathering -> BOM structure -> materialization into real PLM data. Use this when the user describes a product, assembly, or system they want to design and needs help breaking it down into requirements and a bill of materials.
+The session must belong to a program:
+- If the user named a program, resolve it (via search_programs or its code) and pass programId.
+- If no program is known yet, call this tool WITHOUT programId — it returns availablePrograms (and canCreateProgram) so you can ask the user to pick one or offer to create a new program with create_program. Never invent a programId.`,
   inputSchema: z.object({
     description: z
       .string()
@@ -20,8 +27,9 @@ export const initiateCollaborativeDesignDef = toolDefinition({
       ),
     programId: z
       .string()
+      .optional()
       .describe(
-        'Program UUID (from search_programs) or program code. REQUIRED.',
+        'Program UUID (from search_programs) or program code. Omit if the user has not chosen a program yet — the tool will return their available programs to choose from.',
       ),
     designId: z
       .string()
@@ -35,6 +43,24 @@ export const initiateCollaborativeDesignDef = toolDefinition({
     workspaceUrl: z.string().optional(),
     action: z.string().optional(),
     error: z.string().optional(),
+    availablePrograms: z
+      .array(
+        z.object({
+          id: z.string(),
+          name: z.string(),
+          code: z.string(),
+        }),
+      )
+      .optional()
+      .describe(
+        'Programs the user can start the session in (returned when no program was specified or it was not found). Present these to the user.',
+      ),
+    canCreateProgram: z
+      .boolean()
+      .optional()
+      .describe(
+        'Whether the user has permission to create a new program. If true, offer create_program as an option.',
+      ),
   }),
 })
 

--- a/src/lib/ai/tools/design-engine-handlers.ts
+++ b/src/lib/ai/tools/design-engine-handlers.ts
@@ -3,6 +3,10 @@
  *
  * Creates a design session and returns a workspace URL.
  * No confirmation step — creating a session is lightweight and non-destructive.
+ *
+ * When no program is specified (or it can't be resolved / accessed), the
+ * handler returns the user's accessible programs and whether they may create
+ * a new one, so the assistant can suggest options instead of dead-ending.
  */
 
 import { randomUUID } from 'node:crypto'
@@ -12,6 +16,9 @@ import type { ToolContext, WriteOperationMeta } from './permission-wrapper'
 import { DesignSessionService } from '@/lib/design-engine/session-service'
 import { db } from '@/lib/db'
 import { programs } from '@/lib/db/schema'
+import { AccessControlService } from '@/lib/auth/AccessControlService'
+import { permissionService } from '@/lib/auth/permission-service'
+import { DesignService } from '@/lib/services/DesignService'
 
 interface InitiateInput {
   description: string
@@ -24,6 +31,32 @@ interface InitiateOutput {
   workspaceUrl?: string
   action?: string
   error?: string
+  availablePrograms?: Array<{ id: string; name: string; code: string }>
+  canCreateProgram?: boolean
+}
+
+/**
+ * Build the "pick or create a program" response: the user's accessible
+ * programs plus whether they're allowed to create a new one.
+ */
+async function programOptionsResponse(
+  userId: string,
+  error: string,
+): Promise<InitiateOutput> {
+  const accessible = await AccessControlService.getAccessiblePrograms(userId)
+  const canCreateProgram = await permissionService.canUser(
+    userId,
+    'create',
+    'programs',
+  )
+
+  return {
+    error,
+    availablePrograms: accessible
+      .slice(0, 20)
+      .map((p) => ({ id: p.id, name: p.name, code: p.code })),
+    canCreateProgram,
+  }
 }
 
 async function initiateCollaborativeDesignImpl(
@@ -33,17 +66,46 @@ async function initiateCollaborativeDesignImpl(
   // Prefer programId from input (LLM looked it up), fall back to session context
   const rawProgramId = input.programId || context.programId
   if (!rawProgramId) {
-    return {
-      error:
-        'A program is required to start a design session. Please specify which program to use.',
-    }
+    return programOptionsResponse(
+      context.userId,
+      'A program is required to start a design session. Ask the user to pick one of availablePrograms, or offer to create a new program (create_program) if canCreateProgram is true.',
+    )
   }
 
   // Resolve program: accept UUID or code
   const programId = await resolveProgramId(rawProgramId)
   if (!programId) {
-    return {
-      error: `Could not find program "${rawProgramId}". Please check the program ID or code.`,
+    return programOptionsResponse(
+      context.userId,
+      `Could not find program "${rawProgramId}". Ask the user to pick one of availablePrograms, or offer to create a new program (create_program) if canCreateProgram is true.`,
+    )
+  }
+
+  // The user must be a member of the program (or a global admin)
+  const canAccess = await AccessControlService.canAccessProgram(
+    context.userId,
+    programId,
+  )
+  if (!canAccess) {
+    return programOptionsResponse(
+      context.userId,
+      `You don't have access to program "${rawProgramId}". Ask the user to pick one of availablePrograms instead.`,
+    )
+  }
+
+  // If a target design was given, it must exist and belong to the program —
+  // materialization will create items in it.
+  if (input.designId) {
+    const design = await DesignService.getById(input.designId)
+    if (!design) {
+      return {
+        error: `Could not find design "${input.designId}". Omit designId to create a new design, or use search_designs to find the right one.`,
+      }
+    }
+    if (design.programId !== programId) {
+      return {
+        error: `Design "${design.name}" belongs to a different program. Pass the design's own program as programId, or omit designId to create a new design.`,
+      }
     }
   }
 

--- a/src/lib/ai/tools/index.ts
+++ b/src/lib/ai/tools/index.ts
@@ -19,6 +19,7 @@
  * - create_relationship: Create BOM or Document relationships
  * - transition_item_state: Transition items through workflow states
  * - create_change_order: Create a new ECO for managing changes
+ * - create_program: Create a new program (creator becomes admin)
  *
  * Usage:
  * ```typescript
@@ -64,6 +65,7 @@ import {
   allWriteToolDefinitions,
   createChangeOrderDef,
   createItemDef,
+  createProgramDef,
   createRelationshipDef,
   transitionItemStateDef,
   updateItemDef,
@@ -72,6 +74,7 @@ import {
 import {
   createChangeOrderHandler,
   createItemHandler,
+  createProgramHandler,
   createRelationshipHandler,
   transitionItemStateHandler,
   updateItemHandler,
@@ -123,6 +126,7 @@ export {
   createRelationshipDef,
   transitionItemStateDef,
   createChangeOrderDef,
+  createProgramDef,
 }
 
 /**
@@ -187,6 +191,10 @@ export function createServerTools(context: ToolContext) {
     createChangeOrderHandler(input, context),
   )
 
+  const createProgram = createProgramDef.server((input) =>
+    createProgramHandler(input, context),
+  )
+
   // Design engine tools
   const initiateCollaborativeDesign = initiateCollaborativeDesignDef.server(
     (input) => initiateCollaborativeDesignHandler(input, context),
@@ -208,6 +216,7 @@ export function createServerTools(context: ToolContext) {
     createRelationship,
     transitionItemState,
     createChangeOrder,
+    createProgram,
     // Design engine
     initiateCollaborativeDesign,
   ]

--- a/src/lib/ai/tools/write-definitions.ts
+++ b/src/lib/ai/tools/write-definitions.ts
@@ -19,6 +19,7 @@
  * - create_relationship: Create BOM or Document relationships
  * - transition_item_state: Transition items through workflow states
  * - create_change_order: Create a new ECO for managing changes
+ * - create_program: Create a new program (top-level container)
  */
 
 import { toolDefinition } from '@tanstack/ai'
@@ -299,6 +300,39 @@ Requires user confirmation before creating.`,
 })
 
 // ============================================================================
+// create_program - Create a new program
+// ============================================================================
+
+export const createProgramDef = toolDefinition({
+  name: 'create_program',
+  description: `Create a new program. Programs are the top-level containers and permission boundaries for designs and items.
+Use this when the user wants to start work that doesn't fit any existing program — for example, kicking off a collaborative design session when none of their programs are a good match.
+The requesting user automatically becomes the program's admin. Requires the 'programs: create' permission — the tool returns a permission error if the user lacks it.
+Requires user confirmation before creating.`,
+  inputSchema: z.object({
+    name: z.string().describe('Program name (e.g., "Drone Platform")'),
+    code: z
+      .string()
+      .optional()
+      .describe(
+        'Program code — uppercase alphanumeric with hyphens (e.g., "DRONE-X"). Auto-generated from the name if omitted.',
+      ),
+    description: z.string().optional().describe('Program description'),
+    customer: z.string().optional().describe('Customer name, if any'),
+    // Confirmation flag
+    confirmed: z
+      .boolean()
+      .optional()
+      .describe('Set to true after user confirms the operation'),
+  }),
+  outputSchema: confirmationResponseSchema.extend({
+    programId: z.string().optional(),
+    programCode: z.string().optional(),
+    programName: z.string().optional(),
+  }),
+})
+
+// ============================================================================
 // Export all write definitions
 // ============================================================================
 
@@ -308,6 +342,7 @@ export const allWriteToolDefinitions = [
   createRelationshipDef,
   transitionItemStateDef,
   createChangeOrderDef,
+  createProgramDef,
 ]
 
 // Export type helpers for handlers
@@ -322,6 +357,7 @@ export type TransitionItemStateInput = z.infer<
 export type CreateChangeOrderInput = z.infer<
   typeof createChangeOrderDef.inputSchema
 >
+export type CreateProgramInput = z.infer<typeof createProgramDef.inputSchema>
 
 // Export confirmation response type
 export type WriteToolResponse = z.infer<typeof confirmationResponseSchema>

--- a/src/lib/ai/tools/write-handlers.ts
+++ b/src/lib/ai/tools/write-handlers.ts
@@ -11,6 +11,7 @@
 
 import { randomUUID } from 'node:crypto'
 
+import { eq } from 'drizzle-orm'
 import { withWritePermissionAndAudit } from './permission-wrapper'
 import type { BaseItem } from '@/lib/items/types/base'
 
@@ -19,7 +20,10 @@ import { ChangeOrderService } from '@/lib/items/services/ChangeOrderService'
 import { ItemService } from '@/lib/items/services/ItemService'
 import { BranchService } from '@/lib/services/BranchService'
 import { DesignService } from '@/lib/services/DesignService'
+import { ProgramService } from '@/lib/services/ProgramService'
 import { aiLogger } from '@/lib/logging/logger'
+import { db } from '@/lib/db'
+import { programs } from '@/lib/db/schema'
 
 // ============================================================================
 // Input Types (manually defined for better type inference)
@@ -87,6 +91,14 @@ interface CreateChangeOrderInput {
   impactDescription?: string
   affectedItemIds?: Array<string>
   designIds?: Array<string>
+  confirmed?: boolean
+}
+
+interface CreateProgramInput {
+  name: string
+  code?: string
+  description?: string
+  customer?: string
   confirmed?: boolean
 }
 
@@ -861,5 +873,124 @@ export const createChangeOrderHandler = (
     'create_change_order',
     { resource: 'change_orders', action: 'create' },
     createChangeOrderHandlerImpl,
+  )(input, context, meta)
+}
+
+// ============================================================================
+// create_program handler
+// ============================================================================
+
+/**
+ * Derive a program code from a name: uppercase alphanumeric with hyphens.
+ * Deterministic so the code shown in the confirmation step matches the one
+ * used when the tool is re-invoked with confirmed: true.
+ */
+function programCodeFromName(name: string): string {
+  const base = name
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 20)
+    .replace(/-+$/g, '')
+  return base || 'PROGRAM'
+}
+
+/** Find a free program code: the name-derived base, or base-2, base-3, ... */
+async function findAvailableProgramCode(name: string): Promise<string> {
+  const base = programCodeFromName(name)
+  for (let i = 0; i < 50; i++) {
+    const candidate = i === 0 ? base : `${base}-${i + 1}`
+    const existing = await db
+      .select({ id: programs.id })
+      .from(programs)
+      .where(eq(programs.code, candidate))
+      .limit(1)
+    if (existing.length === 0) return candidate
+  }
+  return `${base}-${Date.now().toString(36).toUpperCase()}`
+}
+
+async function createProgramHandlerImpl(
+  input: CreateProgramInput,
+  context: ToolContext,
+): Promise<
+  WriteToolResponse & {
+    programId?: string
+    programCode?: string
+    programName?: string
+  }
+> {
+  try {
+    const code = input.code
+      ? input.code.toUpperCase()
+      : await findAvailableProgramCode(input.name)
+
+    if (!input.confirmed) {
+      return confirmationRequired(
+        'Create Program',
+        {
+          action: 'create',
+          itemType: 'Program',
+          itemName: input.name,
+          additionalInfo: [
+            `Code: ${code}`,
+            input.customer ? `Customer: ${input.customer}` : '',
+            'You will be added as the program admin.',
+          ].filter(Boolean),
+        },
+        `Create new program "${input.name}" (${code})?`,
+      )
+    }
+
+    const program = await ProgramService.create(
+      {
+        name: input.name,
+        code,
+        description: input.description,
+        customer: input.customer,
+      },
+      context.userId,
+    )
+    if (!program) {
+      return errorResponse('Failed to create program')
+    }
+
+    return {
+      requiresConfirmation: false,
+      success: true,
+      programId: program.id,
+      programCode: program.code,
+      programName: program.name,
+      confirmationMessage: `Created program ${program.code} "${program.name}" — you are its admin`,
+    }
+  } catch (e) {
+    return errorResponse(
+      e instanceof Error ? e.message : 'Failed to create program',
+    )
+  }
+}
+
+export const createProgramHandler = (
+  input: CreateProgramInput,
+  context: ToolContext,
+) => {
+  const meta: WriteOperationMeta = {
+    actionType: 'create_program',
+    affectedItemIds: [],
+    wasConfirmed: input.confirmed ?? false,
+    transactionId: randomUUID(),
+  }
+
+  return withWritePermissionAndAudit<
+    CreateProgramInput,
+    WriteToolResponse & {
+      programId?: string
+      programCode?: string
+      programName?: string
+    }
+  >(
+    'create_program',
+    { resource: 'programs', action: 'create' },
+    createProgramHandlerImpl,
   )(input, context, meta)
 }

--- a/src/lib/design-engine/materialize.test.ts
+++ b/src/lib/design-engine/materialize.test.ts
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Cascadia PLM contributors
+
+/**
+ * MaterializationService Tests
+ *
+ * Data-integrity tests for materializing a design session into real PLM data.
+ * The invariants under test:
+ * - The executed behavior matches the plan shown in the preview
+ *   (same mode, same target, same counts).
+ * - Every created item lands in the 'Draft' state on the target design.
+ * - For a released (branch-protected) design, an ECO is created and the new
+ *   items land on its branch as 'added' working copies — main stays untouched.
+ *
+ * Run: npx vitest run src/lib/design-engine/materialize.test.ts
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest'
+import { and, eq, inArray } from 'drizzle-orm'
+import { MaterializationService } from './materialize'
+import { DesignSessionService } from './session-service'
+import type { DesignSession } from './session-service'
+import type { BomDraft, DesignArtifacts } from './types'
+import type { TestUser } from '@/__tests__/fixtures/users'
+import type { BaseItem } from '@/lib/items/types/base'
+import { TestDatabase } from '@/__tests__/helpers/db'
+import { insertTestUser } from '@/__tests__/fixtures/users'
+import { DesignService } from '@/lib/services/DesignService'
+import { ItemService } from '@/lib/items/services/ItemService'
+import {
+  branchItems,
+  branches,
+  changeOrderAffectedItems,
+  changeOrderDesigns,
+  designs,
+  itemRelationships,
+  items,
+  programs,
+} from '@/lib/db/schema'
+import { workflowDefinitions } from '@/lib/db/schema/workflows'
+import { itemTypeConfigs } from '@/lib/db/schema/config'
+import { ItemTypeRegistry } from '@/lib/items/registry'
+import {
+  SYSTEM_USER_ID,
+  seedStandardPartLifecycle,
+} from '@/__tests__/fixtures/lifecycles'
+
+// Import to register item types
+import '@/lib/items/registerItemTypes.server'
+
+// Unique ECO workflow definition ID for this test file, so it doesn't race with
+// other test files that seed their own ChangeOrder workflows against the shared DB.
+const ECO_WORKFLOW_ID = '00000000-0000-4000-8000-0000000001d3'
+
+// Minimal ChangeOrder workflow so ChangeOrderService.autoStartWorkflow() can
+// start an instance in the initial (Draft) state during eco_required materialization.
+const ecoWorkflowDefinition = {
+  states: [
+    { id: 'Draft', name: 'Draft', isInitial: true, isFinal: false },
+    { id: 'InReview', name: 'InReview', isInitial: false, isFinal: false },
+    { id: 'Approved', name: 'Approved', isInitial: false, isFinal: true },
+  ],
+  transitions: [
+    { id: 't1', name: 'Submit', fromStateId: 'Draft', toStateId: 'InReview' },
+    {
+      id: 't2',
+      name: 'Approve',
+      fromStateId: 'InReview',
+      toStateId: 'Approved',
+    },
+  ],
+  definitionType: 'workflow',
+  applicableItemTypes: ['ChangeOrder'],
+}
+
+function buildArtifacts(): DesignArtifacts {
+  const bom: BomDraft = {
+    rootAssembly: {
+      tempId: 'asm-1',
+      name: 'Bracket Assembly',
+      isNew: true,
+      quantity: 1,
+      partType: 'Manufacture',
+      children: [
+        {
+          tempId: 'part-1',
+          name: 'Base Plate',
+          isNew: true,
+          quantity: 1,
+          partType: 'Manufacture',
+          material: 'Aluminum 6061',
+          children: [],
+          requirementTempIds: ['req-1'],
+          rationale: 'Structural base',
+          confidence: 0.9,
+        },
+        {
+          tempId: 'part-2',
+          name: 'M4 Screw',
+          isNew: true,
+          quantity: 4,
+          partType: 'Purchase',
+          children: [],
+          requirementTempIds: [],
+          rationale: 'Fastening',
+          confidence: 0.95,
+        },
+      ],
+      requirementTempIds: ['req-1'],
+      rationale: 'Top-level assembly',
+      confidence: 0.9,
+    },
+    proposedParts: [],
+    requirementsCoverage: { 'req-1': ['part-1'] },
+    uncoveredRequirements: [],
+    validationIssues: [],
+  }
+
+  return {
+    description: 'A bracket assembly for mounting sensors',
+    requirements: [
+      {
+        tempId: 'req-1',
+        name: 'Holds 1kg load',
+        description: 'The assembly must support a 1kg load',
+        requirementType: 'Functional',
+        priority: 'high',
+        verificationMethod: 'Test',
+        rationale: 'Primary use case',
+        confidence: 0.9,
+        source: 'ai',
+      },
+    ],
+    bom,
+    clarifications: [],
+    userMessages: [],
+  }
+}
+
+describe('MaterializationService', () => {
+  const testDb = new TestDatabase()
+  let user: TestUser
+  let programId: string
+
+  beforeAll(async () => {
+    await testDb.setup()
+
+    // System user + Part lifecycle (gives Parts a 'release' action from Draft).
+    await seedStandardPartLifecycle(testDb.db)
+
+    // Seed a ChangeOrder workflow and point the ChangeOrder item type at it so
+    // autoStartWorkflow() resolves a workflow for the ECO change type.
+    await testDb.db
+      .insert(workflowDefinitions)
+      .values({
+        id: ECO_WORKFLOW_ID,
+        name: 'ECO - Materialize Test Workflow',
+        version: 1,
+        workflowType: 'strict',
+        definition: ecoWorkflowDefinition,
+        isActive: true,
+      })
+      .onConflictDoNothing()
+
+    const changeOrderConfig = {
+      lifecycleDefinitionId: ECO_WORKFLOW_ID,
+      workflowsByChangeType: {
+        ECO: ECO_WORKFLOW_ID,
+        ECN: ECO_WORKFLOW_ID,
+        Deviation: ECO_WORKFLOW_ID,
+        MCO: ECO_WORKFLOW_ID,
+      },
+    }
+    await testDb.db
+      .insert(itemTypeConfigs)
+      .values({
+        itemType: 'ChangeOrder',
+        config: changeOrderConfig,
+        modifiedBy: SYSTEM_USER_ID,
+      })
+      .onConflictDoUpdate({
+        target: itemTypeConfigs.itemType,
+        set: { config: changeOrderConfig, modifiedBy: SYSTEM_USER_ID },
+      })
+
+    // Reload the registry so it picks up the seeded lifecycle/workflow config.
+    await ItemTypeRegistry.reload()
+  })
+
+  afterAll(async () => {
+    await testDb.teardown()
+  })
+
+  beforeEach(async () => {
+    await testDb.beginTransaction()
+
+    user = await insertTestUser(testDb.db)
+
+    const [program] = await testDb.db
+      .insert(programs)
+      .values({
+        name: 'Sensor Platform',
+        code: `PROG-${Date.now()}`,
+        createdBy: user.id,
+      })
+      .returning()
+    programId = program!.id
+  })
+
+  afterEach(async () => {
+    await testDb.rollback()
+  })
+
+  async function createSession(designId?: string): Promise<DesignSession> {
+    const session = await DesignSessionService.create(user.id, {
+      description: 'A bracket assembly for mounting sensors',
+      programId,
+      designId,
+    })
+    const artifacts = buildArtifacts()
+    await DesignSessionService.updateArtifacts(session.id, artifacts)
+    return { ...session, artifacts }
+  }
+
+  it('creates a new design with all items in Draft on main, matching the previewed plan', async () => {
+    const session = await createSession()
+
+    const preview = await MaterializationService.preview(session)
+    expect(preview.plan.mode).toBe('create_design')
+    expect(preview.plan.supported).toBe(true)
+    expect(preview.plan.initialState).toBe('Draft')
+    expect(preview.plan.targetBranch).toBe('main')
+    expect(preview.plan.programName).toBe('Sensor Platform')
+    expect(preview.newPartsCount).toBe(3)
+    expect(preview.newRequirementsCount).toBe(1)
+    expect(preview.bomRelationshipsCount).toBe(2)
+
+    const result = await MaterializationService.execute(session, user.id)
+
+    // Execution matches the previewed plan
+    expect(result.mode).toBe(preview.plan.mode)
+    expect(result.initialState).toBe('Draft')
+    expect(result.createdItems).toHaveLength(
+      preview.newPartsCount + preview.newRequirementsCount,
+    )
+    expect(result.bomRelationshipsCreated).toBe(preview.bomRelationshipsCount)
+
+    // A new design exists in the session's program
+    const [design] = await testDb.db
+      .select()
+      .from(designs)
+      .where(eq(designs.id, result.designId))
+    expect(design).toBeDefined()
+    expect(design!.programId).toBe(programId)
+    expect(result.designName).toBe(design!.name)
+
+    // Invariant: every created item is in Draft state on the new design
+    const createdIds = result.createdItems.map((i) => i.itemId)
+    const createdRows = await testDb.db
+      .select()
+      .from(items)
+      .where(inArray(items.id, createdIds))
+    expect(createdRows).toHaveLength(createdIds.length)
+    for (const row of createdRows) {
+      expect(row.state).toBe('Draft')
+      expect(row.designId).toBe(result.designId)
+    }
+
+    // BOM relationships persisted between the created parts
+    const rels = await testDb.db
+      .select()
+      .from(itemRelationships)
+      .where(
+        and(
+          eq(itemRelationships.relationshipType, 'BOM'),
+          inArray(itemRelationships.sourceId, createdIds),
+        ),
+      )
+    expect(rels).toHaveLength(preview.bomRelationshipsCount)
+
+    // Session is completed and points at the materialized design
+    const fresh = await DesignSessionService.getById(session.id)
+    expect(fresh?.materializedDesignId).toBe(result.designId)
+    expect(fresh?.status).toBe('completed')
+  })
+
+  it('adds items to an existing pre-release design instead of creating a new one', async () => {
+    const design = await DesignService.create(
+      {
+        programId,
+        name: 'Existing Design',
+        code: `EX-${Date.now()}`,
+        designType: 'Engineering',
+      },
+      user.id,
+    )
+
+    const session = await createSession(design.id)
+
+    const preview = await MaterializationService.preview(session)
+    expect(preview.plan.mode).toBe('add_to_design')
+    expect(preview.plan.targetDesignId).toBe(design.id)
+    expect(preview.plan.targetDesignName).toBe('Existing Design')
+
+    const result = await MaterializationService.execute(session, user.id)
+    expect(result.designId).toBe(design.id)
+    expect(result.mode).toBe('add_to_design')
+
+    // No additional design was created in the program
+    const programDesigns = await testDb.db
+      .select({ id: designs.id })
+      .from(designs)
+      .where(eq(designs.programId, programId))
+    expect(programDesigns).toHaveLength(1)
+
+    // All created items are in Draft on the existing design
+    const createdIds = result.createdItems.map((i) => i.itemId)
+    const createdRows = await testDb.db
+      .select()
+      .from(items)
+      .where(inArray(items.id, createdIds))
+    for (const row of createdRows) {
+      expect(row.state).toBe('Draft')
+      expect(row.designId).toBe(design.id)
+    }
+  })
+
+  it('materializes into a released design via an ECO, leaving main untouched', async () => {
+    const design = await DesignService.create(
+      {
+        programId,
+        name: 'Released Design',
+        code: `REL-${Date.now()}`,
+        designType: 'Engineering',
+      },
+      user.id,
+    )
+    const designId = design.id!
+
+    // Release an item to put the design in post-release (protected) phase
+    const releasedPart = await ItemService.create(
+      'Part',
+      {
+        name: 'Released Part',
+        revision: 'A',
+        itemType: 'Part',
+        designId,
+      } as BaseItem,
+      user.id,
+    )
+    await testDb.db
+      .update(items)
+      .set({ state: 'Released' })
+      .where(eq(items.id, releasedPart.id!))
+
+    const session = await createSession(designId)
+
+    // The plan routes through an ECO (now a supported mode)
+    const preview = await MaterializationService.preview(session)
+    expect(preview.plan.mode).toBe('eco_required')
+    expect(preview.plan.supported).toBe(true)
+    expect(preview.plan.ecoName).toBeTruthy()
+
+    const result = await MaterializationService.execute(session, user.id)
+
+    // Result reflects the ECO path
+    expect(result.mode).toBe('eco_required')
+    expect(result.ecoId).toBeTruthy()
+    expect(result.ecoNumber).toBeTruthy()
+    expect(result.createdItems).toHaveLength(
+      preview.newPartsCount + preview.newRequirementsCount,
+    )
+    expect(result.bomRelationshipsCreated).toBe(preview.bomRelationshipsCount)
+
+    // The ECO exists as a ChangeOrder item
+    const [eco] = await testDb.db
+      .select()
+      .from(items)
+      .where(eq(items.id, result.ecoId!))
+    expect(eco).toBeDefined()
+    expect(eco!.itemType).toBe('ChangeOrder')
+
+    // A design association with a dedicated ECO branch was created
+    const [ecoDesign] = await testDb.db
+      .select()
+      .from(changeOrderDesigns)
+      .where(
+        and(
+          eq(changeOrderDesigns.changeOrderId, result.ecoId!),
+          eq(changeOrderDesigns.designId, designId),
+        ),
+      )
+    expect(ecoDesign).toBeDefined()
+    expect(ecoDesign!.branchId).toBeTruthy()
+    const ecoBranchId = ecoDesign!.branchId!
+
+    const [ecoBranch] = await testDb.db
+      .select()
+      .from(branches)
+      .where(eq(branches.id, ecoBranchId))
+    expect(ecoBranch!.branchType).toBe('eco')
+
+    // Invariant: every created item is an 'added' working copy on the ECO branch
+    const createdIds = result.createdItems.map((i) => i.itemId)
+    const createdRows = await testDb.db
+      .select()
+      .from(items)
+      .where(inArray(items.id, createdIds))
+    const createdMasterIds = createdRows.map((r) => r.masterId)
+    for (const row of createdRows) {
+      expect(row.state).toBe('Draft')
+    }
+
+    const ecoBranchItems = await testDb.db
+      .select()
+      .from(branchItems)
+      .where(
+        and(
+          eq(branchItems.branchId, ecoBranchId),
+          inArray(branchItems.itemMasterId, createdMasterIds),
+        ),
+      )
+    expect(ecoBranchItems).toHaveLength(createdIds.length)
+    for (const bi of ecoBranchItems) {
+      expect(bi.changeType).toBe('added')
+    }
+
+    // Parts are registered on the ECO with the 'release' change action so they
+    // show in the Affected Items tab (requirements register too when their
+    // lifecycle supports 'release'; that is best-effort and not asserted here).
+    const partIds = result.createdItems
+      .filter((i) => i.itemType === 'Part')
+      .map((i) => i.itemId)
+    const affected = await testDb.db
+      .select()
+      .from(changeOrderAffectedItems)
+      .where(eq(changeOrderAffectedItems.changeOrderId, result.ecoId!))
+    for (const a of affected) {
+      expect(a.changeAction).toBe('release')
+    }
+    const affectedIds = affected.map((a) => a.affectedItemId)
+    for (const partId of partIds) {
+      expect(affectedIds).toContain(partId)
+    }
+
+    // Invariant: main is untouched — none of the new items are on the main branch
+    const [mainBranch] = await testDb.db
+      .select()
+      .from(branches)
+      .where(
+        and(eq(branches.designId, designId), eq(branches.branchType, 'main')),
+      )
+    const mainBranchItems = await testDb.db
+      .select()
+      .from(branchItems)
+      .where(
+        and(
+          eq(branchItems.branchId, mainBranch!.id),
+          inArray(branchItems.itemMasterId, createdMasterIds),
+        ),
+      )
+    expect(mainBranchItems).toHaveLength(0)
+
+    // Session is completed and points at the target design
+    const fresh = await DesignSessionService.getById(session.id)
+    expect(fresh?.materializedDesignId).toBe(designId)
+    expect(fresh?.status).toBe('completed')
+  })
+})

--- a/src/lib/design-engine/materialize.ts
+++ b/src/lib/design-engine/materialize.ts
@@ -4,8 +4,21 @@
 /**
  * Materialization Service
  *
- * Converts the BOM draft into real PLM data: creates parts, requirements,
- * BOM relationships, and optionally an ECO for branch-protected designs.
+ * Converts the session's reviewed artifacts (requirements + BOM draft) into
+ * real PLM data. The contract is computed by plan() and shared between
+ * preview() and execute(), so what the user is told will happen is exactly
+ * what happens:
+ *
+ * - No target design: a new design is created in the session's program, then
+ *   requirements, parts, and BOM relationships are created on its main branch
+ *   in the 'Draft' lifecycle state. No ECO is involved — pre-release designs
+ *   are directly editable, and revision letters are assigned later when the
+ *   design is first released through an ECO.
+ * - Existing pre-release design: same as above, minus the design creation.
+ * - Existing design with released items: an ECO is created and the new items
+ *   are added to its branch (as 'added' working copies, and registered on the
+ *   ECO with the 'release' change action). They are released with revision
+ *   letters when the ECO is reviewed, approved, and merged to main.
  */
 
 import { DesignSessionService } from './session-service'
@@ -13,31 +26,92 @@ import type { BaseItem } from '@/lib/items/types/base'
 import type { DesignSession } from './session-service'
 import type {
   BomNodeDraft,
+  MaterializationPlan,
   MaterializationPreview,
   MaterializationResult,
 } from './types'
 import { ItemService } from '@/lib/items/services/ItemService'
 import { DesignService } from '@/lib/services/DesignService'
+import { ProgramService } from '@/lib/services/ProgramService'
 import { BranchService } from '@/lib/services/BranchService'
-import { ChangeOrderService } from '@/lib/items/services/ChangeOrderService'
 import { CatalogService } from '@/lib/services/CatalogService'
+import { ChangeOrderService } from '@/lib/items/services/ChangeOrderService'
+import { ValidationError } from '@/lib/errors'
+import { serviceLogger } from '@/lib/logging/logger'
 
 export class MaterializationService {
+  /**
+   * Determine what materialization will do for this session.
+   *
+   * preview() displays this plan and execute() follows it — keep all
+   * mode/target decisions here so the two cannot drift apart.
+   */
+  static async plan(session: DesignSession): Promise<MaterializationPlan> {
+    const program = await ProgramService.getById(session.programId)
+    const programName = program?.name ?? null
+
+    if (!session.designId) {
+      return {
+        mode: 'create_design',
+        supported: true,
+        programId: session.programId,
+        programName,
+        targetDesignId: null,
+        targetDesignName: null,
+        newDesignName: session.title ?? 'Collaborative Design',
+        initialState: 'Draft',
+        targetBranch: 'main',
+      }
+    }
+
+    const design = await DesignService.getById(session.designId)
+    const targetDesignName = design?.name ?? design?.code ?? null
+    const isProtected = await BranchService.isMainBranchProtected(
+      session.designId,
+    )
+
+    if (isProtected) {
+      return {
+        mode: 'eco_required',
+        supported: true,
+        programId: session.programId,
+        programName,
+        targetDesignId: session.designId,
+        targetDesignName,
+        ecoName: `ECO for ${session.title ?? 'Collaborative Design'}`,
+        initialState: 'Draft',
+        targetBranch: 'main',
+      }
+    }
+
+    return {
+      mode: 'add_to_design',
+      supported: true,
+      programId: session.programId,
+      programName,
+      targetDesignId: session.designId,
+      targetDesignName,
+      initialState: 'Draft',
+      targetBranch: 'main',
+    }
+  }
+
   /**
    * Generate a preview of what materialization will create.
    */
   static async preview(
     session: DesignSession,
   ): Promise<MaterializationPreview> {
+    const plan = await this.plan(session)
+
     const artifacts = session.artifacts
     if (!artifacts?.bom) {
       return {
+        plan,
         newPartsCount: 0,
         reusedPartsCount: 0,
         newRequirementsCount: 0,
         bomRelationshipsCount: 0,
-        requiresEco: false,
-        targetDesignId: session.designId,
         items: [],
       }
     }
@@ -87,25 +161,20 @@ export class MaterializationService {
       })
     }
 
-    // Check if ECO is required
-    let requiresEco = false
-    if (session.designId) {
-      requiresEco = await BranchService.isMainBranchProtected(session.designId)
-    }
-
     return {
+      plan,
       newPartsCount: newParts,
       reusedPartsCount: reusedParts,
       newRequirementsCount,
       bomRelationshipsCount: bomRelationships,
-      requiresEco,
-      targetDesignId: session.designId,
       items,
     }
   }
 
   /**
-   * Execute materialization: create all items, relationships, and ECO.
+   * Execute materialization following the plan: create the design if needed,
+   * then create all requirements, parts, and BOM relationships in 'Draft'
+   * state on the target design's main branch.
    */
   static async execute(
     session: DesignSession,
@@ -113,7 +182,15 @@ export class MaterializationService {
   ): Promise<MaterializationResult> {
     const artifacts = session.artifacts
     if (!artifacts?.bom) {
-      throw new Error('No BOM to materialize')
+      throw new ValidationError('No BOM to materialize')
+    }
+
+    const plan = await this.plan(session)
+    if (!plan.supported) {
+      throw new ValidationError(
+        plan.blockedReason ??
+          'Materialization is not supported for this target design',
+      )
     }
 
     const bom = artifacts.bom
@@ -122,33 +199,40 @@ export class MaterializationService {
     const createdItems: MaterializationResult['createdItems'] = []
     let bomRelationshipsCreated = 0
 
-    // Step 1: Resolve or create design
-    let designId = session.designId
-    if (!designId) {
+    // Step 1: Resolve or create the target design
+    let resolvedDesignId = plan.targetDesignId
+    let designName = plan.targetDesignName
+    if (!resolvedDesignId) {
       // Generate a unique uppercase alphanumeric code
       const codeTimestamp = Date.now().toString(36).toUpperCase()
       const design = await DesignService.create(
         {
-          name: session.title ?? 'Collaborative Design',
+          name: plan.newDesignName ?? 'Collaborative Design',
           code: `CD-${codeTimestamp}`,
           programId: session.programId,
           designType: 'Engineering',
         },
         userId,
       )
-      designId = design.id
+      resolvedDesignId = design.id ?? null
+      designName = design.name ?? null
     }
+    if (!resolvedDesignId) {
+      throw new ValidationError('Failed to create design for materialization')
+    }
+    const designId = resolvedDesignId
 
-    // Step 2: Check branch protection and create ECO if needed
+    // Step 1b: For a released (branch-protected) design, create an ECO and a
+    // branch to hold the new items. They are created on that branch as 'added'
+    // working copies and released with revision letters when the ECO merges.
     let ecoId: string | undefined
     let ecoNumber: string | undefined
-    const requiresEco = await BranchService.isMainBranchProtected(designId)
-
-    if (requiresEco) {
+    let ecoBranchId: string | null = null
+    if (plan.mode === 'eco_required') {
       const eco = await ItemService.create(
         'ChangeOrder',
         {
-          name: `ECO for ${session.title ?? 'Design Session'}`,
+          name: plan.ecoName ?? `ECO for ${session.title ?? 'Design Session'}`,
           revision: '-',
           itemType: 'ChangeOrder',
           changeType: 'ECO',
@@ -159,17 +243,72 @@ export class MaterializationService {
         userId,
         { bypassBranchProtection: true },
       )
-
       ecoId = eco.id ?? undefined
       ecoNumber = eco.itemNumber ?? undefined
+      if (!ecoId) {
+        throw new ValidationError('Failed to create ECO for materialization')
+      }
 
-      if (ecoId) {
-        await ChangeOrderService.autoStartWorkflow(ecoId, 'ECO', userId)
-        await ChangeOrderService.addDesignToEco(ecoId, designId, userId)
+      // Start the ECO workflow (Draft) and create its branch for this design.
+      await ChangeOrderService.autoStartWorkflow(ecoId, 'ECO', userId)
+      await ChangeOrderService.addDesignToEco(ecoId, designId, userId)
+
+      const ecoDesigns = await ChangeOrderService.getEcoDesigns(ecoId)
+      ecoBranchId =
+        ecoDesigns.find((d) => d.designId === designId)?.branchId ?? null
+      if (!ecoBranchId) {
+        throw new ValidationError(
+          'Failed to create ECO branch for materialization',
+        )
       }
     }
 
-    // Step 3: Create requirements
+    // Create a requirement or part, either directly on main (create/add modes)
+    // or on the ECO branch (eco_required). On the ECO branch the item is an
+    // 'added' working copy; it is also registered on the ECO with the 'release'
+    // change action so it appears in the Affected Items tab for review.
+    const createItem = async (
+      type: 'Requirement' | 'Part',
+      data: BaseItem,
+    ): Promise<BaseItem> => {
+      if (ecoBranchId) {
+        const { item } = await ItemService.createOnBranch(
+          type,
+          data,
+          ecoBranchId,
+          `Materialized ${type} ${data.name ?? ''}`.trim(),
+          userId,
+        )
+        // Register on the ECO so the item shows in its Affected Items tab.
+        // Best-effort: this is display metadata only — the item is already an
+        // 'added' working copy on the branch and is released at merge whether or
+        // not it is registered. Skip (with a warning) for item types whose
+        // lifecycle doesn't define a 'release' action, rather than aborting.
+        if (ecoId && item.id) {
+          try {
+            await ChangeOrderService.addAffectedItem(
+              ecoId,
+              {
+                affectedItemId: item.id,
+                changeAction: 'release',
+                currentState: item.state ?? 'Draft',
+                currentRevision: item.revision,
+              },
+              userId,
+            )
+          } catch (err) {
+            serviceLogger.warn(
+              { ecoId, itemId: item.id, itemType: type, err },
+              'Could not register materialized item on ECO affected items; item remains on the ECO branch and will release at merge',
+            )
+          }
+        }
+        return item
+      }
+      return ItemService.create(type, data, userId)
+    }
+
+    // Step 2: Create requirements in Draft state (on main, or on the ECO branch)
     // Map design engine enums → PLM Requirement schema enums
     const priorityMap: Record<string, string> = {
       critical: 'MustHave',
@@ -186,21 +325,17 @@ export class MaterializationService {
     }
 
     for (const req of artifacts.requirements) {
-      const item = await ItemService.create(
-        'Requirement',
-        {
-          name: req.name,
-          revision: '-',
-          itemType: 'Requirement',
-          description: req.description,
-          type: typeMap[req.requirementType] ?? 'Functional',
-          priority: priorityMap[req.priority] ?? 'CouldHave',
-          verificationMethod: req.verificationMethod,
-          designId,
-        } as BaseItem,
-        userId,
-        { bypassBranchProtection: requiresEco },
-      )
+      const item = await createItem('Requirement', {
+        name: req.name,
+        revision: '-',
+        itemType: 'Requirement',
+        state: plan.initialState,
+        description: req.description,
+        type: typeMap[req.requirementType] ?? 'Functional',
+        priority: priorityMap[req.priority] ?? 'CouldHave',
+        verificationMethod: req.verificationMethod,
+        designId,
+      } as BaseItem)
 
       const itemId = item.id ?? ''
       const itemNumber = item.itemNumber ?? ''
@@ -216,7 +351,7 @@ export class MaterializationService {
       })
     }
 
-    // Step 4: Create parts depth-first (leaves before parents for BOM relationships)
+    // Step 3: Create parts depth-first (leaves before parents for BOM relationships)
     async function createPartNode(
       node: BomNodeDraft,
       parentNode?: BomNodeDraft,
@@ -289,21 +424,17 @@ export class MaterializationService {
           }
         }
 
-        const item = await ItemService.create(
-          'Part',
-          {
-            name: node.name,
-            revision: '-',
-            itemType: 'Part',
-            partType: node.partType,
-            material: node.material,
-            designId,
-            ...(Object.keys(attributes).length > 0 ? { attributes } : {}),
-            ...(cost !== undefined ? { cost } : {}),
-          } as BaseItem,
-          userId,
-          { bypassBranchProtection: requiresEco },
-        )
+        const item = await createItem('Part', {
+          name: node.name,
+          revision: '-',
+          itemType: 'Part',
+          state: plan.initialState,
+          partType: node.partType,
+          material: node.material,
+          designId,
+          ...(Object.keys(attributes).length > 0 ? { attributes } : {}),
+          ...(cost !== undefined ? { cost } : {}),
+        } as BaseItem)
 
         itemId = item.id ?? ''
         const itemNumber = item.itemNumber ?? ''
@@ -337,13 +468,16 @@ export class MaterializationService {
 
     await createPartNode(bom.rootAssembly)
 
-    // Step 5: Update session and save materialization result to artifacts
+    // Step 4: Update session and save materialization result to artifacts
     await DesignSessionService.setMaterializedDesign(session.id, designId)
 
     const result: MaterializationResult = {
+      mode: plan.mode,
       designId,
-      ecoId,
-      ecoNumber,
+      designName,
+      initialState: plan.initialState,
+      ...(ecoId ? { ecoId } : {}),
+      ...(ecoNumber ? { ecoNumber } : {}),
       createdItems,
       bomRelationshipsCreated,
     }

--- a/src/lib/design-engine/types.ts
+++ b/src/lib/design-engine/types.ts
@@ -395,13 +395,58 @@ export interface DesignArtifacts {
 // Materialization Types
 // ============================================================================
 
+/**
+ * How materialization will write the session's artifacts into the PLM database.
+ *
+ * - 'create_design': the session has no target design — a new design is created
+ *   in the session's program, and all items land on its main branch.
+ * - 'add_to_design': the target design exists and is pre-release (no released
+ *   items) — items are added directly to its main branch.
+ * - 'eco_required': the target design has released items, so changes must go
+ *   through an ECO branch. Materialization creates the ECO, adds the new items
+ *   to its branch, and they are released with revision letters when the ECO is
+ *   approved and merged.
+ */
+export type MaterializationMode =
+  | 'create_design'
+  | 'add_to_design'
+  | 'eco_required'
+
+/**
+ * The materialization contract: exactly what executing materialization will do.
+ * Both the preview shown to the user and the execution derive from this plan,
+ * so the stated behavior cannot drift from the actual behavior.
+ */
+export interface MaterializationPlan {
+  mode: MaterializationMode
+  /** False when execution would be refused (see blockedReason) */
+  supported: boolean
+  programId: string
+  programName: string | null
+  targetDesignId: string | null
+  targetDesignName: string | null
+  /** Name the new design will be given (mode 'create_design' only) */
+  newDesignName?: string
+  /** Name of the ECO that will be created (mode 'eco_required' only) */
+  ecoName?: string
+  /** Lifecycle state every created item starts in */
+  initialState: 'Draft'
+  /**
+   * Branch the items are created on. 'main' for the create/add modes; for
+   * 'eco_required' the items land on a new ECO branch (whose name isn't known
+   * until the ECO is created) but reach 'main' when the ECO merges.
+   */
+  targetBranch: 'main'
+  /** Human-readable reason when supported is false */
+  blockedReason?: string
+}
+
 export interface MaterializationPreview {
+  plan: MaterializationPlan
   newPartsCount: number
   reusedPartsCount: number
   newRequirementsCount: number
   bomRelationshipsCount: number
-  requiresEco: boolean
-  targetDesignId: string | null
   items: Array<{
     tempId: string
     name: string
@@ -412,7 +457,14 @@ export interface MaterializationPreview {
 }
 
 export interface MaterializationResult {
+  // mode/designName/initialState are optional because results persisted by
+  // older sessions predate these fields
+  mode?: MaterializationMode
   designId: string
+  designName?: string | null
+  /** Lifecycle state the created items start in */
+  initialState?: 'Draft'
+  /** The ECO created when materializing into a released design (mode 'eco_required') */
   ecoId?: string
   ecoNumber?: string
   createdItems: Array<{


### PR DESCRIPTION
…he design engine

Materialization now derives a single MaterializationPlan contract in plan(), shared by both preview() and execute(), so what the user is shown cannot drift from what runs. Three modes:

- create_design: no target design -> create one; items land on its main branch in Draft.
- add_to_design: existing pre-release design -> items added to main in Draft.
- eco_required: target design has released items -> create an ECO, add the new items to its branch as `added` working copies, and register each on the ECO with the `release` change action. Items are released with revision letters when the ECO is approved and merged. Previously this was blocked.

Item creation is routed through createItem(), which uses ItemService.createOnBranch() on the ECO branch (fully populating the type-specific tables) or ItemService.create() on main. Affected-item registration is best-effort: item types whose lifecycle has no `release` action (e.g. Requirement) are skipped with a warning instead of aborting the run -- the item is still an `added` working copy on the branch and releases at merge. The old "auto-create ECO and write items to main with bypassBranchProtection" path is removed.

AI design tools:
- Add the create_program write tool (two-step confirmation; creator becomes the program admin; gated on programs:create).
- initiate_collaborative_design: programId is now optional. When it is absent or cannot be resolved/accessed, the tool returns availablePrograms and canCreateProgram so the assistant can offer a choice or create a program instead of dead-ending. Adds program-access and design-belongs-to-program checks.

Tests/docs:
- New materialize.test.ts covering all three modes as data-integrity invariants (matching plan, Draft state, ECO branch created, main untouched).
- Update design-engine feature and API docs to match.