### PR TITLE
Add Design Engine Sessions list page with resume

### DIFF
--- a/src/components/design-engine/SessionsTable.tsx
+++ b/src/components/design-engine/SessionsTable.tsx
@@ -1,0 +1,170 @@
+import { Link } from '@tanstack/react-router'
+import { useCallback } from 'react'
+import { Eye, MoreVertical, Play } from 'lucide-react'
+import type { DataGridColumn, Row } from '@/components/ui'
+import { Badge, Button, DataGrid } from '@/components/ui'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/DropdownMenu'
+import {
+  stageLabel,
+  statusBadgeVariant,
+  statusLabel,
+} from '@/components/design-engine/session-labels'
+
+export interface DesignSessionRow {
+  id: string
+  userId: string
+  title: string | null
+  stage: string
+  status: string
+  programId: string | null
+  programCode?: string
+  programName?: string
+  updatedAt: string | Date
+  createdAt: string | Date
+  completedAt: string | Date | null
+}
+
+interface SessionsTableProps {
+  items: Array<DesignSessionRow>
+}
+
+function formatDate(value: string | Date | null): string {
+  if (!value) return '-'
+  return new Date(value).toLocaleDateString()
+}
+
+const columns: Array<DataGridColumn<DesignSessionRow>> = [
+  {
+    id: 'title',
+    header: 'Session',
+    accessorKey: 'title',
+    enableFiltering: true,
+    filterType: 'text',
+    filterPlaceholder: 'Filter...',
+    cell: ({ row }) => (
+      <Link
+        to="/designs/collaborative/$sessionId"
+        params={{ sessionId: row.original.id }}
+        className="font-medium text-cyan-600 dark:text-cyan-400 hover:underline"
+      >
+        {row.original.title || 'Untitled session'}
+      </Link>
+    ),
+  },
+  {
+    id: 'stage',
+    header: 'Stage',
+    accessorKey: 'stage',
+    enableFiltering: true,
+    filterType: 'text',
+    filterPlaceholder: 'Filter...',
+    cell: ({ getValue }) => (
+      <Badge variant="outline">{stageLabel(getValue() as string)}</Badge>
+    ),
+  },
+  {
+    id: 'status',
+    header: 'Status',
+    accessorKey: 'status',
+    enableFiltering: true,
+    filterType: 'multiSelect',
+    filterOptions: [
+      { label: 'Active', value: 'active' },
+      { label: 'Completed', value: 'completed' },
+      { label: 'Failed', value: 'failed' },
+    ],
+    cell: ({ getValue }) => {
+      const value = getValue() as string
+      return <Badge variant={statusBadgeVariant(value)}>{statusLabel(value)}</Badge>
+    },
+  },
+  {
+    id: 'programCode',
+    header: 'Program',
+    accessorKey: 'programCode',
+    enableFiltering: true,
+    filterType: 'text',
+    filterPlaceholder: 'Filter...',
+    cell: ({ row }) => {
+      const { programId, programCode } = row.original
+      if (!programId || !programCode)
+        return <span className="text-slate-400">-</span>
+      return (
+        <Link
+          to="/programs/$id"
+          params={{ id: programId }}
+          className="text-cyan-600 dark:text-cyan-400 hover:underline"
+        >
+          {programCode}
+        </Link>
+      )
+    },
+  },
+  {
+    id: 'updatedAt',
+    header: 'Updated',
+    accessorKey: 'updatedAt',
+    cell: ({ getValue }) => formatDate(getValue() as string | Date | null),
+  },
+  {
+    id: 'createdAt',
+    header: 'Created',
+    accessorKey: 'createdAt',
+    cell: ({ getValue }) => formatDate(getValue() as string | Date | null),
+  },
+]
+
+export function SessionsTable({ items }: SessionsTableProps) {
+  const renderRowActions = useCallback((row: Row<DesignSessionRow>) => {
+    const session = row.original
+    const isActive = session.status === 'active'
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button size="icon" variant="ghost" className="h-8 w-8">
+            <MoreVertical className="h-4 w-4" />
+            <span className="sr-only">Open menu</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem asChild>
+            <Link
+              to="/designs/collaborative/$sessionId"
+              params={{ sessionId: session.id }}
+            >
+              {isActive ? (
+                <>
+                  <Play className="mr-2 h-4 w-4" />
+                  Resume
+                </>
+              ) : (
+                <>
+                  <Eye className="mr-2 h-4 w-4" />
+                  Open
+                </>
+              )}
+            </Link>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+  }, [])
+
+  return (
+    <DataGrid
+      data={items}
+      columns={columns}
+      getRowId={(row) => row.id}
+      enableRowActions
+      renderRowActions={renderRowActions}
+      emptyMessage="No design sessions"
+      emptyDescription="Start a collaborative design from the AI assistant to see it here"
+      exportFilename="design-sessions"
+    />
+  )
+}

