### PR TITLE
Eliminate implicit-any parameters (CORE 120→101)

### DIFF
--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -26,8 +26,8 @@
 
 import { spawnSync } from 'node:child_process'
 
-const CORE_MAX = 120
-const STRICT_MAX = 1982
+const CORE_MAX = 101
+const STRICT_MAX = 1963
 
 /** Runs tsc against one config and returns its error count plus raw output. */
 function typecheck(project) {

--- a/src/components/navigation/Breadcrumbs.tsx
+++ b/src/components/navigation/Breadcrumbs.tsx
@@ -67,7 +67,9 @@ export function Breadcrumbs() {
     const basePath = pathname.split('/')[1]
     navigate({
       to: `/${basePath}`,
-      search: (prev) => ({
+      // `to` is built from pathname at runtime, so the target route - and with
+      // it the search schema - is not statically known here.
+      search: (prev: Record<string, unknown>) => ({
         ...prev,
         designId: designId || undefined,
         branch: undefined,

--- a/src/components/ui/DataGrid.tsx
+++ b/src/components/ui/DataGrid.tsx
@@ -63,7 +63,7 @@ import type {
   RowData,
   SortingState,
 } from '@tanstack/react-table'
-import type { ReactNode } from 'react'
+import type { ReactNode, SetStateAction } from 'react'
 import { cn } from '@/lib/utils'
 
 // Per-column presentation hints read by DataGrid when rendering headers/cells.
@@ -393,7 +393,23 @@ export function DataGrid<T>({
   const globalFilter = controlledGlobalFilter ?? internalGlobalFilter
   const setGlobalFilter = onGlobalFilterChangeProp ?? setInternalGlobalFilter
   const pagination = controlledPagination ?? internalPagination
-  const setPagination = onPaginationChangeProp ?? setInternalPagination
+  // Normalized to useState's updater-accepting shape. `onPaginationChange` takes
+  // a plain PaginationState, but callers below pass `(prev) => next`; a bare
+  // `??` of the two leaves a union no updater can be called on, which silently
+  // degraded `prev` to `any` and would have handed the callback a function
+  // instead of a state object.
+  const setPagination = useCallback(
+    (updater: SetStateAction<PaginationState>) => {
+      if (onPaginationChangeProp) {
+        onPaginationChangeProp(
+          typeof updater === 'function' ? updater(pagination) : updater,
+        )
+      } else {
+        setInternalPagination(updater)
+      }
+    },
+    [onPaginationChangeProp, pagination],
+  )
 
   // Sync local search value from parent (for external changes like URL navigation or clear button elsewhere)
   useEffect(() => {

--- a/src/routes/designs/$id.tsx
+++ b/src/routes/designs/$id.tsx
@@ -141,7 +141,7 @@ function DesignDetailPage() {
     navigate({
       to: '/designs/$id',
       params: { id: design.id },
-      search: (prev) => ({
+      search: (prev: z.infer<typeof designSearchSchema>) => ({
         ...prev,
         tab: tab as
           | 'structure'

--- a/src/routes/issues/index.tsx
+++ b/src/routes/issues/index.tsx
@@ -163,7 +163,7 @@ function IssuesListPage() {
 
   // Get selected design from URL
   const selectedDesignId = searchParams.designId
-  const selectedDesign = designs.find((d) => d.id === selectedDesignId)
+  const selectedDesign = designs.find((d: Design) => d.id === selectedDesignId)
 
   // Version context management
   const { context, contextLabel } = useVersionContext(selectedDesignId)

--- a/src/routes/issues/new.tsx
+++ b/src/routes/issues/new.tsx
@@ -69,7 +69,7 @@ function NewIssuePage() {
 
   // Parse comma-separated designIds from URL and combine with backward compat designId
   const parsedDesignIds = searchParams.designIds
-    ? searchParams.designIds.split(',').filter((id) => id.length > 0)
+    ? searchParams.designIds.split(',').filter((id: string) => id.length > 0)
     : []
   const defaultDesignIds = [
     ...parsedDesignIds,

--- a/src/routes/programs/$id.tsx
+++ b/src/routes/programs/$id.tsx
@@ -357,7 +357,7 @@ function ProgramDetailPage() {
             <CardContent>
               {designs.length > 0 ? (
                 <div className="space-y-3">
-                  {designs.map((design) => (
+                  {designs.map((design: Design) => (
                     <Link
                       key={design.id}
                       to="/designs/$id"

--- a/src/routes/requirements/index.tsx
+++ b/src/routes/requirements/index.tsx
@@ -155,7 +155,7 @@ function RequirementsListPage() {
 
   // Get selected design from URL
   const selectedDesignId = searchParams.designId
-  const selectedDesign = designs.find((d) => d.id === selectedDesignId)
+  const selectedDesign = designs.find((d: Design) => d.id === selectedDesignId)
 
   // Version context management
   const { context, contextLabel, isEditable } =

--- a/src/routes/users/$id.tsx
+++ b/src/routes/users/$id.tsx
@@ -285,7 +285,7 @@ function UserDetailPage() {
         <CardContent>
           {user.roles.length > 0 ? (
             <div className="space-y-6">
-              {user.roles.map((role) => (
+              {user.roles.map((role: Role) => (
                 <div key={role.id} className="border-b pb-6 last:border-b-0">
                   <div className="flex items-start justify-between mb-3">
                     <div>

--- a/src/routes/work-instructions/$id/execute.tsx
+++ b/src/routes/work-instructions/$id/execute.tsx
@@ -312,7 +312,7 @@ function ExecutionModePage() {
       }
     }
     const unassigned = sortedSteps.filter(
-      (s) => !s.operationId || !operations.some((o) => o.id === s.operationId),
+      (s) => !s.operationId || !operations.some((o: WorkInstructionOperation) => o.id === s.operationId),
     )
     for (const step of unassigned) {
       stepItems.push({ type: 'step', step, operationTitle: undefined })
@@ -355,7 +355,7 @@ function ExecutionModePage() {
   // Resolve parametric values
   useEffect(() => {
     const hasParametric = sortedSteps.some((step) =>
-      step.content?.blocks?.some((b) => b.type === 'parametric'),
+      step.content?.blocks?.some((b: StepContentBlock) => b.type === 'parametric'),
     )
     if (!hasParametric) return
 

--- a/src/routes/work-instructions/$id/present.tsx
+++ b/src/routes/work-instructions/$id/present.tsx
@@ -163,7 +163,7 @@ function PresentationModePage() {
 
     // Unassigned steps
     const unassigned = sortedSteps.filter(
-      (s) => !s.operationId || !operations.some((o) => o.id === s.operationId),
+      (s) => !s.operationId || !operations.some((o: WorkInstructionOperation) => o.id === s.operationId),
     )
     for (const step of unassigned) {
       items.push({ type: 'step', step, operationTitle: undefined })
@@ -200,7 +200,7 @@ function PresentationModePage() {
   // Resolve parametric values on load
   useEffect(() => {
     const hasParametric = sortedSteps.some((step) =>
-      step.content?.blocks?.some((b) => b.type === 'parametric'),
+      step.content?.blocks?.some((b: StepContentBlock) => b.type === 'parametric'),
     )
     if (!hasParametric) return
 


### PR DESCRIPTION
**Collection PR by fix type: every `TS7006` in the codebase (15 sites).** Targets `main` directly — no stacking this time.

Two root causes, not fifteen.

## 1. `DataGrid.setPagination` — a real soundness hole (3 sites)

```ts
const setPagination = onPaginationChangeProp ?? setInternalPagination
```

A union of `(p: PaginationState) => void` and `Dispatch<SetStateAction<PaginationState>>`. **No updater can be called on that union**, so `prev` in `setPagination((prev) => ...)` silently degraded to `any`.

It's also a **latent bug**: in controlled mode the updater *function* would be handed to `onPaginationChange`, which expects a plain `PaginationState` object. It survives today only because all three updater calls sit behind `if (!serverSidePagination && !serverSideOperations)`.

Normalized to a single updater-accepting function — types it, and makes controlled mode actually support updaters. **This fix alone cleared 4 knock-on errors elsewhere** (120 → 114 before I touched anything else).

## 2. Callbacks over values that are genuinely `any` (12 sites)

Annotated using types the files **already import** — `Design`, `Role`, `WorkInstructionOperation`, `StepContentBlock` — so types now propagate downstream instead of stopping at `any`.

Two `navigate()` search updaters:
- `designs/$id.tsx` reuses its own `designSearchSchema` via `z.infer` rather than inventing a type.
- `Breadcrumbs.tsx` builds `to` from `pathname` at runtime, so the target route — and its search schema — genuinely isn't statically known. Takes `Record<string, unknown>` with a comment explaining why.

## The bigger issue this exposed (not fixed here)

**`Route.useLoaderData()` returns `any`.**

I proved it: `const x: number = designs` produces *no* type error, which is only possible if `designs` is `any`. Both loader branches return `designs: Array<Design>`, and `routeTree.gen.ts` registers the routes correctly (and contains zero `loader` references — the type is meant to flow from the route file itself).

That's why so many list-page callbacks were untyped: **every route's loader data is currently unchecked.** The annotations here are a real improvement, but they're documentation over an `any`, not enforcement.

Worth its own investigation — possibly related to the `@tanstack/react-router` 1.150 → 1.170 bump in #27. I didn't chase it because it's an architectural typing question, not a mechanical fix.

## Verification

- **CORE 120 → 101, STRICT 1982 → 1963** (19 fixed — 15 TS7006 + 4 knock-on).
- Gate holds at the new ceilings; `npm run lint` 0 warnings; build green; **1135 unit tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc6rXCR5cB2LAWdzU2fxTZ