### PR TITLE
Add CAD generation API key to admin UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,13 @@ RABBITMQ_URL=amqp://cascadia:cascadia@localhost:5672
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 # ENCRYPTION_KEY=
 
+# CAD Generation (Zoo Text-to-CAD, used by the collaborative design engine)
+# Optional: can also be configured in the UI at /admin/ai (CAD Generation
+# section). A key saved and enabled in the UI overrides this variable.
+# ZOO_API_KEY=
+# ZOO_TEXT_TO_CAD_TIMEOUT_MS=600000
+# ZOO_TEXT_TO_CAD_CONCURRENCY=3
+
 # Database SSL/TLS
 # When NODE_ENV=production the app requires TLS unless you opt out. Set to
 # "disable" for private-network deployments (e.g. compose-bundled postgres),

--- a/SETUP.md
+++ b/SETUP.md
@@ -131,11 +131,17 @@ OPENAI_API_KEY=your-key-here
 
 ### AI CAD Generation
 
-Requires a Zoo API key for text-to-CAD model generation:
+Requires a Zoo API key for text-to-CAD model generation. Set it either via the
+environment:
 
 ```
 ZOO_API_KEY=your-zoo-api-key
 ```
+
+…or in the UI as an admin at **Admin → AI Assistant** (`/admin/ai`), in the
+**CAD Generation** section. A key saved and enabled there is stored in the
+database (encrypted at rest when `ENCRYPTION_KEY` is set) and overrides the
+environment variable.
 
 ### CAD Conversion Workers
 

--- a/docs/api/openapi.v1.json
+++ b/docs/api/openapi.v1.json
@@ -842,6 +842,829 @@
         ]
       }
     },
