### PR TITLE
Fix design engine tool-call duplication and truncated stream text

### DIFF
--- a/src/components/design-engine/ActivityFeed.tsx
+++ b/src/components/design-engine/ActivityFeed.tsx
@@ -75,49 +75,86 @@ export function ActivityFeed({
       currentStage === 'bom_review') &&
     !isStreaming
 
-  // Group consecutive llm_text events for rendering.
-  // Non-rendering events like artifact_update shouldn't break text groups.
-  const renderedEvents: Array<{
-    key: string
-    event: StageEvent | { type: 'llm_text_group'; text: string }
-  }> = []
+  // Build the render list from the raw event stream.
+  //
+  // - Consecutive llm_text events are merged into one markdown block
+  //   (artifact_update events don't render and don't break a text group).
+  // - A tool_call and its matching tool_result are collapsed into a single
+  //   `tool_activity` card that flips from pending → completed, rather than
+  //   rendering two near-identical cards (which reads as the tool being
+  //   reported twice).
+  type RenderedEvent =
+    | StageEvent
+    | { type: 'llm_text_group'; text: string }
+    | { type: 'tool_activity'; toolName: string; completed: boolean }
+
+  const renderedEvents: Array<{ key: string; event: RenderedEvent }> = []
 
   let textBuffer = ''
   let textGroupStart = -1
 
-  // Event types that render visibly and should break text groups
-  const breaksTextGroup = (type: string) =>
-    type !== 'llm_text' && type !== 'artifact_update'
+  const flushText = () => {
+    if (textBuffer) {
+      renderedEvents.push({
+        key: `text-${textGroupStart}`,
+        event: { type: 'llm_text_group', text: textBuffer },
+      })
+      textBuffer = ''
+      textGroupStart = -1
+    }
+  }
 
   for (let i = 0; i < events.length; i++) {
     const event = events[i]
+    if (!event) continue
 
     if (event.type === 'llm_text') {
       if (textGroupStart === -1) textGroupStart = i
       textBuffer += event.text
-    } else if (breaksTextGroup(event.type)) {
-      // Flush text buffer before visible events
-      if (textBuffer) {
-        renderedEvents.push({
-          key: `text-${textGroupStart}`,
-          event: { type: 'llm_text_group', text: textBuffer },
-        })
-        textBuffer = ''
-        textGroupStart = -1
+      continue
+    }
+
+    // artifact_update events don't render and shouldn't split text groups.
+    if (event.type === 'artifact_update') continue
+
+    // Any other event is visible — flush any pending text first.
+    flushText()
+
+    if (event.type === 'tool_call') {
+      renderedEvents.push({
+        key: `event-${i}`,
+        event: { type: 'tool_activity', toolName: event.toolName, completed: false },
+      })
+    } else if (event.type === 'tool_result') {
+      // Mark the most recent unfinished call of the same tool as completed.
+      let paired = false
+      for (let j = renderedEvents.length - 1; j >= 0; j--) {
+        const candidate = renderedEvents[j]?.event
+        if (
+          candidate &&
+          candidate.type === 'tool_activity' &&
+          candidate.toolName === event.toolName &&
+          !candidate.completed
+        ) {
+          candidate.completed = true
+          paired = true
+          break
+        }
       }
+      if (!paired) {
+        // Result without a preceding call (e.g. hydrated history) — show it
+        // as an already-completed activity on its own.
+        renderedEvents.push({
+          key: `event-${i}`,
+          event: { type: 'tool_activity', toolName: event.toolName, completed: true },
+        })
+      }
+    } else {
       renderedEvents.push({ key: `event-${i}`, event })
     }
-    // artifact_update events are skipped — they don't render
-    // and shouldn't split text groups
   }
 
-  // Flush remaining text
-  if (textBuffer) {
-    renderedEvents.push({
-      key: `text-${textGroupStart}`,
-      event: { type: 'llm_text_group', text: textBuffer },
-    })
-  }
+  flushText()
 
   return (
     <div className={cn('flex flex-col overflow-hidden', className)}>
@@ -166,27 +203,21 @@ export function ActivityFeed({
             )
           }
 
-          if (event.type === 'tool_call') {
+          if (event.type === 'tool_activity') {
             return (
               <div
                 key={key}
                 className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400 bg-slate-50 dark:bg-slate-800 rounded px-2 py-1"
               >
-                <Wrench className="h-3 w-3" />
+                {event.completed ? (
+                  <CheckCircle className="h-3 w-3 text-green-500" />
+                ) : (
+                  <Wrench className="h-3 w-3 animate-pulse" />
+                )}
                 <span className="font-mono">{event.toolName}</span>
-              </div>
-            )
-          }
-
-          if (event.type === 'tool_result') {
-            return (
-              <div
-                key={key}
-                className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400 bg-slate-50 dark:bg-slate-800 rounded px-2 py-1"
-              >
-                <CheckCircle className="h-3 w-3 text-green-500" />
-                <span className="font-mono">{event.toolName}</span>
-                <span className="text-slate-400">completed</span>
+                {event.completed && (
+                  <span className="text-slate-400">completed</span>
+                )}
               </div>
             )
           }

--- a/src/lib/design-engine/stages/bom.ts
+++ b/src/lib/design-engine/stages/bom.ts
@@ -217,19 +217,19 @@ export async function* runBomStage(
       streamIter: any,
     ): AsyncGenerator<StageEvent, boolean> {
       let lastBomVersion = bomState.changeVersion
-      let accumulatedText = ''
       // Fresh tracker per stream — pending args are keyed by a per-call index.
       const tracker = createToolEventTracker()
 
       for await (const chunk of streamIter) {
         if (clarificationRef.requested || signal?.aborted) break
 
-        if (chunk.type === 'content' && chunk.content) {
-          const delta = (chunk.content as string).slice(accumulatedText.length)
-          accumulatedText = chunk.content as string
-          if (delta) {
-            yield { type: 'llm_text', text: delta }
-          }
+        // Yield only the incremental text. The SDK resets its accumulated
+        // `content` at the start of each agent-loop iteration (i.e. after every
+        // tool call), so slicing against a persistent offset would drop the
+        // leading characters of each post-tool-call message. `chunk.delta` is
+        // the true per-chunk increment and is iteration-safe.
+        if (chunk.type === 'content' && chunk.delta) {
+          yield { type: 'llm_text', text: chunk.delta as string }
         }
 
         // Translate SDK tool chunks into tool_call/tool_result events so they're

--- a/src/lib/design-engine/stages/requirements.ts
+++ b/src/lib/design-engine/stages/requirements.ts
@@ -140,20 +140,19 @@ export async function* runRequirementsStage(
     })
 
     let lastRequirementsCount = artifacts.requirements.length
-    let accumulatedText = ''
     const tracker = createToolEventTracker()
 
     for await (const chunk of stream) {
       // Check if clarification was requested or abort signalled — break out of loop
       if (clarificationRef.requested || signal?.aborted) break
 
-      // Yield text content (delta only — chunk.content is accumulated)
-      if (chunk.type === 'content' && chunk.content) {
-        const delta = chunk.content.slice(accumulatedText.length)
-        accumulatedText = chunk.content
-        if (delta) {
-          yield { type: 'llm_text', text: delta }
-        }
+      // Yield only the incremental text. The SDK resets its accumulated
+      // `content` at the start of each agent-loop iteration (i.e. after every
+      // tool call), so slicing against a persistent offset would drop the
+      // leading characters of each post-tool-call message. `chunk.delta` is the
+      // true per-chunk increment and is iteration-safe.
+      if (chunk.type === 'content' && chunk.delta) {
+        yield { type: 'llm_text', text: chunk.delta }
       }
 
       // Translate SDK tool chunks into tool_call/tool_result events so they're

--- a/src/lib/design-engine/stages/toolset-establishment.ts
+++ b/src/lib/design-engine/stages/toolset-establishment.ts
@@ -130,19 +130,18 @@ export async function* runToolsetEstablishmentStage(
     })
 
     let lastToolCount = artifacts.toolset?.tools.length ?? 0
-    let accumulatedText = ''
     const tracker = createToolEventTracker()
 
     for await (const chunk of stream) {
       if (clarificationRef.requested || signal?.aborted) break
 
-      // Yield text content
-      if (chunk.type === 'content' && chunk.content) {
-        const delta = chunk.content.slice(accumulatedText.length)
-        accumulatedText = chunk.content
-        if (delta) {
-          yield { type: 'llm_text', text: delta }
-        }
+      // Yield only the incremental text. The SDK resets its accumulated
+      // `content` at the start of each agent-loop iteration (i.e. after every
+      // tool call), so slicing against a persistent offset would drop the
+      // leading characters of each post-tool-call message. `chunk.delta` is the
+      // true per-chunk increment and is iteration-safe.
+      if (chunk.type === 'content' && chunk.delta) {
+        yield { type: 'llm_text', text: chunk.delta }
       }
 
       // Translate SDK tool chunks into tool_call/tool_result events so they're


### PR DESCRIPTION
Two bugs in the collaborative design engine activity feed:

1. Every tool showed up twice. The stream emits a separate tool_call and
   tool_result event per tool, and ActivityFeed rendered each as its own
   near-identical card, so each tool appeared to be reported twice. Pair a
   result with its preceding call into a single tool_activity card that
   flips from pending (wrench) to completed (check).

2. The first characters of each message were cut off after tool calls. The
   drafting stages derived the text delta by slicing chunk.content against a
   persistent accumulatedText offset. TanStack AI resets its accumulated
   content to "" at the start of every agent-loop iteration (i.e. after each
   tool call), so post-tool-call messages were shorter than the stale offset
   and lost their leading characters. Use chunk.delta — the SDK's true
   per-chunk increment — which is iteration-safe.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013iTejfKj5mXDGH9XMG2P1k