### PR TITLE
Allow unlimited 3D viewer rotation for CAD model interrogation

### DIFF
--- a/docs/features/visualization.md
+++ b/docs/features/visualization.md
@@ -220,7 +220,7 @@ STEP and IGES files are not rendered directly. They are converted server-side by
 
 ### Viewer Features
 
-- **Orbit controls:** Rotate, pan, and zoom with mouse. Damping is enabled for smooth motion.
+- **Trackball controls:** Rotate, pan, and zoom with mouse. Rotation is fully unconstrained (no polar-angle limit), so models can be tumbled freely in any direction for interrogation. Damping is enabled for smooth motion.
 - **Auto-fit camera:** On model load, the camera automatically positions itself to frame the entire model with comfortable padding.
 - **Dynamic zoom limits:** Min and max zoom distances are calculated from the model's bounding box, preventing both clipping into the model and zooming too far away.
 - **Wireframe mode:** Toggle wireframe rendering. In wireframe mode, the model renders as blue lines.
@@ -294,7 +294,7 @@ The `CADViewerToolbar` floats in the top-left corner of the viewer and provides:
 The viewer is built on:
 
 - **React Three Fiber** (`@react-three/fiber` v9) -- React renderer for Three.js
-- **React Three Drei** (`@react-three/drei` v10) -- Helper components (OrbitControls, Environment, GizmoHelper, Grid, etc.)
+- **React Three Drei** (`@react-three/drei` v10) -- Helper components (TrackballControls, Environment, GizmoHelper, Grid, etc.)
 - **Three.js** (v0.182) -- Core 3D rendering library
 
 The `CADViewer` component uses `forwardRef` to expose a `CADViewerHandle` with `resetView()` and `setView()` methods. The internal `Model` component handles loading via Three.js loaders, computing normals and bounding boxes, and applying material presets.

--- a/src/components/parts/CADViewer.tsx
+++ b/src/components/parts/CADViewer.tsx
@@ -15,8 +15,8 @@ import {
   GizmoHelper,
   GizmoViewcube,
   Grid,
-  OrbitControls,
   PerspectiveCamera,
+  TrackballControls,
 } from '@react-three/drei'
 import * as THREE from 'three'
 import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js'
@@ -62,7 +62,8 @@ interface CADViewerProps {
 
 /**
  * 3D CAD Model Viewer Component
- * Supports STL and OBJ file formats with orbit controls
+ * Supports STL and OBJ file formats with trackball controls
+ * (full, unconstrained rotation for model interrogation)
  */
 export const CADViewer = forwardRef<CADViewerHandle, CADViewerProps>(
   function CADViewer(
@@ -316,14 +317,17 @@ export const CADViewer = forwardRef<CADViewerHandle, CADViewerProps>(
             />
           </GizmoHelper>
 
-          {/* Controls with dynamic zoom limits */}
-          <OrbitControls
+          {/* Trackball controls: unlimited tumbling (no polar-angle clamp
+              like OrbitControls), so models can be rotated freely for
+              inspection from any direction. Dynamic zoom limits. */}
+          <TrackballControls
             ref={controlsRef}
-            enableDamping
-            dampingFactor={0.05}
-            rotateSpeed={0.5}
+            makeDefault
+            rotateSpeed={2.5}
             zoomSpeed={1.0}
             panSpeed={0.5}
+            staticMoving={false}
+            dynamicDampingFactor={0.15}
             minDistance={minZoomDistance}
             maxDistance={maxZoomDistance}
           />


### PR DESCRIPTION
Replace OrbitControls with TrackballControls in the CAD viewer.
OrbitControls clamps the polar angle to [0, π], so vertical rotation
stopped at straight-up/straight-down, preventing free tumbling of
models. TrackballControls has no such constraint and rotates the
camera up-vector freely, allowing full unconstrained rotation in any
direction. Standard views and reset still re-normalize the up-vector,
so snapping to front/top/iso etc. behaves as before.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017HnAvmehLUrAbNzEmbWWXk