### PR TITLE
Update available AI provider models in AI settings

### DIFF
--- a/docs/features/ai-assistant.md
+++ b/docs/features/ai-assistant.md
@@ -303,10 +303,10 @@ The AI assistant supports multiple LLM providers through TanStack AI adapters.
 
 | Provider               | Status    | Default Model       | Adapter                  |
 | ---------------------- | --------- | ------------------- | ------------------------ |
-| **Anthropic** (Claude) | Supported | `claude-sonnet-4-6` | `@tanstack/ai-anthropic` |
+| **Anthropic** (Claude) | Supported | `claude-sonnet-5`   | `@tanstack/ai-anthropic` |
 | **OpenAI** (GPT)       | Supported | `gpt-4.1`           | `@tanstack/ai-openai`    |
-| **Google** (Gemini)    | Planned   | `gemini-2.0-flash`  | Not yet implemented      |
-| **Ollama** (local)     | Planned   | `llama3.2`          | Not yet implemented      |
+| **Google** (Gemini)    | Supported | `gemini-2.5-flash`  | `@tanstack/ai-openai` (OpenAI-compatible endpoint) |
+| **Ollama** (local)     | Supported | `llama3.3`          | `@tanstack/ai-openai` (OpenAI-compatible endpoint) |
 
 ### Provider Selection
 

--- a/src/components/setup/steps/AiKeysStep.tsx
+++ b/src/components/setup/steps/AiKeysStep.tsx
@@ -29,7 +29,7 @@ import {
 
 const DEFAULT_MODELS: Record<AiProviderType, Array<string>> = {
   openai: ['gpt-5', 'gpt-5-mini', 'gpt-4.1', 'o3', 'o4-mini'],
-  anthropic: ['claude-opus-4-7', 'claude-sonnet-4-6'],
+  anthropic: ['claude-opus-4-8', 'claude-sonnet-5', 'claude-haiku-4-5'],
   gemini: ['gemini-2.5-pro', 'gemini-2.5-flash'],
   ollama: ['llama3.3', 'qwen2.5'],
 }

--- a/src/lib/ai/adapters.ts
+++ b/src/lib/ai/adapters.ts
@@ -36,7 +36,7 @@ const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434/v1'
  */
 export const DEFAULT_MODELS: Record<ProviderType, string> = {
   openai: 'gpt-4.1',
-  anthropic: 'claude-sonnet-4-6',
+  anthropic: 'claude-sonnet-5',
   gemini: 'gemini-2.5-flash',
   ollama: 'llama3.3',
 }

--- a/src/routes/admin/ai.tsx
+++ b/src/routes/admin/ai.tsx
@@ -56,7 +56,13 @@ const DEFAULT_MODELS: Record<ProviderType, Array<string>> = {
     'o3',
     'o4-mini',
   ],
-  anthropic: ['claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-4-6'],
+  anthropic: [
+    'claude-opus-4-8',
+    'claude-opus-4-7',
+    'claude-sonnet-5',
+    'claude-sonnet-4-6',
+    'claude-haiku-4-5',
+  ],
   gemini: [
     'gemini-2.5-pro',
     'gemini-2.5-flash',
@@ -85,7 +91,7 @@ function AISettingsPage() {
     enabled: false,
     provider: 'openai',
     apiKey: '',
-    model: 'gpt-4o',
+    model: DEFAULT_MODELS.openai[0],
     baseURL: '',
   })
   const [originalSettings, setOriginalSettings] = useState<AISettings | null>(


### PR DESCRIPTION
Refresh the Anthropic model lineup, which was stale (missing Opus 4.8, Sonnet 5, and Haiku 4.5), across all AI-settings surfaces:

- Admin AI settings dropdown (src/routes/admin/ai.tsx): Anthropic list is now Opus 4.8, Opus 4.7, Sonnet 5, Sonnet 4.6, Haiku 4.5. Also fix the stale initial `gpt-4o` state to reference the OpenAI list's first entry.
- Setup wizard (AiKeysStep.tsx): Anthropic short list -> Opus 4.8, Sonnet 5, Haiku 4.5.
- adapters.ts: bump the Anthropic env-var fallback default from the prior-gen Sonnet 4.6 to the current-gen Sonnet 5 (keeps the balanced Sonnet-tier default intent).
- docs/features/ai-assistant.md: sync default-model table and mark Gemini/Ollama as Supported (both are already implemented via the OpenAI-compatible adapter).

OpenAI, Gemini, and Ollama lists were already current and are unchanged. Fable 5 intentionally omitted: it carries extra API requirements (thinking always-on, refusal handling, 30-day retention) the generic adapter does not special-case.