### PR TITLE
Fix Docker build context bloat; build demo images selectively

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,20 @@
+# Build context filter for the repo-root builds (docker/app.Dockerfile,
+# docker/vault.Dockerfile, workers/node/Dockerfile). All three do `COPY . .`
+# in their builder stage, so anything not excluded here is both transferred to
+# the daemon and baked into a builder layer that `cache-to: gha,mode=max`
+# uploads.
+#
+# Keep in sync with .gitignore: a path that is gitignored but not listed here
+# is absent in CI (fresh checkout) yet ships from every developer machine.
+
 # Dependencies
 node_modules
 npm-debug.log*
 
-# Environment files
+# Environment files — .env.docker is gitignored and would otherwise be
+# included; the .example files are not needed inside an image either.
 .env
+.env.*
 .env.local
 .env.*.local
 
@@ -12,14 +23,30 @@ dist
 .output
 .vinxi
 .vite
+.nitro
+.tanstack
+html
+
+# Runtime data. `vault` is the local file-vault store and reaches multiple GB.
+# These match root-level entries only, so src/lib/vault is unaffected.
+vault
+vault-storage
+storage
+todos.json
+
+# Demo dataset (~200 MB of GLB + thumbnails, ~590 MB with STEPs). Only
+# docker/demo-data.Dockerfile needs it, and that build uses `demo-data` as its
+# own context with demo-data/.dockerignore filtering it.
+demo-data
 
 # Git
 .git
 .gitignore
 
-# IDE
+# IDE / agent tooling
 .vscode
 .idea
+.claude
 *.swp
 *.swo
 *~
@@ -31,6 +58,9 @@ Thumbs.db
 # Testing
 coverage
 .nyc_output
+test-results
+playwright-report
+playwright/.auth
 
 # Documentation
 *.md

--- a/.github/workflows/publish-demo-images.yml
+++ b/.github/workflows/publish-demo-images.yml
@@ -51,8 +51,10 @@ jobs:
             context: .
             dockerfile: workers/node/Dockerfile
             target: production
+          # Context is demo-data/, not the repo root: the root .dockerignore
+          # excludes demo-data so the other builds don't transfer it.
           - name: cascadia-demo-data
-            context: .
+            context: demo-data
             dockerfile: docker/demo-data.Dockerfile
             target: ''
 

--- a/.github/workflows/publish-demo-images.yml
+++ b/.github/workflows/publish-demo-images.yml
@@ -1,18 +1,27 @@
-# Build and publish the four images that back the zero-friction demo:
+# Build and publish the images that back the zero-friction demo:
 #   ghcr.io/cascadia-plm/cascadia-app
 #   ghcr.io/cascadia-plm/cascadia-cad-converter
 #   ghcr.io/cascadia-plm/cascadia-jobs-worker
 #   ghcr.io/cascadia-plm/cascadia-demo-data
 #
+# Images are built SELECTIVELY: the `plan` job diffs the push/PR against its base
+# and emits a matrix containing only the images whose inputs actually changed. A
+# docs-only or test-only commit builds nothing. Tag pushes and manual dispatches
+# always build the full set so a release is coherent.
+#
 # Triggers:
-#   - push to main           -> multi-arch build, push :latest, :main, :sha-<short>
-#   - workflow_dispatch      -> same as above (manual rebuild)
-#   - pull_request to main   -> amd64-only build, no push (verify Dockerfiles still build)
-#   - tag push v*            -> additionally publish :semver (workflow already wired
-#                               via metadata-action; activates when first git tag exists)
+#   - push to main           -> multi-arch build of changed images, push :latest, :main, :sha-<short>
+#   - workflow_dispatch      -> full multi-arch rebuild of every image
+#   - pull_request to main   -> amd64-only build of changed images, no push (Dockerfile smoke test)
+#   - tag push v*            -> full rebuild, additionally publish :semver
+#
+# NOTE on :sha-<short> tags. Because images build selectively, a given commit SHA
+# only tags the images that changed in it. `docker-compose.demo.yml` pins :latest,
+# which always resolves (unchanged images keep pointing at their previous digest),
+# so this affects only users hand-pinning :sha-<short> across all services.
 #
 # ONE-TIME SETUP after the first successful run:
-#   For each of the four packages, flip visibility to public:
+#   For each package, flip visibility to public:
 #     GitHub -> org Cascadia-PLM -> Packages -> <package> -> Settings ->
 #     "Change visibility" -> Public.
 #   Without this the curl quickstart fails with `unauthorized` for unauthenticated
@@ -33,30 +42,121 @@ permissions:
   packages: write
 
 jobs:
-  publish:
+  # ---------------------------------------------------------------------------
+  # Decide which images need building. Emits a JSON matrix consumed by `publish`.
+  # ---------------------------------------------------------------------------
+  plan:
     runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.select.outputs.images }}
+      any: ${{ steps.select.outputs.any }}
+    steps:
+      # Default shallow checkout. paths-filter deepens on demand via its
+      # initial-fetch-depth (default 100); `fetch-depth: 0` would drag in every
+      # historical demo-data blob for no benefit.
+      - uses: actions/checkout@v4
+
+      # Skipped entirely on tag pushes, workflow_dispatch, and the all-zeros
+      # `before` SHA (branch creation / history-rewriting force-push). In those
+      # cases `changes` is unset and the next step force-builds everything.
+      - name: Detect changed image sources
+        id: filter
+        if: >-
+          github.event_name == 'pull_request' ||
+          (github.event_name == 'push'
+           && !startsWith(github.ref, 'refs/tags/')
+           && github.event.before != '0000000000000000000000000000000000000000')
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            # Anchor for the sources shared by cascadia-app and cascadia-jobs-worker.
+            # Both Dockerfiles `COPY . .` and run the identical `npm run build`, so a
+            # change to any of these genuinely invalidates both images. It surfaces as
+            # its own filter key, which the catalog below has no entry for and drops.
+            _app_sources: &app_sources
+              - 'src/**'
+              - 'scripts/**'
+              - 'public/**'
+              - 'test-data/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'index.html'
+              - 'vite.config.ts'
+              - 'tsconfig.json'
+              - 'drizzle.config.ts'
+              - '.dockerignore'
+            # Editing the pipeline itself rebuilds everything, so a change to how
+            # images are built is always exercised by the commit that makes it.
+            _pipeline: &pipeline
+              - '.github/workflows/publish-demo-images.yml'
+            app:
+              - *app_sources
+              - *pipeline
+              - 'docker/app.Dockerfile'
+            jobs_worker:
+              - *app_sources
+              - *pipeline
+              - 'workers/node/Dockerfile'
+            cad_converter:
+              - *pipeline
+              - 'workers/cad-converter/**'
+            demo_data:
+              - *pipeline
+              - 'demo-data/**'
+              - 'docker/demo-data.Dockerfile'
+
+      - name: Select images to build
+        id: select
+        env:
+          # JSON array of matched filter names, e.g. ["_app_sources","app","jobs_worker"].
+          # Empty string when the filter step above was skipped.
+          CHANGES: ${{ steps.filter.outputs.changes }}
+        run: |
+          set -euo pipefail
+
+          # Canonical catalog. `filter` maps each image to its paths-filter key and is
+          # stripped before the matrix is emitted. Retiring an image (cascadia-demo-data
+          # is moving to its own repo) means deleting one row here and its filter block.
+          catalog='[
+            {"name":"cascadia-app","context":".","dockerfile":"docker/app.Dockerfile","target":"production","filter":"app"},
+            {"name":"cascadia-jobs-worker","context":".","dockerfile":"workers/node/Dockerfile","target":"production","filter":"jobs_worker"},
+            {"name":"cascadia-cad-converter","context":"workers/cad-converter","dockerfile":"workers/cad-converter/Dockerfile","target":"","filter":"cad_converter"},
+            {"name":"cascadia-demo-data","context":"demo-data","dockerfile":"docker/demo-data.Dockerfile","target":"","filter":"demo_data"}
+          ]'
+
+          if [ -z "${CHANGES}" ]; then
+            echo "No change detection ran (tag push, manual dispatch, or no diff base) - building every image."
+            images=$(jq -c '[.[] | del(.filter)]' <<<"$catalog")
+          else
+            # --argjson parses CHANGES as JSON rather than interpolating it into the
+            # program, so an unexpected filter name cannot alter the jq expression.
+            images=$(jq -c --argjson ch "$CHANGES" \
+              '[.[] | select(.filter as $f | $ch | index($f)) | del(.filter)]' \
+              <<<"$catalog")
+          fi
+
+          count=$(jq 'length' <<<"$images")
+          {
+            echo "images=$images"
+            echo "any=$([ "$count" -gt 0 ] && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Building $count image(s):"
+          jq -r '.[].name | "  - " + .' <<<"$images"
+
+  # ---------------------------------------------------------------------------
+  # Build (and, off PRs, push) each selected image.
+  # ---------------------------------------------------------------------------
+  publish:
+    needs: plan
+    # Short-circuits before matrix expansion; an empty matrix would otherwise error.
+    if: needs.plan.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    name: publish ${{ matrix.image.name }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: cascadia-app
-            context: .
-            dockerfile: docker/app.Dockerfile
-            target: production
-          - name: cascadia-cad-converter
-            context: workers/cad-converter
-            dockerfile: workers/cad-converter/Dockerfile
-            target: ''
-          - name: cascadia-jobs-worker
-            context: .
-            dockerfile: workers/node/Dockerfile
-            target: production
-          # Context is demo-data/, not the repo root: the root .dockerignore
-          # excludes demo-data so the other builds don't transfer it.
-          - name: cascadia-demo-data
-            context: demo-data
-            dockerfile: docker/demo-data.Dockerfile
-            target: ''
+        image: ${{ fromJSON(needs.plan.outputs.images) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +179,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/cascadia-plm/${{ matrix.name }}
+          images: ghcr.io/cascadia-plm/${{ matrix.image.name }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=main,enable={{is_default_branch}}
@@ -90,14 +190,14 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          target: ${{ matrix.target }}
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.dockerfile }}
+          target: ${{ matrix.image.target }}
           # PRs build amd64 only and don't push - faster feedback, no GHCR pollution.
           # Main branch and tags build multi-arch and push.
           platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+          cache-from: type=gha,scope=${{ matrix.image.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}

--- a/demo-data/.dockerignore
+++ b/demo-data/.dockerignore
@@ -1,0 +1,8 @@
+# Build context filter for docker/demo-data.Dockerfile (context: demo-data).
+#
+# STEP files are build-time inputs to scripts/prepare-demo-cad.ts, not runtime
+# data — scripts/seed-demo-robot-arm.ts treats them as optional and seeds from
+# glb/ + thumbnails/ + manifest.json alone. They are gitignored, so a CI build
+# never sees them; excluding them here keeps a local build byte-comparable
+# instead of silently producing a ~590 MB image.
+robot-arm/step

--- a/docker/demo-data.Dockerfile
+++ b/docker/demo-data.Dockerfile
@@ -1,16 +1,22 @@
-# Demo CAD dataset (~592 MB) packaged as a tiny image.
+# Demo CAD dataset packaged as a tiny image.
 #
 # Loaded into the cascadia-demo stack via a one-shot init container that
 # copies into a named volume; the app reads from that volume via the
 # DEMO_DATA_DIR env. Kept separate from cascadia-app so production deploys
 # don't carry demo data they will never use.
 #
-# Build context is the repo root.
+# Build context is `demo-data/`, NOT the repo root — the root .dockerignore
+# excludes demo-data so the app/vault/jobs builds don't transfer it. STEP
+# files are filtered out by demo-data/.dockerignore, which keeps this image
+# identical whether it is built in CI (where step/ is gitignored and absent)
+# or on a developer machine (where it is present).
+#
+#   docker build -f docker/demo-data.Dockerfile demo-data
 
 FROM alpine:3.20
 
-COPY demo-data/robot-arm /demo-data/robot-arm
+COPY robot-arm /demo-data/robot-arm
 
 LABEL org.opencontainers.image.source="https://github.com/Cascadia-PLM/Cascadia-App"
-LABEL org.opencontainers.image.description="Cascadia PLM demo dataset (TDJ-25 robot arm: 79 STEP/GLB/PNG trios + manifest)."
+LABEL org.opencontainers.image.description="Cascadia PLM demo dataset (TDJ-25 robot arm: 79 GLB + thumbnail pairs and a manifest)."
 LABEL org.opencontainers.image.licenses="AGPL-3.0-only"


### PR DESCRIPTION
Two independent fixes to the image pipeline, found while investigating whether the repo carries large files that belong in the demo-data package.

## 1. `.dockerignore` had drifted out of sync with `.gitignore`

The worst offender was `vault/` — the local file-vault store, **5.0 GB** on a working dev machine — which was never excluded. All three repo-root images (`app`, `vault`, `workers/node`) do `COPY . .` in their builder stage, so every local build transferred it to the daemon *and* baked it into a layer that `cache-to: gha,mode=max` uploads. `.env.docker` was also slipping through: it's gitignored, but the existing `.env.*.local` pattern doesn't match it.

Measured on a **fresh** buildx builder (buildx incrementally syncs context between builds, so a naive re-measure under-reports — it claimed 71 kB):

| | Before | After |
|---|---|---|
| Root build context | 5.99 GB | **15.26 MB** |
| `cascadia-demo-data` image | 199 MB (CI) / 592 MB (local) | 198.9 MB, deterministic |

Excluding `demo-data` from the root context would have broken the one build that needs it, so `docker/demo-data.Dockerfile` now uses `demo-data/` as its own context. A new `demo-data/.dockerignore` drops `robot-arm/step`, which the seed treats as optional and which is gitignored — so CI never saw it. The image was 199 MB built in CI and 592 MB built locally; now it's 199 MB either way.

## 2. All four images rebuilt on every push

Every push to `main` rebuilt all four images multi-arch, so `cascadia-app` and `cascadia-jobs-worker` ran `npm ci` under QEMU arm64 emulation. A README typo was enough to trigger it, and that emulated `npm ci` is the source of the recurring exit-132 / SIGILL flake.

A `plan` job now diffs against the base with `dorny/paths-filter` and emits a JSON matrix of only the images whose inputs changed. `publish` consumes it via `fromJSON` and is skipped outright when nothing matched.

`app` and `jobs-worker` share an `_app_sources` anchor because both Dockerfiles `COPY . .` and run the identical `npm run build` — any source change genuinely invalidates both, and they can only diverge on a Dockerfile-only change. Selective building therefore can't ship a mismatched app/worker pair. Tag pushes, `workflow_dispatch`, and the all-zeros `before` SHA force-build everything.

`paths-filter` is pinned to a commit SHA. The obvious alternative, `tj-actions/changed-files`, was compromised in March 2025 and also wants `fetch-depth: 0`, which here would clone every historical demo-data blob.

**Caveat:** a skipped image publishes no `:sha-<short>` tag, so that tag is no longer coherent across all four. `docker-compose.demo.yml` pins `:latest`, which always resolves, and the repo has no git tags — so nothing depends on this today. Documented in the workflow header.

## Verification

- Built the demo-data image: 79 GLB + 79 thumbnails, no `step/`, 198.9 MB.
- Ran `app.Dockerfile`'s builder stage to completion to confirm nothing was over-excluded.
- `actionlint` clean.
- Exercised the `jq` matrix selection against 8 change scenarios (docs-only, src-only, each Dockerfile in isolation, tag push, anchor-key-alone).
- Parsed the nested `filters` YAML to confirm the anchor flattens and the two Dockerfiles don't cross-trigger.

Because this PR touches the workflow file, it should build all four images amd64-only without pushing — a live test of the new `plan` job.

## Follow-ups (not in this PR)

- Move `demo-data/` (95.5% of the repo's 58.59 MiB packed history) to its own repo, then rewrite history.
- Split arm64 onto native `ubuntu-24.04-arm` runners to remove QEMU entirely rather than retrying around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)