+    "/api/v1/admin/cad-settings": {
+      "get": {
+        "operationId": "getApiV1AdminCadSettings",
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Server error"
+          }
+        },
+        "tags": [
+          "Admin"
+        ]
+      },
+      "post": {
+        "operationId": "postApiV1AdminCadSettings",
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Server error"
+          }
+        },
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/v1/admin/cad-settings/test": {
+      "post": {
+        "operationId": "postApiV1AdminCadSettingsTest",
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Server error"
+          }
+        },
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
     "/api/v1/admin/component-catalog": {
       "get": {
         "operationId": "getApiV1AdminComponentCatalog",

--- a/docs/features/cad-services.md
+++ b/docs/features/cad-services.md
@@ -197,7 +197,7 @@ The `ZooClient` class (`zoo-client.ts`) handles communication with the Zoo API:
 
 Configuration:
 
-- `ZOO_API_KEY` (required): API key for authentication.
+- `ZOO_API_KEY` (required): API key for authentication. Can be provided via the environment variable **or** configured in the UI by an admin at **Admin → AI Assistant** (`/admin/ai`) in the **CAD Generation** section. A key saved and enabled in the UI is stored in the `settings` table (encrypted at rest when `ENCRYPTION_KEY` is set) and takes precedence over the environment variable; if no UI key is set/enabled, the app falls back to `ZOO_API_KEY`.
 - `ZOO_TEXT_TO_CAD_TIMEOUT_MS` (optional): Maximum wait time, default 600 seconds (10 minutes).
 - `ZOO_TEXT_TO_CAD_CONCURRENCY` (optional): Max parallel Zoo API calls, default 3.
 

--- a/docs/features/design-engine.md
+++ b/docs/features/design-engine.md
@@ -190,6 +190,8 @@ Generates individual STEP files for each new Manufacture leaf part. Two generati
 
 **Concurrency**: Parts are generated in parallel with a configurable concurrency limit (default 3, controlled by `ZOO_TEXT_TO_CAD_CONCURRENCY` env var).
 
+**API key**: The Zoo API key resolves from the database first (the **CAD Generation** section of **Admin → AI Assistant**, `/admin/ai`), falling back to the `ZOO_API_KEY` environment variable.
+
 **Flow**:
 
 1. Walk the BOM tree to collect all new Manufacture leaf parts

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -139,7 +139,7 @@ Cascadia includes an AI chatbot and design engine that require API keys from sup
 | ------------------- | -------------------------------------- |
 | `OPENAI_API_KEY`    | OpenAI API key for GPT models          |
 | `ANTHROPIC_API_KEY` | Anthropic API key for Claude models    |
-| `ZOO_API_KEY`       | Zoo API key for text-to-CAD generation |
+| `ZOO_API_KEY`       | Zoo API key for text-to-CAD generation (can also be set in the UI at `/admin/ai`) |
 
 At least one of `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` is required for AI features. If neither is set, the AI chatbot panel is hidden but the rest of the application works normally.
 

--- a/src/components/admin/CadGenerationSettingsCard.tsx
+++ b/src/components/admin/CadGenerationSettingsCard.tsx
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Cascadia PLM contributors
+
+import {
+  AlertCircle,
+  Box,
+  CheckCircle,
+  Eye,
+  EyeOff,
+  Loader2,
+  Save,
+  Sparkles,
+  TestTube,
+} from 'lucide-react'
+import { useEffect, useState } from 'react'
+import type { CadProvider } from '@/lib/cad-generation/settings-types'
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
+} from '@/components/ui'
+import { CAD_PROVIDERS } from '@/lib/cad-generation/settings-types'
+
+/**
+ * Admin card for configuring the CAD generation (Zoo Text-to-CAD) API key.
+ *
+ * Mirrors the AI provider settings pattern: DB-stored + encrypted at rest, with
+ * an env-var (`ZOO_API_KEY`) fallback. The secret is never prefilled into the
+ * editable field — the API key input starts empty and a "Key configured" badge
+ * indicates a saved key; saving with a blank field preserves the stored key.
+ */
+export function CadGenerationSettingsCard() {
+  const [provider, setProvider] = useState<CadProvider>('zoo')
+  const [enabled, setEnabled] = useState(false)
+  const [originalEnabled, setOriginalEnabled] = useState(false)
+  const [apiKey, setApiKey] = useState('')
+  const [hasApiKey, setHasApiKey] = useState(false)
+  const [apiKeyPreview, setApiKeyPreview] = useState<string | undefined>()
+  const [showApiKey, setShowApiKey] = useState(false)
+  const [envDetected, setEnvDetected] = useState(false)
+
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [testing, setTesting] = useState(false)
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>(
+    'idle',
+  )
+  const [testStatus, setTestStatus] = useState<'idle' | 'success' | 'error'>(
+    'idle',
+  )
+  const [errorMessage, setErrorMessage] = useState('')
+  const [testMessage, setTestMessage] = useState('')
+
+  useEffect(() => {
+    void loadSettings()
+  }, [])
+
+  const loadSettings = async () => {
+    try {
+      setLoading(true)
+      const response = await fetch('/api/v1/admin/cad-settings')
+      if (response.ok) {
+        const data = await response.json()
+        const s = data.data?.settings
+        if (s) {
+          setProvider(s.provider ?? 'zoo')
+          setEnabled(s.enabled ?? false)
+          setOriginalEnabled(s.enabled ?? false)
+          setHasApiKey(s.hasApiKey ?? false)
+          setApiKeyPreview(s.apiKeyPreview)
+        }
+        setEnvDetected(data.data?.envVars?.zoo ?? false)
+      }
+    } catch (error) {
+      console.error('Error loading CAD generation settings:', error)
+      setErrorMessage('Failed to load CAD generation settings')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleSave = async () => {
+    try {
+      setSaving(true)
+      setSaveStatus('idle')
+      setErrorMessage('')
+
+      const response = await fetch('/api/v1/admin/cad-settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          enabled,
+          provider,
+          config: {
+            provider,
+            // Only send a key when the admin typed one; blank preserves the
+            // stored key server-side.
+            apiKey: apiKey || undefined,
+          },
+        }),
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(
+          error.error?.message || 'Failed to save CAD generation settings',
+        )
+      }
+
+      const data = await response.json()
+      const s = data.data?.settings
+      if (s) {
+        setHasApiKey(s.hasApiKey ?? false)
+        setApiKeyPreview(s.apiKeyPreview)
+      }
+      setOriginalEnabled(enabled)
+      setApiKey('')
+      setSaveStatus('success')
+      setTimeout(() => setSaveStatus('idle'), 3000)
+    } catch (error) {
+      console.error('Error saving CAD generation settings:', error)
+      setSaveStatus('error')
+      setErrorMessage((error as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleTestConnection = async () => {
+    try {
+      setTesting(true)
+      setTestStatus('idle')
+      setTestMessage('')
+
+      const response = await fetch('/api/v1/admin/cad-settings/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider, apiKey: apiKey || undefined }),
+      })
+
+      const data = await response.json()
+      if (!response.ok) {
+        setTestStatus('error')
+        setTestMessage(data.error?.message || 'Connection test failed')
+      } else {
+        setTestStatus('success')
+        setTestMessage(data.data?.message || 'Connection successful!')
+        setTimeout(() => setTestStatus('idle'), 5000)
+      }
+    } catch (error) {
+      console.error('Error testing Zoo connection:', error)
+      setTestStatus('error')
+      setTestMessage((error as Error).message)
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const hasChanges = enabled !== originalEnabled || apiKey.length > 0
+  const canTest = apiKey.length > 0 || hasApiKey || envDetected
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-12">
+          <Loader2 className="w-6 h-6 animate-spin text-slate-400 mr-2" />
+          <span className="text-slate-600 dark:text-slate-400">
+            Loading CAD generation settings...
+          </span>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      {/* Environment variable info */}
+      {envDetected && (
+        <Card className="border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/30">
+          <CardContent className="pt-6">
+            <div className="flex items-start gap-3">
+              <Sparkles className="w-5 h-5 text-blue-600 dark:text-blue-400 mt-0.5" />
+              <div>
+                <p className="font-medium text-blue-900 dark:text-blue-100">
+                  Environment variable detected
+                </p>
+                <p className="text-sm text-blue-700 dark:text-blue-300 mt-1">
+                  <Badge variant="outline" className="mr-1">
+                    ZOO_API_KEY
+                  </Badge>
+                  configured
+                </p>
+                <p className="text-sm text-blue-600 dark:text-blue-400 mt-2">
+                  A key saved here (and enabled) overrides the environment
+                  variable.
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Enable/Disable */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Box className="w-5 h-5 text-slate-600 dark:text-slate-400" />
+              <CardTitle>CAD Generation Status</CardTitle>
+            </div>
+            <div className="flex items-center gap-3">
+              <span
+                className={`text-sm ${enabled ? 'text-green-600 dark:text-green-400' : 'text-slate-500'}`}
+              >
+                {enabled ? 'Enabled' : 'Disabled'}
+              </span>
+              <Switch checked={enabled} onCheckedChange={setEnabled} />
+            </div>
+          </div>
+          <CardDescription>
+            Use the stored key for Text-to-CAD generation in the design engine.
+            When disabled, the app falls back to the ZOO_API_KEY environment
+            variable.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+
+      {/* Provider configuration */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Box className="w-5 h-5 text-slate-600 dark:text-slate-400" />
+            <CardTitle>Provider Configuration</CardTitle>
+          </div>
+          <CardDescription>
+            Select your CAD generation provider and configure API credentials
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Provider */}
+          <div className="space-y-2">
+            <Label htmlFor="cad-provider">Provider</Label>
+            <Select
+              value={provider}
+              onValueChange={(value) => setProvider(value as CadProvider)}
+            >
+              <SelectTrigger id="cad-provider" className="w-full max-w-md">
+                <SelectValue placeholder="Select a provider" />
+              </SelectTrigger>
+              <SelectContent>
+                {(
+                  Object.entries(CAD_PROVIDERS) as Array<[CadProvider, string]>
+                ).map(([key, label]) => (
+                  <SelectItem key={key} value={key}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* API Key */}
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Label htmlFor="cad-api-key">API Key</Label>
+              {hasApiKey && (
+                <Badge variant="outline" className="text-green-600">
+                  Key configured
+                </Badge>
+              )}
+            </div>
+            <div className="relative flex-1 max-w-md">
+              {/* Hidden input to prevent browser autofill targeting the header search bar */}
+              <input
+                type="text"
+                name="prevent-autofill"
+                autoComplete="username"
+                style={{
+                  position: 'absolute',
+                  opacity: 0,
+                  pointerEvents: 'none',
+                  height: 0,
+                  width: 0,
+                }}
+                tabIndex={-1}
+                aria-hidden="true"
+              />
+              <Input
+                id="cad-api-key"
+                name="cad-api-key-field"
+                type={showApiKey ? 'text' : 'password'}
+                placeholder={
+                  hasApiKey
+                    ? 'Leave blank to keep the saved key'
+                    : `Enter your ${CAD_PROVIDERS[provider]} API key`
+                }
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                autoComplete="new-password"
+                className="pr-10"
+              />
+              <button
+                type="button"
+                onClick={() => setShowApiKey(!showApiKey)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+              >
+                {showApiKey ? (
+                  <EyeOff className="w-4 h-4" />
+                ) : (
+                  <Eye className="w-4 h-4" />
+                )}
+              </button>
+            </div>
+            {hasApiKey && apiKeyPreview && !apiKey && (
+              <p className="text-sm text-slate-500">
+                Saved key: <span className="font-mono">{apiKeyPreview}</span>
+              </p>
+            )}
+          </div>
+
+          {/* Test Connection */}
+          <div className="flex items-center gap-3 pt-2">
+            <Button
+              variant="outline"
+              onClick={handleTestConnection}
+              disabled={!canTest || testing}
+            >
+              {testing ? (
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              ) : (
+                <TestTube className="w-4 h-4 mr-2" />
+              )}
+              {testing ? 'Testing...' : 'Test Connection'}
+            </Button>
+            {testStatus === 'success' && (
+              <span className="flex items-center gap-1 text-sm text-green-600 dark:text-green-400">
+                <CheckCircle className="w-4 h-4" />
+                {testMessage}
+              </span>
+            )}
+            {testStatus === 'error' && (
+              <span className="flex items-center gap-1 text-sm text-red-600 dark:text-red-400">
+                <AlertCircle className="w-4 h-4" />
+                {testMessage}
+              </span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Save */}
+      <div className="flex items-center gap-3">
+        <Button onClick={handleSave} disabled={saving || !hasChanges}>
+          {saving ? (
+            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+          ) : (
+            <Save className="w-4 h-4 mr-2" />
+          )}
+          {saving ? 'Saving...' : 'Save Configuration'}
+        </Button>
+        {saveStatus === 'success' && (
+          <span className="flex items-center gap-1 text-sm text-green-600 dark:text-green-400">
+            <CheckCircle className="w-4 h-4" />
+            Settings saved successfully!
+          </span>
+        )}
+        {saveStatus === 'error' && (
+          <span className="flex items-center gap-1 text-sm text-red-600 dark:text-red-400">
+            <AlertCircle className="w-4 h-4" />
+            {errorMessage}
+          </span>
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/lib/cad-generation/part-generator.ts
+++ b/src/lib/cad-generation/part-generator.ts
@@ -11,6 +11,7 @@
  */
 
 import { ZooClient } from './zoo-client'
+import { resolveZooApiKey } from './settings'
 import { buildCadPrompt } from './prompt-builder'
 import type {
   BomNodeDraft,
@@ -154,7 +155,7 @@ export async function* generateAllParts(
     artifacts: { cadGenerationState: state },
   }
 
-  const zooClient = new ZooClient()
+  const zooClient = new ZooClient(await resolveZooApiKey())
   const results: Array<CadGenerationResult> = []
 
   // Process parts with concurrency limit using a Map keyed by tempId

--- a/src/lib/cad-generation/settings-types.ts
+++ b/src/lib/cad-generation/settings-types.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Cascadia PLM contributors
+
+/**
+ * Shared types for CAD generation provider settings.
+ *
+ * This file is intentionally dependency-free (no db / node / fetch imports) so
+ * it can be imported from both the client bundle and server code without
+ * pulling server-only modules into the SPA build.
+ *
+ * Zoo (zoo.dev) is the only Text-to-CAD provider today; the `provider` field
+ * exists so additional vendors can be added later without a schema change.
+ */
+
+export type CadProvider = 'zoo'
+
+export interface CadGenerationConfig {
+  provider: CadProvider
+  /** Encrypted at rest when ENCRYPTION_KEY is set; plaintext otherwise. */
+  apiKey?: string
+  enabled: boolean
+}
+
+export const CAD_PROVIDERS: Record<CadProvider, string> = {
+  zoo: 'Zoo (zoo.dev)',
+}
+
+export const CAD_PROVIDER_KEYS = Object.keys(
+  CAD_PROVIDERS,
+) as Array<CadProvider>

--- a/src/lib/cad-generation/settings.ts
+++ b/src/lib/cad-generation/settings.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Cascadia PLM contributors
+
+/**
+ * Server-side resolver for CAD generation (Zoo) provider settings.
+ *
+ * Precedence (mirrors the AI provider resolver in `@/lib/ai/adapters`):
+ *   1. Database settings (the `cad_generation` blob in the `settings` table),
+ *      when present and `enabled`.
+ *   2. The `ZOO_API_KEY` environment variable.
+ *
+ * Stored keys are encrypted at rest when `ENCRYPTION_KEY` is configured; this
+ * module transparently decrypts them, falling back to treating the value as
+ * plaintext if decryption fails (e.g. rows written before encryption was on).
+ */
+
+import type { CadGenerationConfig } from './settings-types'
+import { SettingsService } from '@/lib/config/SettingsService'
+import { SettingKeys } from '@/lib/config/SettingKeys'
+import { decrypt, isEncryptionConfigured } from '@/lib/crypto/encryption'
+
+/**
+ * Read the stored CAD generation config blob (with the API key still encrypted).
+ */
+export async function loadCadGenerationConfig(): Promise<CadGenerationConfig | null> {
+  return SettingsService.getJsonValue<CadGenerationConfig>(
+    SettingKeys.CAD_GENERATION,
+  )
+}
+
+/**
+ * Decrypt a stored API key, tolerating plaintext values.
+ */
+export function decryptCadApiKey(apiKey: string): string {
+  if (!isEncryptionConfigured()) return apiKey
+  try {
+    return decrypt(apiKey)
+  } catch {
+    // May be plaintext from before encryption was enabled — use as-is.
+    return apiKey
+  }
+}
+
+/**
+ * Resolve the effective Zoo API key: database settings first (when enabled),
+ * otherwise the `ZOO_API_KEY` environment variable. Returns `undefined` when
+ * neither source provides a key (callers/`ZooClient` surface the error).
+ */
+export async function resolveZooApiKey(): Promise<string | undefined> {
+  const stored = await loadCadGenerationConfig()
+  if (stored?.enabled && stored.apiKey) {
+    return decryptCadApiKey(stored.apiKey)
+  }
+  return process.env.ZOO_API_KEY || undefined
+}

--- a/src/lib/config/SettingKeys.ts
+++ b/src/lib/config/SettingKeys.ts
@@ -11,6 +11,7 @@ export const SettingKeys = {
   SETUP_COMPLETED: 'system.setup_completed',
   SETUP_PROGRESS: 'system.setup_progress',
   ORG_INFO: 'org.info',
+  CAD_GENERATION: 'cad_generation',
 } as const
 
 export type SettingKey = (typeof SettingKeys)[keyof typeof SettingKeys]

--- a/src/lib/design-engine/stages/cad-generation.ts
+++ b/src/lib/design-engine/stages/cad-generation.ts
@@ -12,6 +12,7 @@ import type { BomNodeDraft, DesignArtifacts, StageEvent } from '../types'
 import type { CadPromptContext } from '@/lib/cad-generation/types'
 import { generateAllParts } from '@/lib/cad-generation/part-generator'
 import { ZooClient } from '@/lib/cad-generation/zoo-client'
+import { resolveZooApiKey } from '@/lib/cad-generation/settings'
 import { buildCadPrompt } from '@/lib/cad-generation/prompt-builder'
 import {
   findAffectedAssemblies,
@@ -220,7 +221,7 @@ export async function* regeneratePartCad(
       return
     }
 
-    const zooClient = new ZooClient()
+    const zooClient = new ZooClient(await resolveZooApiKey())
 
     const promptContext: CadPromptContext = {
       partName: partNode.name,

--- a/src/lib/jobs/node-handlers/zoo-generation.ts
+++ b/src/lib/jobs/node-handlers/zoo-generation.ts
@@ -38,7 +38,8 @@ export const zooGenerationHandler: JobHandler<
 
     // Submit to Zoo and wait for completion
     const { ZooClient } = await import('@/lib/cad-generation/zoo-client')
-    const zooClient = new ZooClient()
+    const { resolveZooApiKey } = await import('@/lib/cad-generation/settings')
+    const zooClient = new ZooClient(await resolveZooApiKey())
 
     const { requestId, stepContent } = await zooClient.generateAndWait(
       prompt,

--- a/src/routes/admin/ai.tsx
+++ b/src/routes/admin/ai.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { PageContainer } from '@/components/layout'
+import { CadGenerationSettingsCard } from '@/components/admin/CadGenerationSettingsCard'
 import {
   Badge,
   Button,
@@ -55,11 +56,7 @@ const DEFAULT_MODELS: Record<ProviderType, Array<string>> = {
     'o3',
     'o4-mini',
   ],
-  anthropic: [
-    'claude-opus-4-7',
-    'claude-opus-4-6',
-    'claude-sonnet-4-6',
-  ],
+  anthropic: ['claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-4-6'],
   gemini: [
     'gemini-2.5-pro',
     'gemini-2.5-flash',
@@ -557,6 +554,22 @@ function AISettingsPage() {
           </div>
         </>
       )}
+
+      {/* CAD Generation section */}
+      <div className="border-t border-slate-200 dark:border-slate-800 pt-8 mt-4">
+        <div className="mb-4">
+          <h2 className="text-2xl font-bold text-slate-900 dark:text-white">
+            CAD Generation
+          </h2>
+          <p className="text-slate-600 dark:text-slate-400 mt-1">
+            Configure the Text-to-CAD provider used by the collaborative design
+            engine
+          </p>
+        </div>
+        <div className="space-y-6">
+          <CadGenerationSettingsCard />
+        </div>
+      </div>
     </PageContainer>
   )
 }

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -5,6 +5,10 @@ import { streamToText } from '@tanstack/ai'
 import { tagged } from '../adapter'
 import type { AIProviderConfig as AIProviderDBConfig } from '@/lib/db/schema/ai'
 import type { AIProviderConfig, ProviderType } from '@/lib/ai/adapters'
+import type {
+  CadGenerationConfig,
+  CadProvider,
+} from '@/lib/cad-generation/settings-types'
 import { apiHandler, parseQuery } from '@/lib/api/handler'
 import { db } from '@/lib/db'
 import { aiSettings } from '@/lib/db/schema/ai'
@@ -26,6 +30,9 @@ import { ConfigService } from '@/lib/config'
 import { ItemTypeRegistry } from '@/lib/items/registry'
 import { JobService } from '@/lib/jobs/JobService'
 import { SettingsService } from '@/lib/config/SettingsService'
+import { SettingKeys } from '@/lib/config/SettingKeys'
+import { decryptCadApiKey } from '@/lib/cad-generation/settings'
+import { CAD_PROVIDER_KEYS } from '@/lib/cad-generation/settings-types'
 import { ThreadCacheService } from '@/lib/services/ThreadCacheService'
 import { StorageFactory } from '@/lib/vault/storage/storage-factory'
 import '@/lib/items/registerItemTypes.server'
@@ -228,7 +235,8 @@ app.post(
         effectiveApiKey = process.env.ANTHROPIC_API_KEY
       }
       if (!effectiveApiKey && provider === 'gemini') {
-        effectiveApiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY
+        effectiveApiKey =
+          process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY
       }
 
       // Ollama doesn't need an API key
@@ -325,6 +333,167 @@ app.post(
             error: {
               code: 'CONNECTION_ERROR',
               message: err.message || 'Failed to connect to AI provider',
+            },
+          }),
+          { status: 503, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+    }),
+  ),
+)
+
+// ============================================
+// CAD Generation Settings
+// ============================================
+
+/** Mask a stored (possibly encrypted) key as `first8...last4` for display. */
+function maskCadApiKey(stored: string | undefined): string | undefined {
+  if (!stored) return undefined
+  const decrypted = decryptCadApiKey(stored)
+  return `${decrypted.slice(0, 8)}...${decrypted.slice(-4)}`
+}
+
+function cadValidationError(message: string): Response {
+  return new Response(
+    JSON.stringify({ error: { code: 'VALIDATION_ERROR', message } }),
+    { status: 400, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+// GET /api/admin/cad-settings
+app.get(
+  '/cad-settings',
+  adapt(
+    apiHandler({ permission: ['system', 'manage'] }, async () => {
+      const stored = await SettingsService.getJsonValue<CadGenerationConfig>(
+        SettingKeys.CAD_GENERATION,
+      )
+
+      return {
+        settings: {
+          provider: stored?.provider ?? 'zoo',
+          enabled: stored?.enabled ?? false,
+          hasApiKey: !!stored?.apiKey,
+          apiKeyPreview: maskCadApiKey(stored?.apiKey),
+        },
+        envVars: { zoo: !!process.env.ZOO_API_KEY },
+      }
+    }),
+  ),
+)
+
+// POST /api/admin/cad-settings
+app.post(
+  '/cad-settings',
+  adapt(
+    apiHandler(
+      { permission: ['system', 'manage'] },
+      async ({ request, user }) => {
+        const body = await request.json()
+        const { enabled, provider, config } = body as {
+          enabled: boolean
+          provider: string
+          config?: { apiKey?: string }
+        }
+
+        if (typeof enabled !== 'boolean') {
+          return cadValidationError('enabled must be a boolean')
+        }
+        if (!provider || typeof provider !== 'string') {
+          return cadValidationError('provider is required')
+        }
+        if (!(CAD_PROVIDER_KEYS as ReadonlyArray<string>).includes(provider)) {
+          return cadValidationError(
+            `Invalid provider. Must be one of: ${CAD_PROVIDER_KEYS.join(', ')}`,
+          )
+        }
+
+        // Preserve the existing key when the client submits a blank/omitted one
+        // (the UI never prefills the secret into the editable field).
+        const existing =
+          await SettingsService.getJsonValue<CadGenerationConfig>(
+            SettingKeys.CAD_GENERATION,
+          )
+        const submittedKey = config?.apiKey?.trim()
+        let storedKey = existing?.apiKey
+        if (submittedKey) {
+          storedKey = isEncryptionConfigured()
+            ? encrypt(submittedKey)
+            : submittedKey
+        }
+
+        const blob: CadGenerationConfig = {
+          provider: provider as CadProvider,
+          apiKey: storedKey,
+          enabled,
+        }
+        await SettingsService.setJsonValue(
+          SettingKeys.CAD_GENERATION,
+          blob,
+          user.id,
+          'CAD generation provider settings',
+        )
+
+        return {
+          settings: {
+            provider: blob.provider,
+            enabled: blob.enabled,
+            hasApiKey: !!storedKey,
+            apiKeyPreview: maskCadApiKey(storedKey),
+          },
+        }
+      },
+    ),
+  ),
+)
+
+// POST /api/admin/cad-settings/test
+app.post(
+  '/cad-settings/test',
+  adapt(
+    apiHandler({ permission: ['system', 'manage'] }, async ({ request }) => {
+      const body = await request.json()
+      const { apiKey } = body as { apiKey?: string }
+
+      // Prefer an explicitly-typed key; otherwise test the saved key, then env.
+      let effectiveKey = apiKey?.trim()
+      if (!effectiveKey) {
+        const stored = await SettingsService.getJsonValue<CadGenerationConfig>(
+          SettingKeys.CAD_GENERATION,
+        )
+        effectiveKey = stored?.apiKey
+          ? decryptCadApiKey(stored.apiKey)
+          : process.env.ZOO_API_KEY
+      }
+
+      if (!effectiveKey) {
+        return cadValidationError('API key is required to test the connection')
+      }
+
+      try {
+        const response = await fetch('https://api.zoo.dev/user', {
+          headers: { Authorization: `Bearer ${effectiveKey}` },
+          signal: AbortSignal.timeout(5000),
+        })
+        if (!response.ok) {
+          return new Response(
+            JSON.stringify({
+              error: {
+                code: 'CONNECTION_ERROR',
+                message: `Zoo API returned status ${response.status}. Check that the API key is valid.`,
+              },
+            }),
+            { status: 503, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+        return { success: true, message: 'Connected to Zoo successfully!' }
+      } catch (error) {
+        const err = error as Error
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: 'CONNECTION_ERROR',
+              message: `Failed to connect to Zoo: ${err.message}`,
             },
           }),
           { status: 503, headers: { 'Content-Type': 'application/json' } },


### PR DESCRIPTION
- Add a CAD Generation section/card to /admin/ai for managing the Zoo Text-to-CAD key, mirroring the AI provider settings pattern
- Store the key in the settings table (encrypted at rest, env fallback) via a new resolveZooApiKey() resolver; wire it into all three ZooClient call sites (part generator, design-engine stage, zoo-generation worker)
- Add admin cad-settings GET/POST/test routes guarded by system:manage, with encrypt-on-write, mask-on-read, and preserve-on-blank behavior
- Keep a provider field for future Text-to-CAD vendors (Zoo only for now)
- Update .env.example, setup/CAD docs, and the OpenAPI v1 snapshot