### PR TITLE
Fix design engine toolset stage resume and clarification tool-wipe

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -9,7 +9,14 @@ import { spawn } from 'node:child_process'
 const RESET = '\x1b[0m'
 const procs = [
   { name: 'client', color: '\x1b[34m', cmd: 'vite', args: ['--port', '3000'] },
-  { name: 'api', color: '\x1b[32m', cmd: 'tsx', args: ['src/server/dev.ts'] },
+  // `watch` so edits to server/lib files auto-reload the API (matches Vite HMR
+  // on the client side); without it the API serves stale code until restarted.
+  {
+    name: 'api',
+    color: '\x1b[32m',
+    cmd: 'tsx',
+    args: ['watch', 'src/server/dev.ts'],
+  },
 ]
 
 const labelWidth = Math.max(...procs.map((p) => p.name.length))

--- a/src/components/design-engine/ActivityFeed.tsx
+++ b/src/components/design-engine/ActivityFeed.tsx
@@ -68,7 +68,8 @@ export function ActivityFeed({
   const showInput =
     onSendMessage &&
     currentStage &&
-    (currentStage === 'requirements_drafting' ||
+    (currentStage === 'toolset_establishment' ||
+      currentStage === 'requirements_drafting' ||
       currentStage === 'requirements_review' ||
       currentStage === 'bom_drafting' ||
       currentStage === 'bom_review') &&

--- a/src/components/design-engine/CollaborativeWorkspace.tsx
+++ b/src/components/design-engine/CollaborativeWorkspace.tsx
@@ -18,6 +18,7 @@ import { AssemblyReviewPanel } from './AssemblyReviewPanel'
 import type {
   DesignArtifacts,
   DesignSessionStage,
+  LlmHistoryEntry,
   MaterializationPreview as PreviewType,
   MaterializationResult as ResultType,
 } from '@/lib/design-engine/types'
@@ -32,6 +33,7 @@ interface CollaborativeWorkspaceProps {
     stage: string
     status: string
     artifacts: DesignArtifacts | null
+    llmHistory?: Array<LlmHistoryEntry> | null
   }
 }
 
@@ -62,12 +64,17 @@ export function CollaborativeWorkspace({
       stream.initializeArtifacts(
         initialSession.artifacts,
         initialSession.stage as DesignSessionStage,
+        initialSession.llmHistory,
       )
     }
   }, [])
 
   const handleStartToolset = useCallback(() => {
     stream.sendAction('start_toolset')
+  }, [stream])
+
+  const handleResumeToolset = useCallback(() => {
+    stream.sendAction('resume')
   }, [stream])
 
   const handleConfirmToolset = useCallback(() => {
@@ -203,6 +210,13 @@ export function CollaborativeWorkspace({
 
   // Determine if we need the start button
   const showStartToolset = stream.currentStage === 'idle' && !stream.isStreaming
+  // Toolset establishment paused mid-run (e.g. after a clarification): offer a
+  // way to continue. Hidden while a clarification is still pending — the prompt
+  // in the feed drives the resume in that case.
+  const showResumeToolset =
+    stream.currentStage === 'toolset_establishment' &&
+    !stream.isStreaming &&
+    !stream.artifacts.pendingClarification
   const showStartRequirements =
     stream.currentStage === 'requirements_drafting' &&
     !stream.isStreaming &&
@@ -343,6 +357,27 @@ export function CollaborativeWorkspace({
 
         {/* Right panel: Activity Feed */}
         <div className="overflow-hidden flex flex-col">
+          {/* Resume controls when toolset establishment paused mid-run */}
+          {showResumeToolset && (
+            <div className="p-4 border-b border-slate-200 dark:border-slate-700 space-y-2">
+              <Button
+                variant="default"
+                onClick={handleResumeToolset}
+                className="w-full gap-2"
+              >
+                <Play className="h-4 w-4" />
+                Continue Toolset Establishment
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={handleStartRequirements}
+                className="w-full text-xs text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+              >
+                Skip toolset — go straight to Requirements
+              </Button>
+            </div>
+          )}
+
           {/* Start button for initial stages */}
           {(showStartToolset ||
             showStartRequirements ||

--- a/src/hooks/useDesignEngineStream.ts
+++ b/src/hooks/useDesignEngineStream.ts
@@ -9,11 +9,55 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type {
   DesignArtifacts,
   DesignSessionStage,
+  LlmHistoryEntry,
   StageEvent,
 } from '@/lib/design-engine/types'
 
 interface UseDesignEngineStreamOptions {
   sessionId: string
+}
+
+/**
+ * Rebuild the activity feed from persisted LLM history so a reloaded session
+ * shows the prior reasoning and tool calls, not just the final artifacts.
+ * Mirrors the capture format in CollaborativeDesignEngine.wrapWithHistoryCapture:
+ * assistant text is stored raw, tool entries as JSON with args (a call) or a
+ * result (a completion).
+ */
+function hydrateEventsFromHistory(
+  history: Array<LlmHistoryEntry>,
+): Array<StageEvent> {
+  const events: Array<StageEvent> = []
+  for (const entry of history) {
+    if (entry.role === 'assistant') {
+      if (entry.content) events.push({ type: 'llm_text', text: entry.content })
+    } else if (entry.role === 'tool') {
+      try {
+        const parsed = JSON.parse(entry.content) as {
+          toolName?: string
+          args?: Record<string, unknown>
+          result?: Record<string, unknown>
+        }
+        if (!parsed.toolName) continue
+        if (parsed.result !== undefined) {
+          events.push({
+            type: 'tool_result',
+            toolName: parsed.toolName,
+            result: parsed.result,
+          })
+        } else {
+          events.push({
+            type: 'tool_call',
+            toolName: parsed.toolName,
+            args: parsed.args ?? {},
+          })
+        }
+      } catch {
+        // Skip unparseable history entries
+      }
+    }
+  }
+  return events
 }
 
 interface StreamState {
@@ -31,6 +75,7 @@ type StreamAction =
   | 'start_cad_generation'
   | 'start_assembly_composition'
   | 'regenerate_part'
+  | 'resume'
   | 'confirm_toolset'
   | 'confirm_requirements'
   | 'confirm_bom'
@@ -328,9 +373,25 @@ export function useDesignEngineStream({
   }, [])
 
   const initializeArtifacts = useCallback(
-    (artifacts: DesignArtifacts, stage: DesignSessionStage) => {
+    (
+      artifacts: DesignArtifacts,
+      stage: DesignSessionStage,
+      llmHistory?: Array<LlmHistoryEntry> | null,
+    ) => {
+      const events = llmHistory ? hydrateEventsFromHistory(llmHistory) : []
+      // Re-surface an unanswered clarification so the prompt reappears on reload.
+      if (artifacts.pendingClarification) {
+        events.push({
+          type: 'clarification_needed',
+          questionId: artifacts.pendingClarification.id,
+          question: artifacts.pendingClarification.question,
+          options: artifacts.pendingClarification.options,
+          multiSelect: artifacts.pendingClarification.multiSelect,
+        })
+      }
       setState((prev) => ({
         ...prev,
+        events,
         artifacts: {
           ...artifacts,
           clarifications: artifacts.clarifications,

--- a/src/lib/design-engine/stages/toolset-establishment.ts
+++ b/src/lib/design-engine/stages/toolset-establishment.ts
@@ -64,7 +64,9 @@ export async function* runToolsetEstablishmentStage(
     } | null
   } = { requested: false, data: null }
 
-  // Create stage tools with callbacks
+  // Create stage tools with callbacks. Seed the builder with the current
+  // toolset so a resumed stage adds to the existing tools instead of wiping
+  // them (each tool mutation emits the full set).
   const { tools } = createToolsetTools(
     session.programId,
     (toolset) => {
@@ -76,6 +78,7 @@ export async function* runToolsetEstablishmentStage(
       clarificationRef.requested = true
       clarificationRef.data = { questionId, question, options, multiSelect }
     },
+    currentToolset,
   )
 
   try {

--- a/src/lib/design-engine/tools/toolset-tools.ts
+++ b/src/lib/design-engine/tools/toolset-tools.ts
@@ -34,10 +34,14 @@ export function createToolsetTools(
     options?: Array<string>,
     multiSelect?: boolean,
   ) => void,
+  initialToolset?: DesignSessionToolset,
 ) {
+  // Seed from any existing toolset so a resumed stage accumulates onto prior
+  // tools/scope instead of replacing them. Every mutation emits the full set,
+  // so an empty seed on resume would wipe tools added before the pause.
   const state: ToolsetBuildState = {
-    scope: 'unconstrained',
-    tools: [],
+    scope: initialToolset?.scope ?? 'unconstrained',
+    tools: initialToolset ? [...initialToolset.tools] : [],
     changeVersion: 0,
   }
 

--- a/src/routes/designs/collaborative/$sessionId.tsx
+++ b/src/routes/designs/collaborative/$sessionId.tsx
@@ -33,6 +33,7 @@ function CollaborativeWorkspacePage() {
         stage: session.stage,
         status: session.status,
         artifacts: session.artifacts,
+        llmHistory: session.llmHistory,
       }}
     />
   )

--- a/src/server/routes/design-engine.ts
+++ b/src/server/routes/design-engine.ts
@@ -59,14 +59,31 @@ function encodeSSE(event: string, data: unknown): string {
   return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
 }
 
-function determineStageForResume(stage: string): 'requirements' | 'bom' | null {
-  if (stage === 'requirements_drafting' || stage === 'idle') {
-    return 'requirements'
+/**
+ * Map a stage that supports a streaming (re)start to the generator that runs it.
+ *
+ * Covers the drafting stages that can pause for a clarification / user guidance
+ * and later resume: toolset establishment, requirements, and BOM. Returns null
+ * for stages with no streaming resume path (reviews, materialization, etc.).
+ *
+ * Each generator re-fetches the session, so any answer/message persisted just
+ * before the call is picked up as context when the stage continues.
+ */
+function draftingStageSource(
+  stage: string,
+  sessionId: string,
+  signal: AbortSignal,
+): AsyncIterable<StageEvent> | null {
+  switch (stage) {
+    case 'toolset_establishment':
+      return designEngine.runToolsetEstablishmentStage(sessionId, signal)
+    case 'requirements_drafting':
+      return designEngine.runRequirementsStage(sessionId, signal)
+    case 'bom_drafting':
+      return designEngine.runBomStage(sessionId, signal)
+    default:
+      return null
   }
-  if (stage === 'bom_drafting') {
-    return 'bom'
-  }
-  return null
 }
 
 function findPendingQuestion(
@@ -447,26 +464,19 @@ app.post(
           await DesignSessionService.updateArtifacts(params.id, artifacts)
         }
 
-        // Determine which stage to restart and fall through to streaming
-        const stageType = determineStageForResume(
-          current?.stage ?? session.stage,
+        // Restart the paused stage as a stream so the LLM continues with the
+        // answer in context. `idle` predates toolset establishment and is kept
+        // mapping to requirements for backwards compatibility.
+        const pausedStage = current?.stage ?? session.stage
+        const resumeStage =
+          pausedStage === 'idle' ? 'requirements_drafting' : pausedStage
+        const eventSource = draftingStageSource(
+          resumeStage,
+          params.id,
+          abortController.signal,
         )
-        if (!stageType) {
+        if (!eventSource) {
           return { acknowledged: true, questionId }
-        }
-
-        // Fall through to streaming — the stage processor will re-fetch the session
-        let eventSource: AsyncIterable<StageEvent>
-        if (stageType === 'requirements') {
-          eventSource = designEngine.runRequirementsStage(
-            params.id,
-            abortController.signal,
-          )
-        } else {
-          eventSource = designEngine.runBomStage(
-            params.id,
-            abortController.signal,
-          )
         }
 
         return streamResponse(eventSource, params.id, request)
@@ -497,24 +507,14 @@ app.post(
           await DesignSessionService.updateArtifacts(params.id, artifacts)
         }
 
-        // If in a drafting stage, restart as streaming
+        // If in a drafting stage, restart as streaming so the guidance is applied
         const currentStage = current?.stage ?? session.stage
-        if (
-          currentStage === 'requirements_drafting' ||
-          currentStage === 'bom_drafting'
-        ) {
-          let eventSource: AsyncIterable<StageEvent>
-          if (currentStage === 'requirements_drafting') {
-            eventSource = designEngine.runRequirementsStage(
-              params.id,
-              abortController.signal,
-            )
-          } else {
-            eventSource = designEngine.runBomStage(
-              params.id,
-              abortController.signal,
-            )
-          }
+        const eventSource = draftingStageSource(
+          currentStage,
+          params.id,
+          abortController.signal,
+        )
+        if (eventSource) {
           return streamResponse(eventSource, params.id, request)
         }
 
@@ -568,20 +568,17 @@ app.post(
         )
       } else {
         // 'resume' — continue whatever stage was in progress
-        const currentStage = session.stage
-        if (currentStage === 'requirements_drafting') {
-          eventSource = designEngine.runRequirementsStage(
-            params.id,
-            abortController.signal,
+        const source = draftingStageSource(
+          session.stage,
+          params.id,
+          abortController.signal,
+        )
+        if (!source) {
+          throw new ValidationError(
+            `Cannot resume from stage: ${session.stage}`,
           )
-        } else if (currentStage === 'bom_drafting') {
-          eventSource = designEngine.runBomStage(
-            params.id,
-            abortController.signal,
-          )
-        } else {
-          throw new ValidationError(`Cannot resume from stage: ${currentStage}`)
         }
+        eventSource = source
       }
 
       return streamResponse(eventSource, params.id, request)


### PR DESCRIPTION
The toolset_establishment stage can pause for a clarification, but none of the resume entry points knew how to restart it, and the toolset builder wiped prior tools whenever the stage resumed.

Server (design-engine.ts):
- Replace determineStageForResume with a draftingStageSource() helper that includes toolset_establishment, and route answer_clarification, send_message, and resume through it. Answering a toolset clarification now streams the continuation instead of silently no-oping or throwing "Cannot resume from stage: toolset_establishment".

Toolset builder (toolset-tools.ts, toolset-establishment.ts):
- Seed createToolsetTools() from the existing toolset so a resumed stage accumulates onto prior tools/scope instead of replacing them. Each tool mutation emits the full set, so an empty seed on resume dropped tools that were added before the pause.

Client (useDesignEngineStream.ts, CollaborativeWorkspace.tsx, ActivityFeed.tsx, $sessionId.tsx):
- Rehydrate the activity feed from persisted llmHistory and re-surface a pending clarification on reload.
- Add a "Continue Toolset Establishment" control plus free-form input when the stage is paused, and wire up the resume action.

Dev (scripts/dev.mjs):
- Run the API with `tsx watch` so server edits auto-reload.