### PR TITLE
Add drag-and-drop URL enrichment for items

### DIFF
--- a/docs/api/openapi.v1.json
+++ b/docs/api/openapi.v1.json
@@ -49503,6 +49503,292 @@
         ]
       }
     },
+    "/api/v1/items/enrich-from-url": {
+      "post": {
+        "operationId": "postApiV1ItemsEnrichFromUrl",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "vendor": "zod"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Server error"
+          }
+        },
+        "summary": "Suggest item fields from a web link",
+        "tags": [
+          "Items"
+        ]
+      }
+    },
     "/api/v1/items/search": {
       "get": {
         "operationId": "getApiV1ItemsSearch",

--- a/src/components/items/UrlDropOverlay.tsx
+++ b/src/components/items/UrlDropOverlay.tsx
@@ -1,0 +1,43 @@
+import { Link2, Loader2 } from 'lucide-react'
+
+interface UrlDropOverlayProps {
+  isDragging: boolean
+  isEnriching: boolean
+}
+
+/**
+ * Full-surface overlay shown while a link is being dragged over a create form
+ * or while the dropped link is being parsed. Rendered inside a `relative`
+ * wrapper; `pointer-events-none` so it never swallows the drop event.
+ */
+export function UrlDropOverlay({
+  isDragging,
+  isEnriching,
+}: UrlDropOverlayProps) {
+  if (!isDragging && !isEnriching) return null
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-sm">
+      <div className="flex flex-col items-center gap-3 rounded-xl border-2 border-dashed border-blue-400 bg-white/95 px-8 py-6 text-center shadow-lg dark:bg-slate-800/95">
+        {isEnriching ? (
+          <>
+            <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
+            <p className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              Reading the link and filling in details…
+            </p>
+          </>
+        ) : (
+          <>
+            <Link2 className="h-8 w-8 text-blue-500" />
+            <p className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              Drop a link to auto-fill this form
+            </p>
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              We’ll use it to populate empty fields
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/items/useUrlDropEnrichment.ts
+++ b/src/components/items/useUrlDropEnrichment.ts
@@ -1,0 +1,142 @@
+import { useCallback, useRef, useState } from 'react'
+import { apiPost } from '@/lib/api/client'
+import { useErrorHandler } from '@/lib/hooks/useErrorHandler'
+
+export interface UrlEnrichmentResult {
+  aiEnabled: boolean
+  link: string
+  fields: Record<string, unknown>
+  attributes: Record<string, string>
+}
+
+interface UseUrlDropEnrichmentOptions {
+  itemType: 'Part' | 'Tool'
+  /** When false, all drop handlers are inert (e.g. edit mode). */
+  enabled: boolean
+  /** Called with the server's suggestions to merge into form state. */
+  onEnriched: (result: UrlEnrichmentResult) => void
+}
+
+interface UseUrlDropEnrichmentResult {
+  isDragging: boolean
+  isEnriching: boolean
+  dropHandlers: {
+    onDragEnter: (e: React.DragEvent) => void
+    onDragOver: (e: React.DragEvent) => void
+    onDragLeave: (e: React.DragEvent) => void
+    onDrop: (e: React.DragEvent) => void
+  }
+}
+
+/** A drag carrying a link/text (not files) can be enriched. */
+function dragHasUrl(e: React.DragEvent): boolean {
+  const types = Array.from(e.dataTransfer.types)
+  return types.includes('text/uri-list') || types.includes('text/plain')
+}
+
+/** Pull a usable URL out of a drop's dataTransfer, if any. */
+function extractUrl(dataTransfer: DataTransfer): string | null {
+  const uriList = dataTransfer.getData('text/uri-list')
+  if (uriList) {
+    const firstUrl = uriList
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line.length > 0 && !line.startsWith('#'))
+    if (firstUrl) return firstUrl
+  }
+  const text = dataTransfer.getData('text/plain').trim()
+  return text.length > 0 ? text : null
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Drag-and-drop a web link onto a create form to auto-fill it. The drop calls
+ * the server enrichment endpoint and hands the result back via `onEnriched`.
+ * File drops are ignored (they bubble to any underlying upload zone).
+ */
+export function useUrlDropEnrichment({
+  itemType,
+  enabled,
+  onEnriched,
+}: UseUrlDropEnrichmentOptions): UseUrlDropEnrichmentResult {
+  const { handleError, showWarning } = useErrorHandler()
+  const [isDragging, setIsDragging] = useState(false)
+  const [isEnriching, setIsEnriching] = useState(false)
+  // Depth counter so entering/leaving child elements doesn't flicker the overlay.
+  const dragDepth = useRef(0)
+
+  const onDragEnter = useCallback(
+    (e: React.DragEvent) => {
+      if (!enabled || !dragHasUrl(e)) return
+      e.preventDefault()
+      dragDepth.current += 1
+      setIsDragging(true)
+    },
+    [enabled],
+  )
+
+  const onDragOver = useCallback(
+    (e: React.DragEvent) => {
+      if (!enabled || !dragHasUrl(e)) return
+      e.preventDefault()
+      e.dataTransfer.dropEffect = 'copy'
+    },
+    [enabled],
+  )
+
+  const onDragLeave = useCallback(
+    (e: React.DragEvent) => {
+      if (!enabled || !dragHasUrl(e)) return
+      dragDepth.current = Math.max(0, dragDepth.current - 1)
+      if (dragDepth.current === 0) setIsDragging(false)
+    },
+    [enabled],
+  )
+
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      if (!enabled || !dragHasUrl(e)) return
+      e.preventDefault()
+      dragDepth.current = 0
+      setIsDragging(false)
+
+      const url = extractUrl(e.dataTransfer)
+      if (!url || !isHttpUrl(url)) {
+        showWarning(
+          'Not a valid link',
+          'Drop a web link (http or https) to auto-fill the form.',
+        )
+        return
+      }
+
+      setIsEnriching(true)
+      void apiPost<{ data: UrlEnrichmentResult }>(
+        '/api/v1/items/enrich-from-url',
+        {
+          url,
+          itemType,
+        },
+      )
+        .then((response) => onEnriched(response.data))
+        .catch((error) =>
+          handleError(error, { title: 'Could not read the link' }),
+        )
+        .finally(() => setIsEnriching(false))
+    },
+    [enabled, itemType, onEnriched, handleError, showWarning],
+  )
+
+  return {
+    isDragging,
+    isEnriching,
+    dropHandlers: { onDragEnter, onDragOver, onDragLeave, onDrop },
+  }
+}

--- a/src/components/parts/PartDetail.tsx
+++ b/src/components/parts/PartDetail.tsx
@@ -24,6 +24,7 @@ import type {
   MaterialPreset,
   StandardView,
 } from '@/components/parts/CADViewerTypes'
+import type { UrlEnrichmentResult } from '@/components/items/useUrlDropEnrichment'
 import { PageContainer } from '@/components/layout'
 import { DigitalThreadNavigator } from '@/components/thread'
 import { PartRelationshipsPanel } from '@/components/items/PartRelationshipsPanel'
@@ -43,6 +44,8 @@ import { CADViewer } from '@/components/parts/CADViewer'
 import { CADViewerToolbar } from '@/components/parts/CADViewerToolbar'
 import { useCADViewerKeyboard } from '@/components/parts/useCADViewerKeyboard'
 import { AttributesEditor } from '@/components/items/AttributesEditor'
+import { UrlDropOverlay } from '@/components/items/UrlDropOverlay'
+import { useUrlDropEnrichment } from '@/components/items/useUrlDropEnrichment'
 import { useVersionContext } from '@/lib/hooks/useVersionContext'
 import { WorkspaceContextBanner } from '@/components/workspaces/WorkspaceContextBanner'
 import {
@@ -200,7 +203,7 @@ export function PartDetail({
   const router = useRouter()
   const navigate = useNavigate()
   const { confirm } = useAlertDialog()
-  const { handleError, showSuccess } = useErrorHandler()
+  const { handleError, showSuccess, showInfo } = useErrorHandler()
 
   // Determine if this is create mode
   const isCreateMode = !initialPart?.id
@@ -216,6 +219,63 @@ export function PartDetail({
   const [attributes, setAttributes] = useState<Record<string, string>>(
     initialPart?.attributes ?? {},
   )
+
+  // Drag-and-drop a web link onto the create form to auto-fill it.
+  const applyEnrichment = useCallback(
+    (result: UrlEnrichmentResult) => {
+      // Always keep the source link as provenance (existing keys win).
+      setAttributes((prev) => {
+        const merged: Record<string, string> = { ...result.attributes, ...prev }
+        if (!merged.link || !merged.link.trim()) merged.link = result.link
+        return merged
+      })
+
+      // Fill only empty or still-default fields; never clobber user input.
+      setPart((prev) => {
+        const defaults = createEmptyPart() as unknown as Record<string, unknown>
+        const prevRecord = prev as unknown as Record<string, unknown>
+        const next: Record<string, unknown> = { ...prevRecord }
+        for (const [key, value] of Object.entries(result.fields)) {
+          const current = prevRecord[key]
+          if (
+            current === undefined ||
+            current === null ||
+            current === '' ||
+            current === defaults[key]
+          ) {
+            next[key] = value
+          }
+        }
+        return next as unknown as Part
+      })
+
+      const fieldCount = Object.keys(result.fields).length
+      const attrCount = Object.keys(result.attributes).length
+      if (!result.aiEnabled) {
+        showInfo(
+          'Link saved',
+          'AI isn’t connected — the link was saved as a custom attribute. Connect AI in settings to auto-fill more.',
+        )
+      } else if (fieldCount === 0 && attrCount === 0) {
+        showInfo(
+          'Link saved',
+          'Couldn’t pull details from that page, but the link was saved.',
+        )
+      } else {
+        showSuccess(
+          'Details added',
+          `Filled ${fieldCount} field${fieldCount === 1 ? '' : 's'} and ${attrCount} attribute${attrCount === 1 ? '' : 's'} from the link.`,
+        )
+      }
+    },
+    [showSuccess, showInfo],
+  )
+
+  const { isDragging, isEnriching, dropHandlers } = useUrlDropEnrichment({
+    itemType: 'Part',
+    enabled: isCreateMode,
+    onEnriched: applyEnrichment,
+  })
 
   // Version context state (only for existing parts)
   const [displayedPart, setDisplayedPart] = useState<Part>(part)
@@ -644,824 +704,848 @@ export function PartDetail({
     : ['details', 'relationships', 'work-instructions', 'history']
 
   return (
-    <PageContainer data-testid="part-form">
-      {/* Header */}
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="flex items-center gap-4">
-          <Link to="/parts">
-            <Button variant="outline" size="icon">
-              <ArrowLeft className="h-4 w-4" />
-            </Button>
-          </Link>
-          {!isCreateMode && part.id && (
-            <PartThumbnail itemId={part.id} size="lg" />
-          )}
-          <div>
-            <div className="flex items-center gap-3">
-              <h1 className="text-4xl font-bold text-slate-900 dark:text-white">
-                {isCreateMode
-                  ? 'Create New Part'
-                  : currentPart.itemNumber || 'New Part'}
-              </h1>
-              {!isCreateMode && isLoadingVersion && (
-                <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
-              )}
-              {!isCreateMode && currentPart.state && (
-                <Badge
-                  className="text-base"
-                  variant={stateVariant(currentPart.state)}
-                >
-                  {currentPart.state}
-                </Badge>
-              )}
-              {!isCreateMode && currentPart.state && (
-                <PhaseBadge itemType="Part" state={currentPart.state} />
-              )}
-              {!isCreateMode &&
-                currentPart.designId &&
-                context.type !== 'main' && (
-                  <Badge variant={getContextBadgeVariant()} className="text-sm">
-                    <GitBranch className="h-3 w-3 mr-1" />
-                    {contextLabel}
+    <div className="relative" {...dropHandlers}>
+      <PageContainer data-testid="part-form">
+        {/* Header */}
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <Link to="/parts">
+              <Button variant="outline" size="icon">
+                <ArrowLeft className="h-4 w-4" />
+              </Button>
+            </Link>
+            {!isCreateMode && part.id && (
+              <PartThumbnail itemId={part.id} size="lg" />
+            )}
+            <div>
+              <div className="flex items-center gap-3">
+                <h1 className="text-4xl font-bold text-slate-900 dark:text-white">
+                  {isCreateMode
+                    ? 'Create New Part'
+                    : currentPart.itemNumber || 'New Part'}
+                </h1>
+                {!isCreateMode && isLoadingVersion && (
+                  <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
+                )}
+                {!isCreateMode && currentPart.state && (
+                  <Badge
+                    className="text-base"
+                    variant={stateVariant(currentPart.state)}
+                  >
+                    {currentPart.state}
                   </Badge>
                 )}
+                {!isCreateMode && currentPart.state && (
+                  <PhaseBadge itemType="Part" state={currentPart.state} />
+                )}
+                {!isCreateMode &&
+                  currentPart.designId &&
+                  context.type !== 'main' && (
+                    <Badge
+                      variant={getContextBadgeVariant()}
+                      className="text-sm"
+                    >
+                      <GitBranch className="h-3 w-3 mr-1" />
+                      {contextLabel}
+                    </Badge>
+                  )}
+              </div>
+              <p className="text-slate-600 dark:text-slate-400 mt-1">
+                {isCreateMode
+                  ? 'Enter the details for the new part'
+                  : `Revision ${currentPart.revision} • ${currentPart.name || 'Unnamed'}`}
+              </p>
             </div>
-            <p className="text-slate-600 dark:text-slate-400 mt-1">
-              {isCreateMode
-                ? 'Enter the details for the new part'
-                : `Revision ${currentPart.revision} • ${currentPart.name || 'Unnamed'}`}
-            </p>
           </div>
-        </div>
 
-        <div className="flex flex-wrap items-center gap-4">
-          <div className="flex gap-2">
-            {isEditing ? (
-              <>
-                <Button
-                  variant="outline"
-                  onClick={handleCancelEdit}
-                  disabled={isSubmitting}
-                >
-                  <X className="h-4 w-4 mr-2" />
-                  Cancel
-                </Button>
-                <Button
-                  onClick={handleSave}
-                  disabled={
-                    isSubmitting ||
-                    (isCreateMode && branchRequired && !selectedBranchId)
-                  }
-                  data-testid="part-submit"
-                >
-                  <Save className="h-4 w-4 mr-2" />
-                  {isSubmitting
-                    ? 'Saving...'
-                    : isCreateMode
-                      ? 'Create Part'
-                      : 'Save Changes'}
-                </Button>
-              </>
-            ) : (
-              <>
-                {!isCreateMode && currentPart.id && (
+          <div className="flex flex-wrap items-center gap-4">
+            <div className="flex gap-2">
+              {isEditing ? (
+                <>
                   <Button
                     variant="outline"
-                    onClick={() => setIsImpactDialogOpen(true)}
+                    onClick={handleCancelEdit}
+                    disabled={isSubmitting}
                   >
-                    <Search className="h-4 w-4 mr-2" />
-                    Impact Analysis
+                    <X className="h-4 w-4 mr-2" />
+                    Cancel
                   </Button>
-                )}
-                {/* Edit button with tooltip when disabled */}
-                {getEditDisabledReason() ? (
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span>
-                          <Button
-                            variant="outline"
-                            onClick={handleEdit}
-                            disabled={!isEditable}
-                          >
-                            {needsCheckout ? (
-                              <>
-                                <GitBranch className="h-4 w-4 mr-2" />
-                                Revise
-                              </>
-                            ) : (
-                              <>
-                                <Edit className="h-4 w-4 mr-2" />
-                                Edit
-                              </>
-                            )}
-                          </Button>
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>{getEditDisabledReason()}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                ) : (
                   <Button
-                    variant="outline"
-                    onClick={handleEdit}
-                    disabled={!isEditable}
+                    onClick={handleSave}
+                    disabled={
+                      isSubmitting ||
+                      (isCreateMode && branchRequired && !selectedBranchId)
+                    }
+                    data-testid="part-submit"
                   >
-                    {needsCheckout ? (
-                      <>
-                        <GitBranch className="h-4 w-4 mr-2" />
-                        Revise
-                      </>
-                    ) : (
-                      <>
-                        <Edit className="h-4 w-4 mr-2" />
-                        Edit
-                      </>
-                    )}
+                    <Save className="h-4 w-4 mr-2" />
+                    {isSubmitting
+                      ? 'Saving...'
+                      : isCreateMode
+                        ? 'Create Part'
+                        : 'Save Changes'}
                   </Button>
-                )}
-                {onDelete && (
-                  <Button
-                    variant="destructive"
-                    onClick={handleDelete}
-                    disabled={!isEditable}
-                  >
-                    <Trash2 className="h-4 w-4 mr-2" />
-                    Delete
-                  </Button>
-                )}
-                {!isCreateMode && currentPart.partType === 'Manufacture' && (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="outline" size="icon">
-                        <MoreVertical className="h-4 w-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem
-                        onClick={() => setIsGenerateCadOpen(true)}
-                      >
-                        <Box className="h-4 w-4 mr-2" />
-                        Generate CAD
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )}
-              </>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {/* Workspace Context Banner */}
-      {!isCreateMode &&
-        isWorkspaceContext &&
-        context.type === 'branch' &&
-        context.branchId && (
-          <WorkspaceContextBanner branchId={context.branchId} />
-        )}
-
-      {/* Tabs */}
-      <Tabs value={activeTab} onValueChange={onTabChange} className="w-full">
-        <TabsList
-          className={`grid w-full ${isCreateMode ? 'grid-cols-2' : 'grid-cols-4'}`}
-        >
-          <TabsTrigger value="details">Details</TabsTrigger>
-          <TabsTrigger value="relationships">Relationships</TabsTrigger>
-          {!isCreateMode && (
-            <TabsTrigger value="work-instructions">
-              Work Instructions
-            </TabsTrigger>
-          )}
-          {!isCreateMode && <TabsTrigger value="history">History</TabsTrigger>}
-        </TabsList>
-
-        {/* Details Tab */}
-        <TabsContent value="details" className="mt-6">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            {/* Main Content - Left 2 columns */}
-            <div className="lg:col-span-2 space-y-6">
-              {/* Overview Card */}
-              <Card>
-                <CardHeader>
-                  <CardTitle>Overview</CardTitle>
-                  <CardDescription>
-                    General information about this part
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <dl className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <ViewEditText
-                      label="Item Number"
-                      value={
-                        isEditing ? part.itemNumber : currentPart.itemNumber
-                      }
-                      onChange={(v) => updateField('itemNumber', v)}
-                      isEditing={isEditing && isCreateMode} // Only editable when creating
-                      placeholder="PART-001"
-                      required
-                      data-testid="part-item-number"
-                    />
-                    <ViewEditText
-                      label="Revision"
-                      value={isEditing ? part.revision : currentPart.revision}
-                      onChange={(v) => updateField('revision', v)}
-                      isEditing={false} // Revision is system-managed
-                    />
-                    <ViewEditText
-                      label="Name"
-                      value={isEditing ? part.name : currentPart.name}
-                      onChange={(v) => updateField('name', v)}
-                      isEditing={isEditing}
-                      placeholder="Part name"
-                      required
-                      data-testid="part-name"
-                    />
-                    <ViewEditBadge
-                      label="State"
-                      value={isEditing ? part.state : currentPart.state}
-                      onChange={(v) => updateField('state', v)}
-                      isEditing={isEditing}
-                      options={STATE_OPTIONS}
-                      variant={stateVariant}
-                      readOnly={!isCreateMode} // State is managed by lifecycle
-                    />
-                    <ViewEditTextarea
-                      label="Description"
-                      value={
-                        isEditing ? part.description : currentPart.description
-                      }
-                      onChange={(v) => updateField('description', v)}
-                      isEditing={isEditing}
-                      placeholder="Enter a description..."
-                      className="md:col-span-2"
-                    />
-                    {/* Design selector (only in create mode or if no design assigned) */}
-                    {(isCreateMode || !currentPart.designId) &&
-                      designs.length > 0 && (
-                        <div className="md:col-span-2 space-y-4">
-                          <div className="flex items-center gap-4">
-                            <ViewEditSelect
-                              label="Design"
-                              value={
-                                isEditing ? part.designId : currentPart.designId
-                              }
-                              onChange={(v) => updateField('designId', v)}
-                              isEditing={isEditing && isCreateMode}
-                              options={designs.map((d) => ({
-                                value: d.id,
-                                label: `${d.code} - ${d.name}`,
-                              }))}
-                              placeholder="Select a design..."
-                              required
-                              data-testid="design-selector"
-                            />
-                            {part.designId &&
-                              !loadingStatus &&
-                              designStatus && (
-                                <DesignPhaseIndicator
-                                  designId={part.designId}
-                                  status={designStatus}
-                                />
+                </>
+              ) : (
+                <>
+                  {!isCreateMode && currentPart.id && (
+                    <Button
+                      variant="outline"
+                      onClick={() => setIsImpactDialogOpen(true)}
+                    >
+                      <Search className="h-4 w-4 mr-2" />
+                      Impact Analysis
+                    </Button>
+                  )}
+                  {/* Edit button with tooltip when disabled */}
+                  {getEditDisabledReason() ? (
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span>
+                            <Button
+                              variant="outline"
+                              onClick={handleEdit}
+                              disabled={!isEditable}
+                            >
+                              {needsCheckout ? (
+                                <>
+                                  <GitBranch className="h-4 w-4 mr-2" />
+                                  Revise
+                                </>
+                              ) : (
+                                <>
+                                  <Edit className="h-4 w-4 mr-2" />
+                                  Edit
+                                </>
                               )}
-                          </div>
-
-                          {/* Branch Selection - Available for new items when design is selected */}
-                          {showBranchSelector && (
-                            <div className="space-y-2">
-                              <label className="text-sm font-medium text-slate-700 dark:text-slate-300">
-                                Target Branch{' '}
-                                {branchRequired && (
-                                  <span className="text-red-500">*</span>
-                                )}
-                              </label>
-                              <BranchSelector
-                                designId={part.designId}
-                                value={selectedBranchId}
-                                onChange={setSelectedBranchId}
-                                showMainOption={!branchRequired}
-                                placeholder={
-                                  branchRequired
-                                    ? 'Select branch...'
-                                    : 'Main branch (default)'
-                                }
-                              />
-                              {branchRequired && (
-                                <div className="flex items-start gap-2 mt-2 p-3 bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300 text-sm rounded-md">
-                                  <Info className="h-4 w-4 mt-0.5 flex-shrink-0" />
-                                  <span>
-                                    This design is under change control. New
-                                    parts must be created on an ECO or workspace
-                                    branch.
-                                  </span>
-                                </div>
-                              )}
-                              {!branchRequired && !selectedBranchId && (
-                                <div className="flex items-start gap-2 mt-2 p-3 bg-slate-50 dark:bg-slate-900 text-slate-600 dark:text-slate-400 text-sm rounded-md">
-                                  <Info className="h-4 w-4 mt-0.5 flex-shrink-0" />
-                                  <span>
-                                    No branch selected - part will be created on
-                                    the main branch. Select a workspace branch
-                                    for private development work.
-                                  </span>
-                                </div>
-                              )}
-                              {branchRequired && !selectedBranchId && (
-                                <p className="text-sm text-red-500">
-                                  Please select a branch to create this part on
-                                </p>
-                              )}
-                            </div>
-                          )}
-                        </div>
+                            </Button>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>{getEditDisabledReason()}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      onClick={handleEdit}
+                      disabled={!isEditable}
+                    >
+                      {needsCheckout ? (
+                        <>
+                          <GitBranch className="h-4 w-4 mr-2" />
+                          Revise
+                        </>
+                      ) : (
+                        <>
+                          <Edit className="h-4 w-4 mr-2" />
+                          Edit
+                        </>
                       )}
-                  </dl>
-                </CardContent>
-              </Card>
+                    </Button>
+                  )}
+                  {onDelete && (
+                    <Button
+                      variant="destructive"
+                      onClick={handleDelete}
+                      disabled={!isEditable}
+                    >
+                      <Trash2 className="h-4 w-4 mr-2" />
+                      Delete
+                    </Button>
+                  )}
+                  {!isCreateMode && currentPart.partType === 'Manufacture' && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="outline" size="icon">
+                          <MoreVertical className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          onClick={() => setIsGenerateCadOpen(true)}
+                        >
+                          <Box className="h-4 w-4 mr-2" />
+                          Generate CAD
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        </div>
 
-              {/* Manufacturing Details Card */}
-              <Card>
-                <CardHeader>
-                  <CardTitle>Manufacturing Details</CardTitle>
-                  <CardDescription>
-                    Production and sourcing information
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <dl className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <ViewEditBadge
-                      label="Type"
-                      value={isEditing ? part.partType : currentPart.partType}
-                      onChange={(v) => updateField('partType', v)}
-                      isEditing={isEditing}
-                      options={PART_TYPE_OPTIONS}
-                      variant={(v) => {
-                        const m: Record<
-                          string,
-                          'default' | 'secondary' | 'success' | 'outline'
-                        > = {
-                          Manufacture: 'default',
-                          Purchase: 'secondary',
-                          Software: 'success',
-                          Phantom: 'outline',
-                        }
-                        return m[v] || 'default'
-                      }}
-                    />
-                    <ViewEditText
-                      label="Material"
-                      value={isEditing ? part.material : currentPart.material}
-                      onChange={(v) => updateField('material', v)}
-                      isEditing={isEditing}
-                      placeholder="e.g., Aluminum 6061"
-                    />
-                    <ViewEditNumber
-                      label="Weight"
-                      value={isEditing ? part.weight : currentPart.weight}
-                      onChange={(v) => updateField('weight', v)}
-                      isEditing={isEditing}
-                      unitOptions={WEIGHT_UNIT_OPTIONS}
-                      unitValue={
-                        isEditing ? part.weightUnit : currentPart.weightUnit
-                      }
-                      onUnitChange={(v) => updateField('weightUnit', v)}
-                      step="0.001"
-                    />
-                    <ViewEditCurrency
-                      label="Cost"
-                      value={isEditing ? part.cost : currentPart.cost}
-                      onChange={(v) => updateField('cost', v)}
-                      isEditing={isEditing}
-                      currency={
-                        isEditing ? part.costCurrency : currentPart.costCurrency
-                      }
-                      currencyOptions={CURRENCY_OPTIONS}
-                      onCurrencyChange={(v) => updateField('costCurrency', v)}
-                    />
-                    <ViewEditNumber
-                      label="Lead Time"
-                      value={
-                        isEditing ? part.leadTimeDays : currentPart.leadTimeDays
-                      }
-                      onChange={(v) =>
-                        updateField('leadTimeDays', v ? parseInt(v) : undefined)
-                      }
-                      isEditing={isEditing}
-                      unit="days"
-                      min={0}
-                    />
-                  </dl>
-                </CardContent>
-              </Card>
+        {/* Workspace Context Banner */}
+        {!isCreateMode &&
+          isWorkspaceContext &&
+          context.type === 'branch' &&
+          context.branchId && (
+            <WorkspaceContextBanner branchId={context.branchId} />
+          )}
 
-              {/* CAD 3D Viewer (only for existing parts with CAD files) */}
-              {!isCreateMode && selectedCADFile && showCADViewer && (
+        {/* Tabs */}
+        <Tabs value={activeTab} onValueChange={onTabChange} className="w-full">
+          <TabsList
+            className={`grid w-full ${isCreateMode ? 'grid-cols-2' : 'grid-cols-4'}`}
+          >
+            <TabsTrigger value="details">Details</TabsTrigger>
+            <TabsTrigger value="relationships">Relationships</TabsTrigger>
+            {!isCreateMode && (
+              <TabsTrigger value="work-instructions">
+                Work Instructions
+              </TabsTrigger>
+            )}
+            {!isCreateMode && (
+              <TabsTrigger value="history">History</TabsTrigger>
+            )}
+          </TabsList>
+
+          {/* Details Tab */}
+          <TabsContent value="details" className="mt-6">
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+              {/* Main Content - Left 2 columns */}
+              <div className="lg:col-span-2 space-y-6">
+                {/* Overview Card */}
                 <Card>
                   <CardHeader>
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <CardTitle>3D CAD Model</CardTitle>
-                        <CardDescription>
-                          Interactive 3D visualization •{' '}
-                          {selectedCADFile.fileName}
-                          {selectedCADFile.source === 'cad_doc' &&
-                            selectedCADFile.sourceItemNumber &&
-                            ` (from ${selectedCADFile.sourceItemNumber})`}
-                        </CardDescription>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        {cadFiles.length > 1 && (
-                          <Select
-                            value={selectedCADFile.id}
-                            onValueChange={(fileId) => {
-                              const file = cadFiles.find((f) => f.id === fileId)
-                              if (file) setSelectedCADFile(file)
-                            }}
-                          >
-                            <SelectTrigger className="w-[220px] h-8 text-xs">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {cadFiles.some((f) => f.source === 'direct') && (
-                                <SelectGroup>
-                                  <SelectLabel>Direct Files</SelectLabel>
-                                  {cadFiles
-                                    .filter((f) => f.source === 'direct')
-                                    .map((f) => (
-                                      <SelectItem key={f.id} value={f.id}>
-                                        {f.fileName}
-                                      </SelectItem>
-                                    ))}
-                                </SelectGroup>
-                              )}
-                              {(() => {
-                                const docGroups = new Map<
-                                  string,
-                                  Array<CADFileEntry>
-                                >()
-                                for (const f of cadFiles.filter(
-                                  (cf) => cf.source === 'cad_doc',
-                                )) {
-                                  const key =
-                                    f.sourceItemNumber ?? f.sourceItemId
-                                  if (!docGroups.has(key))
-                                    docGroups.set(key, [])
-                                  docGroups.get(key)!.push(f)
+                    <CardTitle>Overview</CardTitle>
+                    <CardDescription>
+                      General information about this part
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <dl className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                      <ViewEditText
+                        label="Item Number"
+                        value={
+                          isEditing ? part.itemNumber : currentPart.itemNumber
+                        }
+                        onChange={(v) => updateField('itemNumber', v)}
+                        isEditing={isEditing && isCreateMode} // Only editable when creating
+                        placeholder="PART-001"
+                        required
+                        data-testid="part-item-number"
+                      />
+                      <ViewEditText
+                        label="Revision"
+                        value={isEditing ? part.revision : currentPart.revision}
+                        onChange={(v) => updateField('revision', v)}
+                        isEditing={false} // Revision is system-managed
+                      />
+                      <ViewEditText
+                        label="Name"
+                        value={isEditing ? part.name : currentPart.name}
+                        onChange={(v) => updateField('name', v)}
+                        isEditing={isEditing}
+                        placeholder="Part name"
+                        required
+                        data-testid="part-name"
+                      />
+                      <ViewEditBadge
+                        label="State"
+                        value={isEditing ? part.state : currentPart.state}
+                        onChange={(v) => updateField('state', v)}
+                        isEditing={isEditing}
+                        options={STATE_OPTIONS}
+                        variant={stateVariant}
+                        readOnly={!isCreateMode} // State is managed by lifecycle
+                      />
+                      <ViewEditTextarea
+                        label="Description"
+                        value={
+                          isEditing ? part.description : currentPart.description
+                        }
+                        onChange={(v) => updateField('description', v)}
+                        isEditing={isEditing}
+                        placeholder="Enter a description..."
+                        className="md:col-span-2"
+                      />
+                      {/* Design selector (only in create mode or if no design assigned) */}
+                      {(isCreateMode || !currentPart.designId) &&
+                        designs.length > 0 && (
+                          <div className="md:col-span-2 space-y-4">
+                            <div className="flex items-center gap-4">
+                              <ViewEditSelect
+                                label="Design"
+                                value={
+                                  isEditing
+                                    ? part.designId
+                                    : currentPart.designId
                                 }
-                                return Array.from(docGroups.entries()).map(
-                                  ([label, files]) => (
-                                    <SelectGroup key={label}>
-                                      <SelectLabel>{label}</SelectLabel>
-                                      {files.map((f) => (
+                                onChange={(v) => updateField('designId', v)}
+                                isEditing={isEditing && isCreateMode}
+                                options={designs.map((d) => ({
+                                  value: d.id,
+                                  label: `${d.code} - ${d.name}`,
+                                }))}
+                                placeholder="Select a design..."
+                                required
+                                data-testid="design-selector"
+                              />
+                              {part.designId &&
+                                !loadingStatus &&
+                                designStatus && (
+                                  <DesignPhaseIndicator
+                                    designId={part.designId}
+                                    status={designStatus}
+                                  />
+                                )}
+                            </div>
+
+                            {/* Branch Selection - Available for new items when design is selected */}
+                            {showBranchSelector && (
+                              <div className="space-y-2">
+                                <label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                                  Target Branch{' '}
+                                  {branchRequired && (
+                                    <span className="text-red-500">*</span>
+                                  )}
+                                </label>
+                                <BranchSelector
+                                  designId={part.designId}
+                                  value={selectedBranchId}
+                                  onChange={setSelectedBranchId}
+                                  showMainOption={!branchRequired}
+                                  placeholder={
+                                    branchRequired
+                                      ? 'Select branch...'
+                                      : 'Main branch (default)'
+                                  }
+                                />
+                                {branchRequired && (
+                                  <div className="flex items-start gap-2 mt-2 p-3 bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300 text-sm rounded-md">
+                                    <Info className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                                    <span>
+                                      This design is under change control. New
+                                      parts must be created on an ECO or
+                                      workspace branch.
+                                    </span>
+                                  </div>
+                                )}
+                                {!branchRequired && !selectedBranchId && (
+                                  <div className="flex items-start gap-2 mt-2 p-3 bg-slate-50 dark:bg-slate-900 text-slate-600 dark:text-slate-400 text-sm rounded-md">
+                                    <Info className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                                    <span>
+                                      No branch selected - part will be created
+                                      on the main branch. Select a workspace
+                                      branch for private development work.
+                                    </span>
+                                  </div>
+                                )}
+                                {branchRequired && !selectedBranchId && (
+                                  <p className="text-sm text-red-500">
+                                    Please select a branch to create this part
+                                    on
+                                  </p>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        )}
+                    </dl>
+                  </CardContent>
+                </Card>
+
+                {/* Manufacturing Details Card */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Manufacturing Details</CardTitle>
+                    <CardDescription>
+                      Production and sourcing information
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <dl className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                      <ViewEditBadge
+                        label="Type"
+                        value={isEditing ? part.partType : currentPart.partType}
+                        onChange={(v) => updateField('partType', v)}
+                        isEditing={isEditing}
+                        options={PART_TYPE_OPTIONS}
+                        variant={(v) => {
+                          const m: Record<
+                            string,
+                            'default' | 'secondary' | 'success' | 'outline'
+                          > = {
+                            Manufacture: 'default',
+                            Purchase: 'secondary',
+                            Software: 'success',
+                            Phantom: 'outline',
+                          }
+                          return m[v] || 'default'
+                        }}
+                      />
+                      <ViewEditText
+                        label="Material"
+                        value={isEditing ? part.material : currentPart.material}
+                        onChange={(v) => updateField('material', v)}
+                        isEditing={isEditing}
+                        placeholder="e.g., Aluminum 6061"
+                      />
+                      <ViewEditNumber
+                        label="Weight"
+                        value={isEditing ? part.weight : currentPart.weight}
+                        onChange={(v) => updateField('weight', v)}
+                        isEditing={isEditing}
+                        unitOptions={WEIGHT_UNIT_OPTIONS}
+                        unitValue={
+                          isEditing ? part.weightUnit : currentPart.weightUnit
+                        }
+                        onUnitChange={(v) => updateField('weightUnit', v)}
+                        step="0.001"
+                      />
+                      <ViewEditCurrency
+                        label="Cost"
+                        value={isEditing ? part.cost : currentPart.cost}
+                        onChange={(v) => updateField('cost', v)}
+                        isEditing={isEditing}
+                        currency={
+                          isEditing
+                            ? part.costCurrency
+                            : currentPart.costCurrency
+                        }
+                        currencyOptions={CURRENCY_OPTIONS}
+                        onCurrencyChange={(v) => updateField('costCurrency', v)}
+                      />
+                      <ViewEditNumber
+                        label="Lead Time"
+                        value={
+                          isEditing
+                            ? part.leadTimeDays
+                            : currentPart.leadTimeDays
+                        }
+                        onChange={(v) =>
+                          updateField(
+                            'leadTimeDays',
+                            v ? parseInt(v) : undefined,
+                          )
+                        }
+                        isEditing={isEditing}
+                        unit="days"
+                        min={0}
+                      />
+                    </dl>
+                  </CardContent>
+                </Card>
+
+                {/* CAD 3D Viewer (only for existing parts with CAD files) */}
+                {!isCreateMode && selectedCADFile && showCADViewer && (
+                  <Card>
+                    <CardHeader>
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <CardTitle>3D CAD Model</CardTitle>
+                          <CardDescription>
+                            Interactive 3D visualization •{' '}
+                            {selectedCADFile.fileName}
+                            {selectedCADFile.source === 'cad_doc' &&
+                              selectedCADFile.sourceItemNumber &&
+                              ` (from ${selectedCADFile.sourceItemNumber})`}
+                          </CardDescription>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {cadFiles.length > 1 && (
+                            <Select
+                              value={selectedCADFile.id}
+                              onValueChange={(fileId) => {
+                                const file = cadFiles.find(
+                                  (f) => f.id === fileId,
+                                )
+                                if (file) setSelectedCADFile(file)
+                              }}
+                            >
+                              <SelectTrigger className="w-[220px] h-8 text-xs">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {cadFiles.some(
+                                  (f) => f.source === 'direct',
+                                ) && (
+                                  <SelectGroup>
+                                    <SelectLabel>Direct Files</SelectLabel>
+                                    {cadFiles
+                                      .filter((f) => f.source === 'direct')
+                                      .map((f) => (
                                         <SelectItem key={f.id} value={f.id}>
                                           {f.fileName}
                                         </SelectItem>
                                       ))}
-                                    </SelectGroup>
-                                  ),
-                                )
-                              })()}
-                            </SelectContent>
-                          </Select>
-                        )}
+                                  </SelectGroup>
+                                )}
+                                {(() => {
+                                  const docGroups = new Map<
+                                    string,
+                                    Array<CADFileEntry>
+                                  >()
+                                  for (const f of cadFiles.filter(
+                                    (cf) => cf.source === 'cad_doc',
+                                  )) {
+                                    const key =
+                                      f.sourceItemNumber ?? f.sourceItemId
+                                    if (!docGroups.has(key))
+                                      docGroups.set(key, [])
+                                    docGroups.get(key)!.push(f)
+                                  }
+                                  return Array.from(docGroups.entries()).map(
+                                    ([label, files]) => (
+                                      <SelectGroup key={label}>
+                                        <SelectLabel>{label}</SelectLabel>
+                                        {files.map((f) => (
+                                          <SelectItem key={f.id} value={f.id}>
+                                            {f.fileName}
+                                          </SelectItem>
+                                        ))}
+                                      </SelectGroup>
+                                    ),
+                                  )
+                                })()}
+                              </SelectContent>
+                            </Select>
+                          )}
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setShowCADViewer(false)}
+                            title="Hide 3D viewer"
+                          >
+                            <EyeOff className="h-4 w-4 mr-2" />
+                            Hide Viewer
+                          </Button>
+                        </div>
+                      </div>
+                    </CardHeader>
+                    <CardContent className="p-0">
+                      <div
+                        ref={viewerContainerRef}
+                        className={`relative ${cadFullscreen ? 'h-screen' : 'h-[500px]'}`}
+                        tabIndex={0}
+                      >
+                        <CADViewerToolbar
+                          wireframe={cadWireframe}
+                          showGrid={cadShowGrid}
+                          isFullscreen={cadFullscreen}
+                          backgroundPreset={cadBackground}
+                          materialPreset={cadMaterial}
+                          polygonCount={cadModelStats.polygonCount}
+                          hasEmbeddedColors={
+                            selectedCADFile.hasColors &&
+                            selectedCADFile.fileType === 'glb'
+                          }
+                          onResetView={() => cadViewerRef.current?.resetView()}
+                          onToggleWireframe={() =>
+                            setCADWireframe((prev) => !prev)
+                          }
+                          onToggleGrid={() => setCADShowGrid((prev) => !prev)}
+                          onToggleFullscreen={toggleFullscreen}
+                          onBackgroundChange={setCADBackground}
+                          onMaterialChange={setCADMaterial}
+                          onDownload={handleDownloadCAD}
+                        />
+                        <CADViewer
+                          ref={cadViewerRef}
+                          fileUrl={`/api/v1/files/${selectedCADFile.id}/download`}
+                          fileType={selectedCADFile.fileType}
+                          fileName={selectedCADFile.fileName}
+                          wireframe={cadWireframe}
+                          showGrid={cadShowGrid}
+                          backgroundPreset={cadBackground}
+                          materialPreset={cadMaterial}
+                          hasEmbeddedColors={
+                            selectedCADFile.hasColors &&
+                            selectedCADFile.fileType === 'glb'
+                          }
+                          onLoad={handleCADModelLoad}
+                          onError={(error) =>
+                            handleError(error, {
+                              title: 'Failed to load CAD model',
+                            })
+                          }
+                        />
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
+
+                {/* Show Viewer Button (when hidden) */}
+                {!isCreateMode && cadFiles.length > 0 && !showCADViewer && (
+                  <Card>
+                    <CardContent className="p-6">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <p className="font-medium text-slate-900 dark:text-white">
+                            3D CAD Model Available
+                          </p>
+                          <p className="text-sm text-slate-600 dark:text-slate-400">
+                            {cadFiles.length} viewable CAD{' '}
+                            {cadFiles.length === 1 ? 'file' : 'files'}
+                            {cadFiles.some((f) => f.source === 'cad_doc')
+                              ? ' (includes related documents)'
+                              : ' attached'}
+                          </p>
+                        </div>
                         <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => setShowCADViewer(false)}
-                          title="Hide 3D viewer"
+                          variant="default"
+                          onClick={() => setShowCADViewer(true)}
+                          title="Show 3D viewer"
                         >
-                          <EyeOff className="h-4 w-4 mr-2" />
-                          Hide Viewer
+                          <Eye className="h-4 w-4 mr-2" />
+                          Show 3D Viewer
                         </Button>
                       </div>
-                    </div>
-                  </CardHeader>
-                  <CardContent className="p-0">
-                    <div
-                      ref={viewerContainerRef}
-                      className={`relative ${cadFullscreen ? 'h-screen' : 'h-[500px]'}`}
-                      tabIndex={0}
+                    </CardContent>
+                  </Card>
+                )}
+              </div>
+
+              {/* Sidebar - Right column */}
+              <div className="space-y-6">
+                {/* Custom Attributes */}
+                {isEditing ? (
+                  <Card>
+                    <AttributesEditor
+                      value={attributes}
+                      onChange={setAttributes}
+                      disabled={isSubmitting}
+                      className="border-0 rounded-none"
+                    />
+                  </Card>
+                ) : (
+                  <Card>
+                    <Collapsible
+                      defaultOpen={
+                        Object.keys(currentPart.attributes ?? {}).length > 0
+                      }
                     >
-                      <CADViewerToolbar
-                        wireframe={cadWireframe}
-                        showGrid={cadShowGrid}
-                        isFullscreen={cadFullscreen}
-                        backgroundPreset={cadBackground}
-                        materialPreset={cadMaterial}
-                        polygonCount={cadModelStats.polygonCount}
-                        hasEmbeddedColors={
-                          selectedCADFile.hasColors &&
-                          selectedCADFile.fileType === 'glb'
-                        }
-                        onResetView={() => cadViewerRef.current?.resetView()}
-                        onToggleWireframe={() =>
-                          setCADWireframe((prev) => !prev)
-                        }
-                        onToggleGrid={() => setCADShowGrid((prev) => !prev)}
-                        onToggleFullscreen={toggleFullscreen}
-                        onBackgroundChange={setCADBackground}
-                        onMaterialChange={setCADMaterial}
-                        onDownload={handleDownloadCAD}
-                      />
-                      <CADViewer
-                        ref={cadViewerRef}
-                        fileUrl={`/api/v1/files/${selectedCADFile.id}/download`}
-                        fileType={selectedCADFile.fileType}
-                        fileName={selectedCADFile.fileName}
-                        wireframe={cadWireframe}
-                        showGrid={cadShowGrid}
-                        backgroundPreset={cadBackground}
-                        materialPreset={cadMaterial}
-                        hasEmbeddedColors={
-                          selectedCADFile.hasColors &&
-                          selectedCADFile.fileType === 'glb'
-                        }
-                        onLoad={handleCADModelLoad}
-                        onError={(error) =>
-                          handleError(error, {
-                            title: 'Failed to load CAD model',
-                          })
-                        }
-                      />
-                    </div>
-                  </CardContent>
-                </Card>
-              )}
+                      <CardHeader className="pb-3">
+                        <CollapsibleTrigger className="hover:opacity-70">
+                          <CardTitle>Custom Attributes</CardTitle>
+                        </CollapsibleTrigger>
+                      </CardHeader>
+                      <CollapsibleContent>
+                        <CardContent className="pt-0">
+                          {Object.keys(currentPart.attributes ?? {}).length >
+                          0 ? (
+                            <dl className="space-y-3">
+                              {Object.entries(currentPart.attributes ?? {}).map(
+                                ([key, value]) => (
+                                  <div key={key} className="space-y-1">
+                                    <dt className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                                      {key}
+                                    </dt>
+                                    <dd className="text-sm text-slate-900 dark:text-white bg-slate-100 dark:bg-slate-900 px-3 py-1.5 rounded-md">
+                                      {value || '-'}
+                                    </dd>
+                                  </div>
+                                ),
+                              )}
+                            </dl>
+                          ) : (
+                            <p className="text-sm text-slate-500 dark:text-slate-400">
+                              No custom attributes defined.
+                            </p>
+                          )}
+                        </CardContent>
+                      </CollapsibleContent>
+                    </Collapsible>
+                  </Card>
+                )}
 
-              {/* Show Viewer Button (when hidden) */}
-              {!isCreateMode && cadFiles.length > 0 && !showCADViewer && (
-                <Card>
-                  <CardContent className="p-6">
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="font-medium text-slate-900 dark:text-white">
-                          3D CAD Model Available
-                        </p>
-                        <p className="text-sm text-slate-600 dark:text-slate-400">
-                          {cadFiles.length} viewable CAD{' '}
-                          {cadFiles.length === 1 ? 'file' : 'files'}
-                          {cadFiles.some((f) => f.source === 'cad_doc')
-                            ? ' (includes related documents)'
-                            : ' attached'}
-                        </p>
-                      </div>
-                      <Button
-                        variant="default"
-                        onClick={() => setShowCADViewer(true)}
-                        title="Show 3D viewer"
-                      >
-                        <Eye className="h-4 w-4 mr-2" />
-                        Show 3D Viewer
-                      </Button>
-                    </div>
-                  </CardContent>
-                </Card>
-              )}
-            </div>
+                {/* Files (only for existing parts) */}
+                {!isCreateMode && currentPart.id && (
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>Files</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                      <FileUploadZone
+                        itemId={currentPart.id}
+                        branchId={
+                          context.type === 'branch'
+                            ? context.branchId
+                            : mainBranchId
+                        }
+                        onUploadComplete={() => {
+                          showSuccess(
+                            'File uploaded',
+                            'File has been uploaded successfully',
+                          )
+                          loadCADFiles()
+                          router.invalidate()
+                        }}
+                        onUploadError={(error) =>
+                          handleError(error, { title: 'Upload failed' })
+                        }
+                      />
+                      <FileList
+                        itemId={currentPart.id}
+                        branchId={
+                          context.type === 'branch'
+                            ? context.branchId
+                            : undefined
+                        }
+                        mainBranchId={mainBranchId}
+                        onViewCAD={handleViewCAD}
+                      />
+                    </CardContent>
+                  </Card>
+                )}
 
-            {/* Sidebar - Right column */}
-            <div className="space-y-6">
-              {/* Custom Attributes */}
-              {isEditing ? (
-                <Card>
-                  <AttributesEditor
-                    value={attributes}
-                    onChange={setAttributes}
-                    disabled={isSubmitting}
-                    className="border-0 rounded-none"
-                  />
-                </Card>
-              ) : (
-                <Card>
-                  <Collapsible
-                    defaultOpen={
-                      Object.keys(currentPart.attributes ?? {}).length > 0
-                    }
-                  >
-                    <CardHeader className="pb-3">
+                {/* Metadata */}
+                <Collapsible defaultOpen={false}>
+                  <Card>
+                    <CardHeader>
                       <CollapsibleTrigger className="hover:opacity-70">
-                        <CardTitle>Custom Attributes</CardTitle>
+                        <CardTitle>Metadata</CardTitle>
                       </CollapsibleTrigger>
                     </CardHeader>
                     <CollapsibleContent>
-                      <CardContent className="pt-0">
-                        {Object.keys(currentPart.attributes ?? {}).length >
-                        0 ? (
-                          <dl className="space-y-3">
-                            {Object.entries(
-                              currentPart.attributes ?? {},
-                            ).map(([key, value]) => (
-                              <div key={key} className="space-y-1">
-                                <dt className="text-sm font-medium text-slate-500 dark:text-slate-400">
-                                  {key}
-                                </dt>
-                                <dd className="text-sm text-slate-900 dark:text-white bg-slate-100 dark:bg-slate-900 px-3 py-1.5 rounded-md">
-                                  {value || '-'}
-                                </dd>
-                              </div>
-                            ))}
-                          </dl>
-                        ) : (
-                          <p className="text-sm text-slate-500 dark:text-slate-400">
-                            No custom attributes defined.
-                          </p>
+                      <CardContent className="space-y-3">
+                        <ViewEditStatic
+                          label="Created"
+                          value={
+                            currentPart.createdAt
+                              ? new Date(
+                                  currentPart.createdAt,
+                                ).toLocaleDateString()
+                              : '-'
+                          }
+                        />
+                        <ViewEditStatic
+                          label="Last Modified"
+                          value={
+                            currentPart.modifiedAt
+                              ? new Date(
+                                  currentPart.modifiedAt,
+                                ).toLocaleDateString()
+                              : '-'
+                          }
+                        />
+                        {!isCreateMode && (
+                          <>
+                            <ViewEditStatic
+                              label="Master ID"
+                              value={currentPart.masterId}
+                              mono
+                            />
+                            <ViewEditStatic
+                              label="Part ID"
+                              value={currentPart.id}
+                              mono
+                            />
+                          </>
                         )}
                       </CardContent>
                     </CollapsibleContent>
-                  </Collapsible>
-                </Card>
-              )}
-
-              {/* Files (only for existing parts) */}
-              {!isCreateMode && currentPart.id && (
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Files</CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <FileUploadZone
-                      itemId={currentPart.id}
-                      branchId={
-                        context.type === 'branch'
-                          ? context.branchId
-                          : mainBranchId
-                      }
-                      onUploadComplete={() => {
-                        showSuccess(
-                          'File uploaded',
-                          'File has been uploaded successfully',
-                        )
-                        loadCADFiles()
-                        router.invalidate()
-                      }}
-                      onUploadError={(error) =>
-                        handleError(error, { title: 'Upload failed' })
-                      }
-                    />
-                    <FileList
-                      itemId={currentPart.id}
-                      branchId={
-                        context.type === 'branch' ? context.branchId : undefined
-                      }
-                      mainBranchId={mainBranchId}
-                      onViewCAD={handleViewCAD}
-                    />
-                  </CardContent>
-                </Card>
-              )}
-
-              {/* Metadata */}
-              <Collapsible defaultOpen={false}>
-                <Card>
-                  <CardHeader>
-                    <CollapsibleTrigger className="hover:opacity-70">
-                      <CardTitle>Metadata</CardTitle>
-                    </CollapsibleTrigger>
-                  </CardHeader>
-                  <CollapsibleContent>
-                    <CardContent className="space-y-3">
-                      <ViewEditStatic
-                        label="Created"
-                        value={
-                          currentPart.createdAt
-                            ? new Date(
-                                currentPart.createdAt,
-                              ).toLocaleDateString()
-                            : '-'
-                        }
-                      />
-                      <ViewEditStatic
-                        label="Last Modified"
-                        value={
-                          currentPart.modifiedAt
-                            ? new Date(
-                                currentPart.modifiedAt,
-                              ).toLocaleDateString()
-                            : '-'
-                        }
-                      />
-                      {!isCreateMode && (
-                        <>
-                          <ViewEditStatic
-                            label="Master ID"
-                            value={currentPart.masterId}
-                            mono
-                          />
-                          <ViewEditStatic
-                            label="Part ID"
-                            value={currentPart.id}
-                            mono
-                          />
-                        </>
-                      )}
-                    </CardContent>
-                  </CollapsibleContent>
-                </Card>
-              </Collapsible>
+                  </Card>
+                </Collapsible>
+              </div>
             </div>
-          </div>
-        </TabsContent>
+          </TabsContent>
 
-        {/* Relationships Tab */}
-        <TabsContent value="relationships" className="mt-6 space-y-6">
-          {currentPart.id ? (
-            <>
-              <DigitalThreadNavigator
-                itemId={currentPart.id}
-                itemNumber={currentPart.itemNumber}
-                itemName={currentPart.name}
-                designId={currentPart.designId}
-              />
-              <PartRelationshipsPanel
-                itemId={currentPart.id}
-                itemType="Part"
-                branchId={
-                  context.type === 'branch' ? context.branchId : undefined
+          {/* Relationships Tab */}
+          <TabsContent value="relationships" className="mt-6 space-y-6">
+            {currentPart.id ? (
+              <>
+                <DigitalThreadNavigator
+                  itemId={currentPart.id}
+                  itemNumber={currentPart.itemNumber}
+                  itemName={currentPart.name}
+                  designId={currentPart.designId}
+                />
+                <PartRelationshipsPanel
+                  itemId={currentPart.id}
+                  itemType="Part"
+                  branchId={
+                    context.type === 'branch' ? context.branchId : undefined
+                  }
+                />
+                <RequirementLinkingPanel
+                  itemId={currentPart.id}
+                  designId={currentPart.designId}
+                  readOnly={!isEditable}
+                />
+                <PartValidationPanel
+                  partId={currentPart.id}
+                  designId={currentPart.designId}
+                  isEditable={isEditable}
+                />
+              </>
+            ) : (
+              <Card>
+                <CardContent className="py-12 text-center">
+                  <p className="text-slate-500 dark:text-slate-400">
+                    Save the part first to manage relationships
+                  </p>
+                </CardContent>
+              </Card>
+            )}
+          </TabsContent>
+
+          {/* Work Instructions Tab (only for existing parts) */}
+          {!isCreateMode && currentPart.id && (
+            <TabsContent value="work-instructions" className="mt-6">
+              <WorkInstructionsForPartPanel
+                partId={currentPart.id}
+                onError={(error) =>
+                  handleError(error, {
+                    title: 'Failed to load work instructions',
+                  })
                 }
               />
-              <RequirementLinkingPanel
-                itemId={currentPart.id}
-                designId={currentPart.designId}
-                readOnly={!isEditable}
-              />
-              <PartValidationPanel
-                partId={currentPart.id}
-                designId={currentPart.designId}
-                isEditable={isEditable}
-              />
-            </>
-          ) : (
-            <Card>
-              <CardContent className="py-12 text-center">
-                <p className="text-slate-500 dark:text-slate-400">
-                  Save the part first to manage relationships
-                </p>
-              </CardContent>
-            </Card>
+            </TabsContent>
           )}
-        </TabsContent>
 
-        {/* Work Instructions Tab (only for existing parts) */}
+          {/* History Tab (only for existing parts) */}
+          {!isCreateMode && (
+            <TabsContent value="history" className="mt-6">
+              <ItemHistoryTab
+                itemId={currentPart.id!}
+                designId={currentPart.designId}
+                versionContext={context}
+                onViewHistoricalState={setContext}
+                itemType="Part"
+              />
+            </TabsContent>
+          )}
+        </Tabs>
+
+        {/* Checkout Dialog for released items */}
+        {!isCreateMode && currentPart.id && currentPart.designId && (
+          <CheckoutDialog
+            open={isCheckoutDialogOpen}
+            onOpenChange={setIsCheckoutDialogOpen}
+            itemId={currentPart.id}
+            itemNumber={currentPart.itemNumber ?? ''}
+            designId={currentPart.designId}
+            onCheckoutComplete={handleCheckoutComplete}
+          />
+        )}
+
+        {/* Impact Analysis Dialog */}
         {!isCreateMode && currentPart.id && (
-          <TabsContent value="work-instructions" className="mt-6">
-            <WorkInstructionsForPartPanel
-              partId={currentPart.id}
-              onError={(error) =>
-                handleError(error, {
-                  title: 'Failed to load work instructions',
-                })
-              }
-            />
-          </TabsContent>
+          <ImpactAnalysisDialog
+            open={isImpactDialogOpen}
+            onOpenChange={setIsImpactDialogOpen}
+            itemId={currentPart.id}
+            itemNumber={currentPart.itemNumber ?? ''}
+            itemName={currentPart.name}
+          />
         )}
 
-        {/* History Tab (only for existing parts) */}
-        {!isCreateMode && (
-          <TabsContent value="history" className="mt-6">
-            <ItemHistoryTab
-              itemId={currentPart.id!}
-              designId={currentPart.designId}
-              versionContext={context}
-              onViewHistoricalState={setContext}
-              itemType="Part"
-            />
-          </TabsContent>
+        {/* Generate CAD Dialog */}
+        {!isCreateMode && currentPart.partType === 'Manufacture' && (
+          <GenerateCadDialog
+            open={isGenerateCadOpen}
+            onOpenChange={setIsGenerateCadOpen}
+            part={currentPart}
+          />
         )}
-      </Tabs>
-
-      {/* Checkout Dialog for released items */}
-      {!isCreateMode && currentPart.id && currentPart.designId && (
-        <CheckoutDialog
-          open={isCheckoutDialogOpen}
-          onOpenChange={setIsCheckoutDialogOpen}
-          itemId={currentPart.id}
-          itemNumber={currentPart.itemNumber ?? ''}
-          designId={currentPart.designId}
-          onCheckoutComplete={handleCheckoutComplete}
-        />
-      )}
-
-      {/* Impact Analysis Dialog */}
-      {!isCreateMode && currentPart.id && (
-        <ImpactAnalysisDialog
-          open={isImpactDialogOpen}
-          onOpenChange={setIsImpactDialogOpen}
-          itemId={currentPart.id}
-          itemNumber={currentPart.itemNumber ?? ''}
-          itemName={currentPart.name}
-        />
-      )}
-
-      {/* Generate CAD Dialog */}
-      {!isCreateMode && currentPart.partType === 'Manufacture' && (
-        <GenerateCadDialog
-          open={isGenerateCadOpen}
-          onOpenChange={setIsGenerateCadOpen}
-          part={currentPart}
-        />
-      )}
-    </PageContainer>
+      </PageContainer>
+      <UrlDropOverlay isDragging={isDragging} isEnriching={isEnriching} />
+    </div>
   )
 }

--- a/src/components/tools/ToolDetail.tsx
+++ b/src/components/tools/ToolDetail.tsx
@@ -1,11 +1,16 @@
 import { Link } from '@tanstack/react-router'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { ArrowLeft, Edit, Save, Trash2, X } from 'lucide-react'
 import { CapabilitiesEditor } from './CapabilitiesEditor'
 import type { KnownToolSubtype, Tool } from '@/lib/items/types/tool'
 import type { SearchableSelectOption } from '@/components/ui/SearchableSelect'
+import type { UrlEnrichmentResult } from '@/components/items/useUrlDropEnrichment'
 import { TOOL_SUBTYPES, getSubtypeGroup } from '@/lib/items/types/tool'
 import { PageContainer } from '@/components/layout'
+import { AttributesEditor } from '@/components/items/AttributesEditor'
+import { UrlDropOverlay } from '@/components/items/UrlDropOverlay'
+import { useUrlDropEnrichment } from '@/components/items/useUrlDropEnrichment'
+import { useErrorHandler } from '@/lib/hooks/useErrorHandler'
 import { ItemHistoryTab } from '@/components/items/ItemHistoryTab'
 import {
   Badge,
@@ -131,11 +136,17 @@ export function ToolDetail({
   const [capabilities, setCapabilities] = useState<Record<string, unknown>>(
     initialTool?.capabilities ?? {},
   )
+  const [attributes, setAttributes] = useState<Record<string, string>>(
+    initialTool?.attributes ?? {},
+  )
+
+  const { showSuccess, showInfo } = useErrorHandler()
 
   useEffect(() => {
     if (initialTool) {
       setTool(initialTool)
       setCapabilities(initialTool.capabilities ?? {})
+      setAttributes(initialTool.attributes ?? {})
     }
   }, [initialTool])
 
@@ -145,6 +156,63 @@ export function ToolDetail({
     setTool((prev) => ({ ...prev, [field]: value }))
   }
 
+  // Drag-and-drop a web link onto the create form to auto-fill it.
+  const applyEnrichment = useCallback(
+    (result: UrlEnrichmentResult) => {
+      // Always keep the source link as provenance (existing keys win).
+      setAttributes((prev) => {
+        const merged: Record<string, string> = { ...result.attributes, ...prev }
+        if (!merged.link || !merged.link.trim()) merged.link = result.link
+        return merged
+      })
+
+      // Fill only empty or still-default fields; never clobber user input.
+      setTool((prev) => {
+        const defaults = createEmptyTool() as unknown as Record<string, unknown>
+        const prevRecord = prev as unknown as Record<string, unknown>
+        const next: Record<string, unknown> = { ...prevRecord }
+        for (const [key, value] of Object.entries(result.fields)) {
+          const current = prevRecord[key]
+          if (
+            current === undefined ||
+            current === null ||
+            current === '' ||
+            current === defaults[key]
+          ) {
+            next[key] = value
+          }
+        }
+        return next as unknown as Tool
+      })
+
+      const fieldCount = Object.keys(result.fields).length
+      const attrCount = Object.keys(result.attributes).length
+      if (!result.aiEnabled) {
+        showInfo(
+          'Link saved',
+          'AI isn’t connected — the link was saved as a custom attribute. Connect AI in settings to auto-fill more.',
+        )
+      } else if (fieldCount === 0 && attrCount === 0) {
+        showInfo(
+          'Link saved',
+          'Couldn’t pull details from that page, but the link was saved.',
+        )
+      } else {
+        showSuccess(
+          'Details added',
+          `Filled ${fieldCount} field${fieldCount === 1 ? '' : 's'} and ${attrCount} attribute${attrCount === 1 ? '' : 's'} from the link.`,
+        )
+      }
+    },
+    [showSuccess, showInfo],
+  )
+
+  const { isDragging, isEnriching, dropHandlers } = useUrlDropEnrichment({
+    itemType: 'Tool',
+    enabled: isCreateMode,
+    onEnriched: applyEnrichment,
+  })
+
   const handleEdit = () => {
     setIsEditing(true)
   }
@@ -152,6 +220,7 @@ export function ToolDetail({
   const handleSave = async () => {
     const toolToSave = {
       ...tool,
+      attributes,
       capabilities:
         Object.keys(capabilities).length > 0 ? capabilities : undefined,
     }
@@ -165,6 +234,7 @@ export function ToolDetail({
     } else {
       setTool(initialTool)
       setCapabilities(initialTool.capabilities ?? {})
+      setAttributes(initialTool.attributes ?? {})
       setIsEditing(false)
     }
   }
@@ -205,304 +275,364 @@ export function ToolDetail({
     }))
 
   return (
-    <PageContainer>
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="flex items-center gap-4">
-          <Link to="/tools">
-            <Button variant="outline" size="icon">
-              <ArrowLeft className="h-4 w-4" />
-            </Button>
-          </Link>
-          <div>
-            <h1 className="text-4xl font-bold text-slate-900 dark:text-white">
-              {isCreateMode ? 'Create New Tool' : currentTool.itemNumber}
-            </h1>
-            <p className="text-slate-600 dark:text-slate-400 mt-1">
-              {isCreateMode
-                ? 'Enter the details for the new tool'
-                : currentTool.name || 'Unnamed'}
-            </p>
+    <div className="relative" {...dropHandlers}>
+      <PageContainer>
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <Link to="/tools">
+              <Button variant="outline" size="icon">
+                <ArrowLeft className="h-4 w-4" />
+              </Button>
+            </Link>
+            <div>
+              <h1 className="text-4xl font-bold text-slate-900 dark:text-white">
+                {isCreateMode ? 'Create New Tool' : currentTool.itemNumber}
+              </h1>
+              <p className="text-slate-600 dark:text-slate-400 mt-1">
+                {isCreateMode
+                  ? 'Enter the details for the new tool'
+                  : currentTool.name || 'Unnamed'}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            {isEditing ? (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={handleCancelEdit}
+                  disabled={isSubmitting}
+                >
+                  <X className="h-4 w-4 mr-2" />
+                  Cancel
+                </Button>
+                <Button onClick={handleSave} disabled={isSubmitting}>
+                  <Save className="h-4 w-4 mr-2" />
+                  {isSubmitting
+                    ? 'Saving...'
+                    : isCreateMode
+                      ? 'Create Tool'
+                      : 'Save Changes'}
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button variant="outline" onClick={handleEdit}>
+                  <Edit className="h-4 w-4 mr-2" />
+                  Edit
+                </Button>
+                {onDelete && (
+                  <Button variant="destructive" onClick={handleDelete}>
+                    <Trash2 className="h-4 w-4 mr-2" />
+                    Delete
+                  </Button>
+                )}
+              </>
+            )}
           </div>
         </div>
 
-        <div className="flex gap-2">
-          {isEditing ? (
-            <>
-              <Button
-                variant="outline"
-                onClick={handleCancelEdit}
-                disabled={isSubmitting}
-              >
-                <X className="h-4 w-4 mr-2" />
-                Cancel
-              </Button>
-              <Button onClick={handleSave} disabled={isSubmitting}>
-                <Save className="h-4 w-4 mr-2" />
-                {isSubmitting
-                  ? 'Saving...'
-                  : isCreateMode
-                    ? 'Create Tool'
-                    : 'Save Changes'}
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button variant="outline" onClick={handleEdit}>
-                <Edit className="h-4 w-4 mr-2" />
-                Edit
-              </Button>
-              {onDelete && (
-                <Button variant="destructive" onClick={handleDelete}>
-                  <Trash2 className="h-4 w-4 mr-2" />
-                  Delete
-                </Button>
-              )}
-            </>
-          )}
-        </div>
-      </div>
-
-      {!isCreateMode && (
-        <div className="flex gap-2">
-          <Badge
-            variant={stateVariant(currentTool.state ?? 'Draft')}
-            className="text-sm"
-          >
-            {currentTool.state ?? 'Draft'}
-          </Badge>
-          {currentTool.toolStatus && (
+        {!isCreateMode && (
+          <div className="flex gap-2">
             <Badge
-              variant={statusVariant(currentTool.toolStatus)}
+              variant={stateVariant(currentTool.state ?? 'Draft')}
               className="text-sm"
             >
-              {currentTool.toolStatus}
+              {currentTool.state ?? 'Draft'}
             </Badge>
-          )}
-        </div>
-      )}
+            {currentTool.toolStatus && (
+              <Badge
+                variant={statusVariant(currentTool.toolStatus)}
+                className="text-sm"
+              >
+                {currentTool.toolStatus}
+              </Badge>
+            )}
+          </div>
+        )}
 
-      <Tabs value={activeTab} onValueChange={onTabChange} className="w-full">
-        <TabsList className="grid w-full grid-cols-2">
-          <TabsTrigger value="details">Details</TabsTrigger>
-          <TabsTrigger value="history">History</TabsTrigger>
-        </TabsList>
+        <Tabs value={activeTab} onValueChange={onTabChange} className="w-full">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="details">Details</TabsTrigger>
+            <TabsTrigger value="history">History</TabsTrigger>
+          </TabsList>
 
-        <TabsContent value="details" className="mt-6">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <div className="lg:col-span-2 space-y-6">
-              {/* Overview Card */}
-              <Card>
-                <CardHeader>
-                  <CardTitle>Overview</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <dl className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <ViewEditText
-                      label="Item Number"
-                      value={
-                        isEditing ? tool.itemNumber : currentTool.itemNumber
-                      }
-                      onChange={(v) => updateField('itemNumber', v)}
-                      isEditing={isEditing && isCreateMode}
-                      placeholder="Auto-assigned"
-                    />
-                    <ViewEditText
-                      label="Name"
-                      value={isEditing ? tool.name : currentTool.name}
-                      onChange={(v) => updateField('name', v)}
-                      isEditing={isEditing}
-                      placeholder="e.g., Prusa MK4S"
-                      required
-                    />
-                  </dl>
-                </CardContent>
-              </Card>
-
-              {/* Tool Information Card */}
-              <Card>
-                <CardHeader>
-                  <CardTitle>Tool Information</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <dl className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <ViewEditSelect
-                      label="Tool Type"
-                      value={isEditing ? tool.toolType : currentTool.toolType}
-                      onChange={(v) => updateField('toolType', v)}
-                      isEditing={isEditing}
-                      options={TOOL_TYPE_OPTIONS}
-                    />
-                    {isEditing ? (
-                      <div>
-                        <dt className="text-sm font-medium text-slate-500 dark:text-slate-400 mb-1">
-                          Subtype
-                        </dt>
-                        <dd>
-                          <SearchableSelect
-                            value={tool.toolSubtype || ''}
-                            onValueChange={(v) => updateField('toolSubtype', v)}
-                            options={[
-                              ...subtypeOptions,
-                              { value: 'other', label: 'Other' },
-                            ]}
-                            placeholder="Search subtypes..."
-                            searchPlaceholder="Type to filter..."
-                          />
-                        </dd>
-                      </div>
-                    ) : (
-                      <ViewEditStatic
-                        label="Subtype"
-                        value={subtypeLabel(currentTool.toolSubtype)}
-                      />
-                    )}
-                    <ViewEditText
-                      label="Manufacturer"
-                      value={
-                        isEditing ? tool.manufacturer : currentTool.manufacturer
-                      }
-                      onChange={(v) => updateField('manufacturer', v)}
-                      isEditing={isEditing}
-                      placeholder="e.g., Prusa Research"
-                    />
-                    <ViewEditText
-                      label="Model"
-                      value={isEditing ? tool.model : currentTool.model}
-                      onChange={(v) => updateField('model', v)}
-                      isEditing={isEditing}
-                      placeholder="e.g., MK4S"
-                    />
-                  </dl>
-                </CardContent>
-              </Card>
-
-              {/* Capabilities Card */}
-              {(isEditing ||
-                (currentTool.capabilities &&
-                  Object.keys(currentTool.capabilities).length > 0)) && (
+          <TabsContent value="details" className="mt-6">
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+              <div className="lg:col-span-2 space-y-6">
+                {/* Overview Card */}
                 <Card>
                   <CardHeader>
-                    <CardTitle>Capabilities</CardTitle>
+                    <CardTitle>Overview</CardTitle>
                   </CardHeader>
                   <CardContent>
-                    {isEditing ? (
-                      <CapabilitiesEditor
-                        subtype={tool.toolSubtype || ''}
-                        capabilities={capabilities}
-                        onChange={setCapabilities}
+                    <dl className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                      <ViewEditText
+                        label="Item Number"
+                        value={
+                          isEditing ? tool.itemNumber : currentTool.itemNumber
+                        }
+                        onChange={(v) => updateField('itemNumber', v)}
+                        isEditing={isEditing && isCreateMode}
+                        placeholder="Auto-assigned"
                       />
-                    ) : (
-                      <pre className="text-sm font-mono bg-slate-100 dark:bg-slate-800 p-4 rounded-md overflow-x-auto">
-                        {JSON.stringify(currentTool.capabilities, null, 2)}
-                      </pre>
-                    )}
+                      <ViewEditText
+                        label="Name"
+                        value={isEditing ? tool.name : currentTool.name}
+                        onChange={(v) => updateField('name', v)}
+                        isEditing={isEditing}
+                        placeholder="e.g., Prusa MK4S"
+                        required
+                      />
+                    </dl>
                   </CardContent>
                 </Card>
-              )}
-            </div>
 
-            {/* Right sidebar */}
-            <div className="space-y-6">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Status & Location</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <ViewEditSelect
-                    label="State"
-                    value={isEditing ? tool.state : currentTool.state}
-                    onChange={(v) => updateField('state', v)}
-                    isEditing={isEditing}
-                    options={STATE_OPTIONS}
-                  />
-                  <ViewEditSelect
-                    label="Tool Status"
-                    value={isEditing ? tool.toolStatus : currentTool.toolStatus}
-                    onChange={(v) => updateField('toolStatus', v)}
-                    isEditing={isEditing}
-                    options={TOOL_STATUS_OPTIONS}
-                  />
-                  <ViewEditText
-                    label="Location"
-                    value={isEditing ? tool.location : currentTool.location}
-                    onChange={(v) => updateField('location', v)}
-                    isEditing={isEditing}
-                    placeholder="e.g., Workshop bench 3"
-                  />
-                </CardContent>
-              </Card>
-
-              {/* Notes */}
-              <Card>
-                <CardHeader>
-                  <CardTitle>Notes</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ViewEditTextarea
-                    label=""
-                    value={isEditing ? tool.notes : currentTool.notes}
-                    onChange={(v) => updateField('notes', v)}
-                    isEditing={isEditing}
-                    placeholder="Free-form notes about this tool..."
-                  />
-                </CardContent>
-              </Card>
-
-              <Collapsible defaultOpen={false}>
+                {/* Tool Information Card */}
                 <Card>
                   <CardHeader>
-                    <CollapsibleTrigger className="hover:opacity-70">
-                      <CardTitle>Metadata</CardTitle>
-                    </CollapsibleTrigger>
+                    <CardTitle>Tool Information</CardTitle>
                   </CardHeader>
-                  <CollapsibleContent>
-                    <CardContent className="space-y-3">
-                      <ViewEditStatic
-                        label="Revision"
-                        value={currentTool.revision}
+                  <CardContent>
+                    <dl className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                      <ViewEditSelect
+                        label="Tool Type"
+                        value={isEditing ? tool.toolType : currentTool.toolType}
+                        onChange={(v) => updateField('toolType', v)}
+                        isEditing={isEditing}
+                        options={TOOL_TYPE_OPTIONS}
                       />
-                      <ViewEditStatic
-                        label="Created"
-                        value={formatDate(currentTool.createdAt)}
-                      />
-                      <ViewEditStatic
-                        label="Last Modified"
-                        value={formatDate(currentTool.modifiedAt)}
-                      />
-                      {!isCreateMode && (
+                      {isEditing ? (
+                        <div>
+                          <dt className="text-sm font-medium text-slate-500 dark:text-slate-400 mb-1">
+                            Subtype
+                          </dt>
+                          <dd>
+                            <SearchableSelect
+                              value={tool.toolSubtype || ''}
+                              onValueChange={(v) =>
+                                updateField('toolSubtype', v)
+                              }
+                              options={[
+                                ...subtypeOptions,
+                                { value: 'other', label: 'Other' },
+                              ]}
+                              placeholder="Search subtypes..."
+                              searchPlaceholder="Type to filter..."
+                            />
+                          </dd>
+                        </div>
+                      ) : (
                         <ViewEditStatic
-                          label="Tool ID"
-                          value={currentTool.id}
-                          mono
+                          label="Subtype"
+                          value={subtypeLabel(currentTool.toolSubtype)}
                         />
                       )}
-                    </CardContent>
-                  </CollapsibleContent>
+                      <ViewEditText
+                        label="Manufacturer"
+                        value={
+                          isEditing
+                            ? tool.manufacturer
+                            : currentTool.manufacturer
+                        }
+                        onChange={(v) => updateField('manufacturer', v)}
+                        isEditing={isEditing}
+                        placeholder="e.g., Prusa Research"
+                      />
+                      <ViewEditText
+                        label="Model"
+                        value={isEditing ? tool.model : currentTool.model}
+                        onChange={(v) => updateField('model', v)}
+                        isEditing={isEditing}
+                        placeholder="e.g., MK4S"
+                      />
+                    </dl>
+                  </CardContent>
                 </Card>
-              </Collapsible>
-            </div>
-          </div>
-        </TabsContent>
 
-        <TabsContent value="history" className="mt-6">
-          {currentTool.id ? (
-            <ItemHistoryTab
-              itemId={currentTool.id}
-              designId={currentTool.designId ?? null}
-              versionContext={{ type: 'main' }}
-              onViewHistoricalState={() => {}}
-            />
-          ) : (
-            <Card>
-              <CardContent className="py-12 text-center">
-                <p className="text-slate-500">
-                  Save the tool first to view history
-                </p>
-              </CardContent>
-            </Card>
-          )}
-        </TabsContent>
-      </Tabs>
-    </PageContainer>
+                {/* Capabilities Card */}
+                {(isEditing ||
+                  (currentTool.capabilities &&
+                    Object.keys(currentTool.capabilities).length > 0)) && (
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>Capabilities</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      {isEditing ? (
+                        <CapabilitiesEditor
+                          subtype={tool.toolSubtype || ''}
+                          capabilities={capabilities}
+                          onChange={setCapabilities}
+                        />
+                      ) : (
+                        <pre className="text-sm font-mono bg-slate-100 dark:bg-slate-800 p-4 rounded-md overflow-x-auto">
+                          {JSON.stringify(currentTool.capabilities, null, 2)}
+                        </pre>
+                      )}
+                    </CardContent>
+                  </Card>
+                )}
+              </div>
+
+              {/* Right sidebar */}
+              <div className="space-y-6">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Status & Location</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <ViewEditSelect
+                      label="State"
+                      value={isEditing ? tool.state : currentTool.state}
+                      onChange={(v) => updateField('state', v)}
+                      isEditing={isEditing}
+                      options={STATE_OPTIONS}
+                    />
+                    <ViewEditSelect
+                      label="Tool Status"
+                      value={
+                        isEditing ? tool.toolStatus : currentTool.toolStatus
+                      }
+                      onChange={(v) => updateField('toolStatus', v)}
+                      isEditing={isEditing}
+                      options={TOOL_STATUS_OPTIONS}
+                    />
+                    <ViewEditText
+                      label="Location"
+                      value={isEditing ? tool.location : currentTool.location}
+                      onChange={(v) => updateField('location', v)}
+                      isEditing={isEditing}
+                      placeholder="e.g., Workshop bench 3"
+                    />
+                  </CardContent>
+                </Card>
+
+                {/* Notes */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Notes</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <ViewEditTextarea
+                      label=""
+                      value={isEditing ? tool.notes : currentTool.notes}
+                      onChange={(v) => updateField('notes', v)}
+                      isEditing={isEditing}
+                      placeholder="Free-form notes about this tool..."
+                    />
+                  </CardContent>
+                </Card>
+
+                {/* Custom Attributes */}
+                {isEditing ? (
+                  <Card>
+                    <AttributesEditor
+                      value={attributes}
+                      onChange={setAttributes}
+                      disabled={isSubmitting}
+                      className="border-0 rounded-none"
+                    />
+                  </Card>
+                ) : (
+                  <Card>
+                    <Collapsible
+                      defaultOpen={
+                        Object.keys(currentTool.attributes ?? {}).length > 0
+                      }
+                    >
+                      <CardHeader className="pb-3">
+                        <CollapsibleTrigger className="hover:opacity-70">
+                          <CardTitle>Custom Attributes</CardTitle>
+                        </CollapsibleTrigger>
+                      </CardHeader>
+                      <CollapsibleContent>
+                        <CardContent className="pt-0">
+                          {Object.keys(currentTool.attributes ?? {}).length >
+                          0 ? (
+                            <dl className="space-y-3">
+                              {Object.entries(currentTool.attributes ?? {}).map(
+                                ([key, value]) => (
+                                  <div key={key} className="space-y-1">
+                                    <dt className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                                      {key}
+                                    </dt>
+                                    <dd className="text-sm text-slate-900 dark:text-white bg-slate-100 dark:bg-slate-900 px-3 py-1.5 rounded-md">
+                                      {value || '-'}
+                                    </dd>
+                                  </div>
+                                ),
+                              )}
+                            </dl>
+                          ) : (
+                            <p className="text-sm text-slate-500 dark:text-slate-400">
+                              No custom attributes defined.
+                            </p>
+                          )}
+                        </CardContent>
+                      </CollapsibleContent>
+                    </Collapsible>
+                  </Card>
+                )}
+
+                <Collapsible defaultOpen={false}>
+                  <Card>
+                    <CardHeader>
+                      <CollapsibleTrigger className="hover:opacity-70">
+                        <CardTitle>Metadata</CardTitle>
+                      </CollapsibleTrigger>
+                    </CardHeader>
+                    <CollapsibleContent>
+                      <CardContent className="space-y-3">
+                        <ViewEditStatic
+                          label="Revision"
+                          value={currentTool.revision}
+                        />
+                        <ViewEditStatic
+                          label="Created"
+                          value={formatDate(currentTool.createdAt)}
+                        />
+                        <ViewEditStatic
+                          label="Last Modified"
+                          value={formatDate(currentTool.modifiedAt)}
+                        />
+                        {!isCreateMode && (
+                          <ViewEditStatic
+                            label="Tool ID"
+                            value={currentTool.id}
+                            mono
+                          />
+                        )}
+                      </CardContent>
+                    </CollapsibleContent>
+                  </Card>
+                </Collapsible>
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="history" className="mt-6">
+            {currentTool.id ? (
+              <ItemHistoryTab
+                itemId={currentTool.id}
+                designId={currentTool.designId ?? null}
+                versionContext={{ type: 'main' }}
+                onViewHistoricalState={() => {}}
+              />
+            ) : (
+              <Card>
+                <CardContent className="py-12 text-center">
+                  <p className="text-slate-500">
+                    Save the tool first to view history
+                  </p>
+                </CardContent>
+              </Card>
+            )}
+          </TabsContent>
+        </Tabs>
+      </PageContainer>
+      <UrlDropOverlay isDragging={isDragging} isEnriching={isEnriching} />
+    </div>
   )
 }

--- a/src/components/tools/ToolForm.tsx
+++ b/src/components/tools/ToolForm.tsx
@@ -7,6 +7,7 @@ import {
   getSubtypeGroup,
   toolSchema,
 } from '@/lib/items/types/tool'
+import { AttributesEditor } from '@/components/items/AttributesEditor'
 import { zodValidator } from '@/lib/form-validation'
 import {
   Button,
@@ -50,6 +51,9 @@ export function ToolForm({
   const [capabilities, setCapabilities] = useState<Record<string, unknown>>(
     tool?.capabilities ?? {},
   )
+  const [attributes, setAttributes] = useState<Record<string, string>>(
+    tool?.attributes ?? {},
+  )
 
   const form = useForm({
     defaultValues: {
@@ -78,6 +82,7 @@ export function ToolForm({
       const submissionData = {
         ...value,
         revision: value.revision.trim() || 'A',
+        attributes,
         capabilities:
           Object.keys(capabilities).length > 0 ? capabilities : undefined,
       } as Tool
@@ -278,6 +283,9 @@ export function ToolForm({
           </FormField>
         )}
       </form.Field>
+
+      {/* Custom Attributes */}
+      <AttributesEditor value={attributes} onChange={setAttributes} />
 
       {/* Actions */}
       <div className="flex justify-end gap-2 pt-4">

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -96,6 +96,10 @@ export const ROLE_DEFINITIONS: Record<RoleName, RoleDefinition> = {
         actions: ['create', 'read', 'update', 'delete', 'manage'],
       },
       {
+        resource: 'tools',
+        actions: ['create', 'read', 'update', 'delete', 'manage'],
+      },
+      {
         resource: 'work_instructions',
         actions: ['create', 'read', 'update', 'delete', 'manage'],
       },
@@ -152,6 +156,7 @@ export const ROLE_DEFINITIONS: Record<RoleName, RoleDefinition> = {
         actions: ['create', 'read', 'update', 'delete', 'approve'],
       },
       { resource: 'tasks', actions: ['create', 'read', 'update', 'delete'] },
+      { resource: 'tools', actions: ['create', 'read', 'update', 'delete'] },
       {
         resource: 'work_instructions',
         actions: ['create', 'read', 'update', 'delete'],

--- a/src/lib/items/enrichment/enrich-from-url.ts
+++ b/src/lib/items/enrichment/enrich-from-url.ts
@@ -1,0 +1,264 @@
+/**
+ * Link-based item enrichment.
+ *
+ * Given a dropped URL and an item type, this either:
+ *  - returns just the link (when no AI provider is connected), or
+ *  - fetches the linked page, asks the connected AI to extract structured
+ *    field values + custom attributes, validates them, and returns suggestions.
+ *
+ * The client merges the suggestions into empty / still-default form fields and
+ * always stores the source URL as a `link` custom attribute.
+ *
+ * Modeled on `src/lib/cad-generation/assessment.ts` (prompt -> JSON -> parse).
+ */
+
+import { chat } from '@tanstack/ai'
+import { z } from 'zod'
+import { assertSafeUrl, fetchPageText } from './html-to-text'
+import type { FetchedPage } from './html-to-text'
+import { getAdapter, isAIEnabled, loadProviderConfig } from '@/lib/ai/adapters'
+import { ValidationError } from '@/lib/errors'
+
+export type EnrichableItemType = 'Part' | 'Tool'
+
+export interface ItemEnrichmentResult {
+  aiEnabled: boolean
+  /** The source URL, always returned so the caller can save it as provenance. */
+  link: string
+  /** Validated field suggestions keyed by form field name. */
+  fields: Record<string, unknown>
+  /** Extra metadata suggestions as string key/value pairs. */
+  attributes: Record<string, string>
+}
+
+/** Coerce scalar values to a trimmed string (AI may emit numbers for text fields). */
+const scalarString = z.coerce.string().transform((value) => value.trim())
+
+/** Per-field schemas matching the Part form's field types (weight/cost are strings). */
+const partFieldSchemas = {
+  name: z.string().min(1).max(200),
+  description: scalarString.pipe(z.string().max(5000)),
+  partType: z.enum(['Manufacture', 'Purchase', 'Software', 'Phantom']),
+  material: scalarString.pipe(z.string().max(100)),
+  weight: scalarString.pipe(z.string().max(50)),
+  weightUnit: scalarString.pipe(z.string().max(10)),
+  cost: scalarString.pipe(z.string().max(50)),
+  costCurrency: scalarString.pipe(z.string().length(3)),
+  leadTimeDays: z.coerce.number().int().min(0),
+} satisfies Record<string, z.ZodTypeAny>
+
+/** Per-field schemas matching the Tool form's field types. */
+const toolFieldSchemas = {
+  name: z.string().min(1).max(200),
+  toolType: z.enum(['manufacturing', 'quality', 'utility']),
+  toolSubtype: scalarString.pipe(z.string().min(1).max(50)),
+  manufacturer: scalarString.pipe(z.string().max(200)),
+  model: scalarString.pipe(z.string().max(200)),
+  location: scalarString.pipe(z.string().max(500)),
+  notes: scalarString.pipe(z.string().max(5000)),
+} satisfies Record<string, z.ZodTypeAny>
+
+const MAX_ATTRIBUTES = 20
+
+export async function enrichItemFromUrl(params: {
+  url: string
+  itemType: EnrichableItemType
+}): Promise<ItemEnrichmentResult> {
+  const { url, itemType } = params
+
+  // Validate the URL early (also blocks SSRF) so a bad drop fails fast even
+  // when AI is off and we would otherwise just echo the link back.
+  assertSafeUrl(url)
+
+  const aiEnabled = await isAIEnabled()
+  if (!aiEnabled) {
+    return { aiEnabled: false, link: url, fields: {}, attributes: {} }
+  }
+
+  let page: FetchedPage
+  try {
+    page = await fetchPageText(url)
+  } catch (error) {
+    // A blocked/invalid URL is a hard error; a merely-unreachable page still
+    // lets the client save the link (AI enabled, but nothing to extract).
+    if (error instanceof ValidationError) throw error
+    return { aiEnabled: true, link: url, fields: {}, attributes: {} }
+  }
+
+  const raw = await runExtraction(itemType, url, page)
+  const parsed = parseJsonResponse(raw)
+
+  const fieldSchemas = itemType === 'Part' ? partFieldSchemas : toolFieldSchemas
+  const fields = pickValidFields(fieldSchemas, parsed?.fields)
+  const attributes = normalizeAttributes(parsed?.customAttributes)
+
+  return { aiEnabled: true, link: url, fields, attributes }
+}
+
+async function runExtraction(
+  itemType: EnrichableItemType,
+  url: string,
+  page: FetchedPage,
+): Promise<string> {
+  try {
+    const providerConfig = await loadProviderConfig()
+    const adapter = getAdapter(providerConfig)
+
+    const messages: any = [
+      { role: 'system', content: buildSystemPrompt(itemType) },
+      { role: 'user', content: buildUserPrompt(url, page) },
+    ]
+
+    const stream = chat({ adapter, messages, maxTokens: 1024 })
+    let fullResponse = ''
+    for await (const chunk of stream) {
+      if (chunk.type === 'content' && chunk.content) {
+        fullResponse = chunk.content
+      }
+    }
+    return fullResponse
+  } catch {
+    // Provider/network failure — degrade gracefully to "link only".
+    return ''
+  }
+}
+
+function buildSystemPrompt(itemType: EnrichableItemType): string {
+  if (itemType === 'Part') {
+    return `You extract structured information about a single physical part or component from the text of a web page (a supplier product page, datasheet, or catalog listing).
+
+Return ONLY valid JSON (no markdown fences) in exactly this shape:
+{
+  "fields": {
+    "name": "concise part or product name",
+    "description": "1-3 sentence summary",
+    "partType": "Manufacture" | "Purchase" | "Software" | "Phantom",
+    "material": "primary material",
+    "weight": "numeric value only, no units (e.g. \\"1.5\\")",
+    "weightUnit": "g | kg | lb | oz",
+    "cost": "numeric price only, no currency symbol (e.g. \\"12.99\\")",
+    "costCurrency": "ISO 4217 3-letter code (e.g. \\"USD\\")",
+    "leadTimeDays": 0
+  },
+  "customAttributes": { "label": "value" }
+}
+
+Rules:
+- Only include a field when the page clearly supports it. OMIT anything you are unsure about — never guess.
+- A catalog / supplier / off-the-shelf part is almost always "Purchase".
+- weight and cost values must be plain numbers as strings, with units/currency in the separate fields.
+- Put manufacturer, part number / SKU / MPN, dimensions, tolerances, and other specs into customAttributes (short human labels).
+- Limit customAttributes to at most ${MAX_ATTRIBUTES} of the most useful entries.
+- If the page has no relevant part information, return {"fields":{},"customAttributes":{}}.`
+  }
+
+  return `You extract structured information about a single tool, machine, or piece of equipment from the text of a web page (a manufacturer product page or spec sheet).
+
+Return ONLY valid JSON (no markdown fences) in exactly this shape:
+{
+  "fields": {
+    "name": "concise tool/machine name",
+    "toolType": "manufacturing" | "quality" | "utility",
+    "toolSubtype": "short snake_case category",
+    "manufacturer": "brand / maker",
+    "model": "model number or name",
+    "location": "only if the page states one — usually omit",
+    "notes": "brief free-form notes"
+  },
+  "customAttributes": { "label": "value" }
+}
+
+Guidance:
+- toolType: fabrication/machining/printing/welding equipment is "manufacturing"; measurement/inspection is "quality"; automation/handling/support is "utility".
+- toolSubtype examples: fdm_printer, sla_printer, cnc_mill, cnc_lathe, cnc_router, laser_cutter, press_brake, mig_welder, tig_welder, drill_press, band_saw, surface_grinder, calipers, micrometer, cmm, 3d_scanner, robotic_arm. Choose the closest snake_case category.
+- Only include a field when the page clearly supports it. OMIT anything you are unsure about.
+- Put build volume, work area, power, spindle speed, accuracy, and other specs into customAttributes (short human labels).
+- Limit customAttributes to at most ${MAX_ATTRIBUTES} of the most useful entries.
+- If the page has no relevant tool information, return {"fields":{},"customAttributes":{}}.`
+}
+
+function buildUserPrompt(url: string, page: FetchedPage): string {
+  const lines: Array<string> = [`Source URL: ${url}`]
+  if (page.title) lines.push(`Page title: ${page.title}`)
+  if (page.description) lines.push(`Meta description: ${page.description}`)
+  lines.push('', 'Page text:', '"""', page.text, '"""', '')
+  lines.push('Extract the item information as specified.')
+  return lines.join('\n')
+}
+
+/** Strip markdown fences and isolate the JSON object; returns null on failure. */
+function parseJsonResponse(response: string): {
+  fields?: unknown
+  customAttributes?: unknown
+} | null {
+  let cleaned = response.trim()
+  if (!cleaned) return null
+
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '')
+  }
+
+  const start = cleaned.indexOf('{')
+  const end = cleaned.lastIndexOf('}')
+  if (start >= 0 && end > start) {
+    cleaned = cleaned.slice(start, end + 1)
+  }
+
+  try {
+    return JSON.parse(cleaned)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Validate each candidate field independently so one malformed value does not
+ * discard the whole set. Unknown keys and empty values are dropped.
+ */
+function pickValidFields(
+  schemas: Record<string, z.ZodTypeAny>,
+  raw: unknown,
+): Record<string, unknown> {
+  if (typeof raw !== 'object' || raw === null) return {}
+  const source = raw as Record<string, unknown>
+  const out: Record<string, unknown> = {}
+
+  for (const [key, schema] of Object.entries(schemas)) {
+    if (!(key in source)) continue
+    const value = source[key]
+    if (value === null || value === undefined || value === '') continue
+
+    const result = schema.safeParse(value)
+    if (result.success && result.data !== undefined && result.data !== '') {
+      out[key] = result.data
+    }
+  }
+
+  return out
+}
+
+/** Coerce AI custom attributes to a bounded string->string map. */
+function normalizeAttributes(raw: unknown): Record<string, string> {
+  if (typeof raw !== 'object' || raw === null) return {}
+  const out: Record<string, string> = {}
+
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (Object.keys(out).length >= MAX_ATTRIBUTES) break
+    const trimmedKey = key.trim()
+    if (!trimmedKey) continue
+    if (value === null || value === undefined) continue
+
+    const stringValue =
+      typeof value === 'string'
+        ? value
+        : typeof value === 'number' || typeof value === 'boolean'
+          ? String(value)
+          : JSON.stringify(value)
+
+    if (stringValue.trim()) {
+      out[trimmedKey] = stringValue.trim().slice(0, 1000)
+    }
+  }
+
+  return out
+}

--- a/src/lib/items/enrichment/html-to-text.test.ts
+++ b/src/lib/items/enrichment/html-to-text.test.ts
@@ -1,0 +1,73 @@
+import { assertSafeUrl } from './html-to-text'
+import { ValidationError } from '@/lib/errors'
+
+/**
+ * SSRF boundary: link enrichment fetches an arbitrary user-supplied URL
+ * server-side, so `assertSafeUrl` must reject anything that could reach the
+ * internal network or use a non-web scheme. (Three-gate rule: security.)
+ */
+describe('assertSafeUrl', () => {
+  it('accepts public http and https URLs', () => {
+    expect(assertSafeUrl('https://example.com/product/123').hostname).toBe(
+      'example.com',
+    )
+    expect(assertSafeUrl('http://8.8.8.8/page').hostname).toBe('8.8.8.8')
+    expect(
+      assertSafeUrl('https://sub.vendor.co.uk/spec?id=5').hostname,
+    ).toBe('sub.vendor.co.uk')
+  })
+
+  it('rejects non-http(s) schemes', () => {
+    for (const url of [
+      'ftp://example.com/file',
+      'file:///etc/passwd',
+      'javascript:alert(1)',
+      'data:text/html,<h1>hi</h1>',
+    ]) {
+      expect(() => assertSafeUrl(url)).toThrow(ValidationError)
+    }
+  })
+
+  it('rejects loopback and unspecified hosts', () => {
+    for (const url of [
+      'http://localhost/x',
+      'http://api.localhost/x',
+      'http://127.0.0.1/x',
+      'http://127.9.9.9/x',
+      'http://0.0.0.0/x',
+      'http://[::1]/x',
+    ]) {
+      expect(() => assertSafeUrl(url)).toThrow(ValidationError)
+    }
+  })
+
+  it('rejects private and link-local IPv4 ranges', () => {
+    for (const url of [
+      'http://10.0.0.5/x',
+      'http://192.168.1.1/x',
+      'http://172.16.0.1/x',
+      'http://172.31.255.255/x',
+      'http://169.254.169.254/x', // cloud metadata endpoint
+    ]) {
+      expect(() => assertSafeUrl(url)).toThrow(ValidationError)
+    }
+  })
+
+  it('rejects internal-only hostnames', () => {
+    expect(() => assertSafeUrl('http://db.internal/x')).toThrow(ValidationError)
+    expect(() => assertSafeUrl('http://printer.local/x')).toThrow(
+      ValidationError,
+    )
+  })
+
+  it('allows public IPs that merely start with a private-looking octet', () => {
+    // 172.15.x and 172.32.x are public (private block is 172.16–172.31 only)
+    expect(assertSafeUrl('http://172.15.0.1/x').hostname).toBe('172.15.0.1')
+    expect(assertSafeUrl('http://172.32.0.1/x').hostname).toBe('172.32.0.1')
+  })
+
+  it('throws on malformed URLs', () => {
+    expect(() => assertSafeUrl('not a url')).toThrow(ValidationError)
+    expect(() => assertSafeUrl('')).toThrow(ValidationError)
+  })
+})

--- a/src/lib/items/enrichment/html-to-text.ts
+++ b/src/lib/items/enrichment/html-to-text.ts
@@ -1,0 +1,190 @@
+/**
+ * Server-side webpage fetch + text extraction for link-based item enrichment.
+ *
+ * Dependency-free: strips scripts/styles/tags, decodes common entities, and
+ * bounds the output so it is safe to feed to an LLM. Guards against SSRF by
+ * rejecting non-http(s) URLs and hosts on the local / private network.
+ */
+
+import { ValidationError } from '@/lib/errors'
+
+/** Hard cap on the HTML we will read into memory. */
+const MAX_HTML_BYTES = 1_000_000
+/** Hard cap on the extracted body text handed to the model. */
+const MAX_TEXT_CHARS = 8_000
+/** Fetch timeout — a hung page must not hang the request. */
+const FETCH_TIMEOUT_MS = 8_000
+
+export interface FetchedPage {
+  title?: string
+  description?: string
+  text: string
+}
+
+/**
+ * Validate a URL and block obvious SSRF targets (loopback / private ranges).
+ * Returns the parsed URL on success; throws ValidationError otherwise.
+ */
+export function assertSafeUrl(rawUrl: string): URL {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    throw new ValidationError('That does not look like a valid URL')
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new ValidationError('Only http and https links are supported')
+  }
+
+  if (isBlockedHost(url.hostname.toLowerCase())) {
+    throw new ValidationError(
+      'Links pointing to local or private network addresses are not allowed',
+    )
+  }
+
+  return url
+}
+
+function isBlockedHost(host: string): boolean {
+  // Strip IPv6 brackets if present
+  const bare =
+    host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host
+
+  if (bare === 'localhost' || bare.endsWith('.localhost')) return true
+  if (bare.endsWith('.local') || bare.endsWith('.internal')) return true
+  if (bare === '::1' || bare === '::') return true
+
+  // IPv4 loopback / private / link-local / unspecified ranges
+  const ipv4 = bare.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+  if (ipv4) {
+    const a = Number(ipv4[1])
+    const b = Number(ipv4[2])
+    if (a === 0 || a === 127) return true // unspecified / loopback
+    if (a === 10) return true // private
+    if (a === 192 && b === 168) return true // private
+    if (a === 172 && b >= 16 && b <= 31) return true // private
+    if (a === 169 && b === 254) return true // link-local
+  }
+
+  // IPv6 unique-local (fc00::/7) and link-local (fe80::/10)
+  if (/^f[cd][0-9a-f]{2}:/i.test(bare)) return true
+  if (/^fe[89ab][0-9a-f]:/i.test(bare)) return true
+
+  return false
+}
+
+/**
+ * Fetch a webpage and return its title, meta description, and cleaned body text.
+ * Throws ValidationError for unreachable / non-HTML / blocked URLs.
+ */
+export async function fetchPageText(rawUrl: string): Promise<FetchedPage> {
+  const url = assertSafeUrl(rawUrl)
+
+  let response: Response
+  try {
+    response = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      redirect: 'follow',
+      headers: {
+        'User-Agent': 'CascadiaPLM/1.0 (+link-enrichment)',
+        Accept: 'text/html,application/xhtml+xml',
+      },
+    })
+  } catch {
+    throw new ValidationError('Could not reach that link')
+  }
+
+  if (!response.ok) {
+    throw new ValidationError(
+      `Could not fetch that page (HTTP ${response.status})`,
+    )
+  }
+
+  const contentType = response.headers.get('content-type') ?? ''
+  if (
+    !contentType.includes('text/html') &&
+    !contentType.includes('application/xhtml')
+  ) {
+    throw new ValidationError('The link is not a web page we can read')
+  }
+
+  const contentLength = Number(response.headers.get('content-length') ?? '0')
+  if (contentLength > MAX_HTML_BYTES) {
+    throw new ValidationError('That page is too large to read')
+  }
+
+  const html = (await response.text()).slice(0, MAX_HTML_BYTES)
+  return extractText(html)
+}
+
+function extractText(html: string): FetchedPage {
+  const rawTitle = matchGroup(html, /<title[^>]*>([\s\S]*?)<\/title>/i)
+  const rawDescription =
+    metaContent(html, 'name', 'description') ??
+    metaContent(html, 'property', 'og:description')
+
+  const body = html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<noscript[\s\S]*?<\/noscript>/gi, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+
+  return {
+    title: rawTitle ? clean(rawTitle) : undefined,
+    description: rawDescription ? clean(rawDescription) : undefined,
+    text: clean(body).slice(0, MAX_TEXT_CHARS),
+  }
+}
+
+function matchGroup(html: string, regex: RegExp): string | undefined {
+  const match = regex.exec(html)
+  return match?.[1]
+}
+
+/** Extract the `content` attribute of a <meta> tag matched by attr=value. */
+function metaContent(
+  html: string,
+  attr: string,
+  value: string,
+): string | undefined {
+  const tagRegex = new RegExp(
+    `<meta[^>]+${attr}=["']${escapeRegExp(value)}["'][^>]*>`,
+    'i',
+  )
+  const tag = tagRegex.exec(html)?.[0]
+  if (!tag) return undefined
+  return matchGroup(tag, /content=["']([\s\S]*?)["']/i)
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function clean(value: string): string {
+  return decodeEntities(value).replace(/\s+/g, ' ').trim()
+}
+
+function decodeEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0*39;|&apos;/gi, "'")
+    .replace(/&#(\d+);/g, (_, dec: string) => codePoint(Number(dec)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex: string) =>
+      codePoint(parseInt(hex, 16)),
+    )
+    .replace(/&amp;/gi, '&') // decode last to avoid double-decoding
+}
+
+function codePoint(code: number): string {
+  if (!Number.isFinite(code) || code < 0 || code > 0x10ffff) return ''
+  try {
+    return String.fromCodePoint(code)
+  } catch {
+    return ''
+  }
+}

--- a/src/lib/items/types/tool.ts
+++ b/src/lib/items/types/tool.ts
@@ -16,6 +16,8 @@ export interface Tool extends BaseItem {
   toolStatus?: 'available' | 'in_use' | 'maintenance' | 'retired'
   location?: string
   notes?: string
+  // Free-form key/value metadata (inherited from BaseItem; declared for clarity)
+  attributes?: Record<string, string>
 }
 
 // ============================================================================

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config'
 import { serve } from '@hono/node-server'
 import app from './index'
 

--- a/src/server/routes/items.ts
+++ b/src/server/routes/items.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { and, asc, eq, inArray, isNull, like, or, sql } from 'drizzle-orm'
-import { ZodError } from 'zod'
+import { ZodError, z } from 'zod'
 import { tagged } from '../adapter'
 import type { ResourceType } from '@/lib/auth/permissions'
 import type { BaseItem } from '@/lib/items/types/base'
@@ -11,6 +11,7 @@ import {
   ValidationError,
 } from '@/lib/errors'
 import { ItemService } from '@/lib/items/services/ItemService'
+import { enrichItemFromUrl } from '@/lib/items/enrichment/enrich-from-url'
 import { ItemRelationshipService } from '@/lib/items/services/ItemRelationshipService'
 import { ImpactAssessmentService } from '@/lib/items/services/ImpactAssessmentService'
 import { BranchService } from '@/lib/services/BranchService'
@@ -29,7 +30,8 @@ import { requireBranchAccess, requireDesignAccess } from '@/lib/auth/access'
 import {
   batchCreateRequestSchema,
   calculateLockDuration,
-  createLockedStatus, createUnlockedStatus 
+  createLockedStatus,
+  createUnlockedStatus,
 } from '@/lib/api'
 import {
   batchCheckinRequestSchema,
@@ -47,7 +49,8 @@ import {
   parts,
   requirements,
   tasks,
-  users, vaultFiles 
+  users,
+  vaultFiles,
 } from '@/lib/db/schema'
 import { designs } from '@/lib/db/schema/designs'
 // Register item types (server-side version)
@@ -63,6 +66,7 @@ function getResourceType(itemType: string): ResourceType {
     ChangeOrder: 'change_orders',
     Requirement: 'requirements',
     Task: 'tasks',
+    Tool: 'tools',
     TestPlan: 'test_plans',
     TestCase: 'test_cases',
   }
@@ -896,7 +900,10 @@ app.get(
       const countStates = url.searchParams.get('countStates')
 
       let columnFilters:
-        | Record<string, string | Array<string> | { min?: number; max?: number }>
+        | Record<
+            string,
+            string | Array<string> | { min?: number; max?: number }
+          >
         | undefined
       const columnFiltersRaw = url.searchParams.get('columnFilters')
       if (columnFiltersRaw) {
@@ -1122,6 +1129,49 @@ app.post(
 
       return created({ item })
     }),
+  ),
+)
+
+// POST /api/items/enrich-from-url
+// Parse a dropped web link into suggested field values + custom attributes.
+// Returns { aiEnabled: false, link } when no AI provider is connected.
+app.post(
+  '/enrich-from-url',
+  adapt(
+    apiHandler(
+      {
+        openapi: {
+          summary: 'Suggest item fields from a web link',
+          request: {
+            body: {
+              schema: z.object({
+                url: z.string().url(),
+                itemType: z.enum(['Part', 'Tool']),
+              }),
+            },
+          },
+        },
+      },
+      async ({ request }) => {
+        const body = await request.json()
+        const { url, itemType } = body as {
+          url?: unknown
+          itemType?: unknown
+        }
+
+        if (typeof url !== 'string' || !url.trim()) {
+          throw new ValidationError('url is required')
+        }
+        if (itemType !== 'Part' && itemType !== 'Tool') {
+          throw new ValidationError('itemType must be "Part" or "Tool"')
+        }
+
+        // Gate on the same create permission used when creating the item.
+        await requirePermission(request, getResourceType(itemType), 'create')
+
+        return await enrichItemFromUrl({ url, itemType })
+      },
+    ),
   ),
 )
 
@@ -1994,7 +2044,7 @@ app.get(
 
       // Return graphData directly as Response to preserve existing shape
       // (existing clients expect { nodes, edges } at the top level, not { data: { nodes, edges } })
-       
+
       return new Response(JSON.stringify(graphData), {
         headers: { 'Content-Type': 'application/json' },
       })


### PR DESCRIPTION
- Add enrichment lib that fetches a dropped URL, extracts page text, and asks the connected AI to suggest field values and custom attributes
- Add POST /api/items/enrich-from-url, degrading to a link-only response when no AI provider is connected
- Add UrlDropOverlay and useUrlDropEnrichment to wire drop-to-enrich into Part and Tool detail views
- Add SSRF guard and HTML-to-text conversion with unit tests
- Add custom attributes editor to ToolForm and declare attributes on the Tool type
- Grant the tools resource to Admin and Engineer roles and map Tool to its resource type
- Load dotenv in the dev server so AI provider credentials resolve
- Regenerate the OpenAPI v1 snapshot for the new endpoint