### PR TITLE
Fix openapi:check false positive on Windows CRLF checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Generated snapshot is byte-compared by scripts/snapshot-openapi.ts --check;
+# keep it LF on every platform so checkout never introduces CRLF drift.
+docs/api/openapi.v1.json text eol=lf

--- a/scripts/snapshot-openapi.ts
+++ b/scripts/snapshot-openapi.ts
@@ -68,7 +68,9 @@ if (args.has('--check')) {
     )
     process.exit(1)
   }
-  const committed = readFileSync(SNAPSHOT_PATH, 'utf8')
+  // Normalize CRLF: on Windows clones autocrlf smudges the snapshot to CRLF
+  // on checkout, which must not read as contract drift.
+  const committed = readFileSync(SNAPSHOT_PATH, 'utf8').replace(/\r\n/g, '\n')
   if (committed !== generated) {
     console.error(
       `OpenAPI snapshot is out of date. Run \`npm run openapi:snapshot\` and commit ${SNAPSHOT_PATH}.`,


### PR DESCRIPTION
`npm run openapi:check` failed on a clean tree on Windows, claiming the snapshot was stale. The generated spec is byte-identical to the committed one — no route drift. The strict string comparison failed only because core.autocrlf smudges docs/api/openapi.v1.json to CRLF on checkout while the generator emits LF.

Normalize CRLF before comparing so existing clones pass regardless of git eol config, and pin the snapshot to LF via .gitattributes so future checkouts are byte-stable on every platform.