### PR TITLE
Add a CI guard rejecting new blobs over 5 MB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,3 +183,58 @@ jobs:
 
       - name: Validate contributor compose
         run: docker compose -f docker-compose.demo-with-build.yml config --quiet
+
+  large-files:
+    name: Large File Guard
+    runs-on: ubuntu-latest
+    # PR-only: it needs a base to diff against. Every change reaches main via a
+    # PR, so this is sufficient.
+    if: github.event_name == 'pull_request'
+    steps:
+      # Needs real history to enumerate the objects this PR introduces.
+      # Cheap now: the packed repo is ~3 MB.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # demo-data/robot-arm/glb was once 95% of this repo's history — 79 GLB
+      # files, one of them 62 MB — before it moved to Cascadia-PLM/Demo-Data and
+      # the history was rewritten to reclaim it. Nothing structural stops that
+      # from happening again, so this does.
+      #
+      # rev-list --not base enumerates objects the PR *introduces*, which catches
+      # a blob that was committed and then deleted again: it no longer appears in
+      # any tree, but it is permanently in history all the same.
+      - name: Reject new blobs over 5 MB
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          LIMIT=$((5 * 1024 * 1024))
+
+          offenders=$(
+            git rev-list --objects "$HEAD" --not "$BASE" \
+              | git cat-file --batch-check='%(objecttype) %(objectsize) %(rest)' \
+              | awk -v lim="$LIMIT" '
+                  $1 == "blob" && $2 > lim {
+                    size = $2; $1 = ""; $2 = ""; sub(/^ +/, "")
+                    printf "  %.1f MB  %s\n", size / 1048576, $0
+                  }'
+          )
+
+          if [ -n "$offenders" ]; then
+            echo "::error::This PR introduces blobs larger than 5 MB. Git history is forever."
+            echo ""
+            echo "$offenders"
+            echo ""
+            echo "Large binaries do not belong in this repo. Options:"
+            echo "  - CAD/demo assets  -> Cascadia-PLM/Demo-Data, fetched via 'npm run demo:fetch'"
+            echo "  - build outputs    -> generate them, and add the path to .gitignore"
+            echo "  - genuinely needed -> publish as a release asset and download at build time"
+            echo ""
+            echo "Deleting the file in a later commit does NOT help; the blob stays in history."
+            exit 1
+          fi
+
+          echo "No blobs over 5 MB introduced."


### PR DESCRIPTION
Closes the loop on the demo-data extraction.

`demo-data/robot-arm/glb` was **95% of this repo's packed history** — 79 GLB files, one of them 62 MB. It now lives in [Cascadia-PLM/Demo-Data](https://github.com/Cascadia-PLM/Demo-Data), and `main` was rewritten to reclaim the space:

| | `.git` | checkout |
|---|---|---|
| before | 59 MB | 275 MB |
| after | **3.1 MB** | **21 MB** |

Nothing structural stopped that from happening again. This does.

## Why `rev-list --not base` rather than checking files at HEAD

The check enumerates the objects a PR *introduces*, not the files it leaves behind. That catches the case where someone commits a 60 MB file, notices, and deletes it in a follow-up commit within the same PR — the blob appears in no tree, but it is in history permanently all the same. A `git diff --name-only` check would wave that through.

## Threshold

5 MB, with headroom: the largest tracked file is `docs/api/openapi.v1.json` at 3.19 MB.

## Verification

Tested against four scenarios before wiring it up:

| Scenario | Expected | Result |
|---|---|---|
| Normal PR, small text file | pass | pass |
| Adds a 6 MB blob | flag | flagged, `6.0 MB huge.bin` |
| Adds a 6 MB blob, then deletes it in the same PR | flag | flagged |
| Reintroduces the real `TDJ-25-A-00000-MAIN-ASSEMBLY.glb` | flag | flagged, `62.0 MB` |

`actionlint` clean. `fetch-depth: 0` is cheap now that the packed repo is ~3 MB — which is rather the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)