--- a/src/components/design-engine/TeamSessionsList.tsx
+++ b/src/components/design-engine/TeamSessionsList.tsx
@@ -14,6 +14,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui'
+import { stageLabel } from '@/components/design-engine/session-labels'
 
 interface TeamSession {
   id: string
@@ -29,20 +30,6 @@ interface TeamSession {
 interface TeamSessionsListProps {
   programId: string
   currentUserId: string
-}
-
-const STAGE_LABELS: Record<string, string> = {
-  idle: 'Not started',
-  requirements_drafting: 'Drafting requirements',
-  requirements_review: 'Reviewing requirements',
-  bom_drafting: 'Drafting BOM',
-  bom_review: 'Reviewing BOM',
-  materialization: 'Materializing',
-  cad_generation: 'Generating CAD',
-  cad_review: 'Reviewing CAD',
-  assembly_composition: 'Composing assemblies',
-  assembly_review: 'Reviewing assemblies',
-  complete: 'Complete',
 }
 
 export function TeamSessionsList({
@@ -120,7 +107,7 @@ export function TeamSessionsList({
                   )}
                 </div>
                 <div className="text-xs text-muted-foreground mt-0.5">
-                  {STAGE_LABELS[session.stage] ?? session.stage}
+                  {stageLabel(session.stage)}
                   {' \u00B7 '}
                   {new Date(session.updatedAt).toLocaleDateString()}
                 </div>

--- a/src/components/design-engine/session-labels.ts
+++ b/src/components/design-engine/session-labels.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared display helpers for design engine sessions.
+ *
+ * Keeps stage/status labels in one place so the sessions list
+ * (SessionsTable) and the per-program TeamSessionsList stay in sync.
+ */
+
+import type { BadgeProps } from '@/components/ui'
+
+/** Human-readable label for each design session stage. */
+export const STAGE_LABELS: Record<string, string> = {
+  idle: 'Not started',
+  toolset_establishment: 'Establishing toolset',
+  toolset_review: 'Reviewing toolset',
+  requirements_drafting: 'Drafting requirements',
+  requirements_review: 'Reviewing requirements',
+  bom_drafting: 'Drafting BOM',
+  bom_review: 'Reviewing BOM',
+  materialization: 'Materializing',
+  cad_generation: 'Generating CAD',
+  cad_review: 'Reviewing CAD',
+  assembly_composition: 'Composing assemblies',
+  assembly_review: 'Reviewing assemblies',
+  complete: 'Complete',
+}
+
+/** Resolve a stage value to its label, falling back to the raw value. */
+export function stageLabel(stage: string): string {
+  return STAGE_LABELS[stage] ?? stage
+}
+
+/** Human-readable label for each design session status. */
+export const STATUS_LABELS: Record<string, string> = {
+  active: 'Active',
+  completed: 'Completed',
+  failed: 'Failed',
+}
+
+/** Resolve a status value to its label, falling back to the raw value. */
+export function statusLabel(status: string): string {
+  return STATUS_LABELS[status] ?? status
+}
+
+/** Badge variant to use for a given session status. */
+export function statusBadgeVariant(status: string): BadgeProps['variant'] {
+  switch (status) {
+    case 'completed':
+      return 'success'
+    case 'failed':
+      return 'destructive'
+    default:
+      return 'default'
+  }
+}

--- a/src/components/layout/SidebarNav.tsx
+++ b/src/components/layout/SidebarNav.tsx
@@ -20,6 +20,7 @@ import {
   RotateCcw,
   Settings,
   Shield,
+  Sparkles,
   Users,
   Wrench,
 } from 'lucide-react'
@@ -114,6 +115,14 @@ export function SidebarNav({
           icon={GitFork}
           label="My Workspaces"
           onClick={onNavClick}
+        />
+        <NavSubItem
+          to="/designs/collaborative"
+          icon={Sparkles}
+          label="Design Sessions"
+          onClick={onNavClick}
+          activeOptions={{ exact: true }}
+          testId="nav-design-sessions"
         />
       </SidebarSection>
 

--- a/src/routes/designs/collaborative/index.tsx
+++ b/src/routes/designs/collaborative/index.tsx
@@ -1,0 +1,117 @@
+/**
+ * Design Sessions List Route
+ *
+ * Lists the current user's collaborative design engine sessions and lets
+ * them resume any one (navigating to /designs/collaborative/$sessionId).
+ * URL: /designs/collaborative
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+import type { DesignSessionRow } from '@/components/design-engine/SessionsTable'
+import { SessionsTable } from '@/components/design-engine/SessionsTable'
+import { PageContainer } from '@/components/layout'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui'
+import { apiFetch } from '@/lib/api/client'
+
+interface ProgramInfo {
+  id: string
+  code: string
+  name: string
+}
+
+// The list endpoint returns full DesignSession rows; we only read list fields.
+interface SessionListItem {
+  id: string
+  userId: string
+  title: string | null
+  stage: string
+  status: string
+  programId: string | null
+  updatedAt: string
+  createdAt: string
+  completedAt: string | null
+}
+
+export const Route = createFileRoute('/designs/collaborative/')({
+  component: DesignSessionsListPage,
+  loader: async () => {
+    let sessions: Array<DesignSessionRow> = []
+    try {
+      const sessionsResult = await apiFetch<{
+        data: { sessions: Array<SessionListItem> }
+      }>('/api/v1/design-engine/sessions')
+
+      // Program names are best-effort enrichment — failing here still lists sessions.
+      let programMap = new Map<string, ProgramInfo>()
+      try {
+        const programsResult = await apiFetch<{
+          data: { programs: Array<ProgramInfo> }
+        }>('/api/v1/programs')
+        programMap = new Map(
+          programsResult.data.programs.map((p) => [p.id, p]),
+        )
+      } catch {
+        // Ignore — sessions render without program codes.
+      }
+
+      sessions = sessionsResult.data.sessions.map((s) => ({
+        id: s.id,
+        userId: s.userId,
+        title: s.title,
+        stage: s.stage,
+        status: s.status,
+        programId: s.programId,
+        programCode: s.programId
+          ? programMap.get(s.programId)?.code
+          : undefined,
+        programName: s.programId
+          ? programMap.get(s.programId)?.name
+          : undefined,
+        updatedAt: s.updatedAt,
+        createdAt: s.createdAt,
+        completedAt: s.completedAt,
+      }))
+    } catch (error) {
+      console.error('Error loading design sessions:', error)
+    }
+
+    return { sessions }
+  },
+})
+
+function DesignSessionsListPage() {
+  const { sessions } = Route.useLoaderData()
+
+  return (
+    <PageContainer>
+      {/* Header */}
+      <div>
+        <h1 className="text-4xl font-bold text-slate-900 dark:text-white">
+          Design Sessions
+        </h1>
+        <p className="text-slate-600 dark:text-slate-400 mt-2">
+          Resume a collaborative design engine session you've started.
+        </p>
+      </div>
+
+      {/* Sessions Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Your Sessions</CardTitle>
+          <CardDescription>
+            {sessions.length} {sessions.length === 1 ? 'session' : 'sessions'}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <SessionsTable items={sessions} />
+        </CardContent>
+      </Card>
+    </PageContainer>
+  )
+}


### PR DESCRIPTION
Adds a /designs/collaborative list page so users can navigate back into collaborative design engine sessions after leaving the workspace — the only prior entry point was the AI chat's "Open Design Workspace" button.

- New SessionsTable (client-side DataGrid) listing the user's sessions with Session/Stage/Status/Program/Updated/Created columns and a status-aware Resume/Open row action linking to the workspace
- New /designs/collaborative index route fetching GET /api/v1/design-engine/sessions, best-effort enriched with program names
- Extract shared STAGE_LABELS/status helpers into session-labels.ts; TeamSessionsList now reuses them instead of a local duplicate
- Add a "Design Sessions" sub-item under the Designs sidebar section

No backend changes — reuses the existing sessions endpoint and the workspace loader's resume flow.