### PR TITLE
Fix strict-mode violation in part edit E2E test

### DIFF
--- a/tests/e2e/workflows/part-lifecycle.spec.ts
+++ b/tests/e2e/workflows/part-lifecycle.spec.ts
@@ -147,7 +147,11 @@ test.describe('Part Lifecycle Workflow', () => {
         await page.click('[data-testid="part-submit"]')
 
         // 4. Verify update was successful
-        await expect(page.locator('text=Updated Part Name')).toBeVisible({
+        // Use an exact match: the name also appears in the "Revision A • Updated
+        // Part Name" subtitle, so a substring match trips Playwright strict mode.
+        await expect(
+          page.getByText('Updated Part Name', { exact: true }),
+        ).toBeVisible({
           timeout: 5000,
         })
       }


### PR DESCRIPTION
## Problem

The `can edit an existing part` test in `tests/e2e/workflows/part-lifecycle.spec.ts` intermittently fails in CI with a Playwright **strict mode violation**:

```
Locator: locator('text=Updated Part Name')
Error: strict mode violation: locator('text=Updated Part Name') resolved to 2 elements:
    1) <p>Revision A • Updated Part Name</p>
    2) <span>Updated Part Name</span>
```

The part detail page renders the updated name in two places — the "Revision A • Updated Part Name" subtitle and the name field itself — so the substring locator matches both. It only fails intermittently because it's a render race: the assertion throws whenever both elements are present at evaluation time.

Observed in runs [28905711350](https://github.com/Cascadia-PLM/Cascadia-App/actions/runs/28905711350/job/85752231351) and [28905450777](https://github.com/Cascadia-PLM/Cascadia-App/actions/runs/28905450777/job/85751419231).

## Fix

Switch to an exact-text match (`getByText('Updated Part Name', { exact: true })`), which uniquely targets the name field and not the subtitle — exactly what Playwright's own error output suggests. This mirrors the existing `.first()` disambiguation already used a few lines above for the item number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)