### PR TITLE
Fix create-mode item initializers + remove dead Description field (CORE 88→69)

### DIFF
--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -26,8 +26,8 @@
 
 import { spawnSync } from 'node:child_process'
 
-const CORE_MAX = 88
-const STRICT_MAX = 1950
+const CORE_MAX = 77
+const STRICT_MAX = 1939
 
 /** Runs tsc against one config and returns its error count plus raw output. */
 function typecheck(project) {

--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -26,8 +26,8 @@
 
 import { spawnSync } from 'node:child_process'
 
-const CORE_MAX = 77
-const STRICT_MAX = 1939
+const CORE_MAX = 69
+const STRICT_MAX = 1931
 
 /** Runs tsc against one config and returns its error count plus raw output. */
 function typecheck(project) {

--- a/src/components/change-orders/ChangeOrderDetail.tsx
+++ b/src/components/change-orders/ChangeOrderDetail.tsx
@@ -116,6 +116,7 @@ const riskVariant = (risk: string) => {
 const createEmptyChangeOrder = (): ChangeOrder => ({
   id: undefined,
   masterId: undefined,
+  itemType: 'ChangeOrder',
   itemNumber: '',
   revision: 'A',
   name: '',

--- a/src/components/documents/DocumentDetail.tsx
+++ b/src/components/documents/DocumentDetail.tsx
@@ -75,6 +75,7 @@ const stateVariant = (state: string) => {
 const createEmptyDocument = (): Document => ({
   id: undefined,
   masterId: undefined,
+  itemType: 'Document',
   itemNumber: '',
   revision: 'A',
   name: '',
@@ -86,7 +87,7 @@ const createEmptyDocument = (): Document => ({
   mimeType: undefined,
   fileId: undefined,
   storagePath: undefined,
-  designId: undefined,
+  designId: '',
   createdAt: undefined,
   modifiedAt: undefined,
 })
@@ -133,7 +134,7 @@ export function DocumentDetail({
     () =>
       initialDocument || {
         ...createEmptyDocument(),
-        designId: defaultDesignId,
+        designId: defaultDesignId ?? '',
       },
   )
   const [isEditing, setIsEditing] = useState(isCreateMode)

--- a/src/components/parts/PartDetail.tsx
+++ b/src/components/parts/PartDetail.tsx
@@ -138,6 +138,7 @@ const stateVariant = (state: string) => {
 const createEmptyPart = (): Part => ({
   id: undefined,
   masterId: undefined,
+  itemType: 'Part',
   itemNumber: '',
   revision: 'A',
   name: '',
@@ -151,7 +152,7 @@ const createEmptyPart = (): Part => ({
   cost: undefined,
   costCurrency: 'USD',
   leadTimeDays: undefined,
-  designId: undefined,
+  designId: '',
   createdAt: undefined,
   modifiedAt: undefined,
 })
@@ -209,7 +210,8 @@ export function PartDetail({
 
   // Part state
   const [part, setPart] = useState<Part>(
-    () => initialPart || { ...createEmptyPart(), designId: defaultDesignId },
+    () =>
+      initialPart || { ...createEmptyPart(), designId: defaultDesignId ?? '' },
   )
   const [isEditing, setIsEditing] = useState(isCreateMode)
   const [isCheckoutDialogOpen, setIsCheckoutDialogOpen] = useState(false)

--- a/src/components/requirements/RequirementDetail.tsx
+++ b/src/components/requirements/RequirementDetail.tsx
@@ -143,6 +143,7 @@ const verificationStatusVariant = (status: string) => {
 const createEmptyRequirement = (): Requirement => ({
   id: undefined,
   masterId: undefined,
+  itemType: 'Requirement',
   itemNumber: '',
   revision: 'A',
   name: '',
@@ -155,7 +156,7 @@ const createEmptyRequirement = (): Requirement => ({
   source: undefined,
   category: undefined,
   acceptanceCriteria: undefined,
-  designId: undefined,
+  designId: '',
   createdAt: undefined,
   modifiedAt: undefined,
   verificationMethod: undefined,
@@ -195,7 +196,7 @@ export function RequirementDetail({
     () =>
       initialRequirement || {
         ...createEmptyRequirement(),
-        designId: defaultDesignId,
+        designId: defaultDesignId ?? '',
       },
   )
   const [isEditing, setIsEditing] = useState(isCreateMode)

--- a/src/components/tasks/TaskDetail.tsx
+++ b/src/components/tasks/TaskDetail.tsx
@@ -75,6 +75,7 @@ const priorityVariant = (priority: string) => {
 const createEmptyTask = (): Task => ({
   id: undefined,
   masterId: undefined,
+  itemType: 'Task',
   itemNumber: '',
   revision: 'A',
   name: '',
@@ -361,7 +362,7 @@ export function TaskDetail({
                     {isEditing ? (
                       <ViewEditText
                         label="Tags (comma-separated)"
-                        value={task.tags.join(', ')}
+                        value={task.tags?.join(', ') ?? ''}
                         onChange={(v) =>
                           updateField(
                             'tags',

--- a/src/components/tests/TestCaseDetail.tsx
+++ b/src/components/tests/TestCaseDetail.tsx
@@ -118,10 +118,10 @@ const executionStatusVariant = (status: string) => {
 const createEmptyTestCase = (): TestCase => ({
   id: undefined,
   masterId: undefined,
+  itemType: 'TestCase',
   itemNumber: '',
   revision: 'A',
   name: '',
-  description: '',
   state: 'Draft',
   isCurrent: true,
   designId: '',
@@ -747,17 +747,6 @@ export function TestCaseDetail({
                   options={STATE_OPTIONS}
                   variant={stateVariant}
                   readOnly={!isCreateMode}
-                />
-                <ViewEditTextarea
-                  label="Description"
-                  value={
-                    isEditing
-                      ? testCase.description
-                      : currentTestCase.description
-                  }
-                  onChange={(v) => updateField('description', v)}
-                  isEditing={isEditing}
-                  className="md:col-span-2"
                 />
                 {testPlan && (
                   <ViewEditStatic

--- a/src/components/tests/TestCaseDetail.tsx
+++ b/src/components/tests/TestCaseDetail.tsx
@@ -124,7 +124,7 @@ const createEmptyTestCase = (): TestCase => ({
   description: '',
   state: 'Draft',
   isCurrent: true,
-  designId: undefined,
+  designId: '',
   testPlanId: undefined,
   testType: undefined,
   preconditions: undefined,
@@ -169,7 +169,7 @@ export function TestCaseDetail({
     () =>
       initialTestCase || {
         ...createEmptyTestCase(),
-        designId: defaultDesignId,
+        designId: defaultDesignId ?? '',
         testPlanId: defaultTestPlanId,
       },
   )

--- a/src/components/tests/TestPlanDetail.tsx
+++ b/src/components/tests/TestPlanDetail.tsx
@@ -92,10 +92,10 @@ const statusVariant = (status: string) => {
 const createEmptyTestPlan = (): TestPlan => ({
   id: undefined,
   masterId: undefined,
+  itemType: 'TestPlan',
   itemNumber: '',
   revision: 'A',
   name: '',
-  description: '',
   state: 'Draft',
   isCurrent: true,
   designId: '',
@@ -529,17 +529,6 @@ export function TestPlanDetail({
                   options={STATE_OPTIONS}
                   variant={stateVariant}
                   readOnly={!isCreateMode}
-                />
-                <ViewEditTextarea
-                  label="Description"
-                  value={
-                    isEditing
-                      ? testPlan.description
-                      : currentTestPlan.description
-                  }
-                  onChange={(v) => updateField('description', v)}
-                  isEditing={isEditing}
-                  className="md:col-span-2"
                 />
                 {(isCreateMode || !currentTestPlan.designId) &&
                   designs.length > 0 && (

--- a/src/components/tests/TestPlanDetail.tsx
+++ b/src/components/tests/TestPlanDetail.tsx
@@ -98,7 +98,7 @@ const createEmptyTestPlan = (): TestPlan => ({
   description: '',
   state: 'Draft',
   isCurrent: true,
-  designId: undefined,
+  designId: '',
   scope: undefined,
   environment: undefined,
   entryCriteria: undefined,
@@ -139,7 +139,7 @@ export function TestPlanDetail({
     () =>
       initialTestPlan || {
         ...createEmptyTestPlan(),
-        designId: defaultDesignId,
+        designId: defaultDesignId ?? '',
       },
   )
   const [isEditing, setIsEditing] = useState(isCreateMode)


### PR DESCRIPTION
> **Stacked on #33** (which is stacked on #32) — shared ceiling constants. I'll retarget each to `main` myself as its parent merges.

**Collection PR: the `createEmpty*()` literals behind every item detail component's create mode.** One copy-pasted pattern, three defects, 11 errors.

## The three defects

**1. `designId: undefined`** in all five of Part/Document/Requirement/TestCase/TestPlan. These item types override `BaseItem`'s optional `designId` to a **required `string`**. Set to `''` instead — matching the `itemNumber: ''` and `name: ''` already sitting in the same literals. Nothing compares `designId` to `undefined` (only truthiness), and the Zod uuid check still rejects `''` on submit, so behaviour is unchanged.

**2. `designId: defaultDesignId`** at the five call sites that spread the empty item, where the prop is `string | undefined`. Now `?? ''`.

**3. `itemType` missing entirely** from Part/Document/Requirement/Task/ChangeOrder. **This was masked** — TypeScript reports one error per object literal, so it only surfaced *after* `designId` was fixed. The discriminant every item type requires was simply never set.

That masking is worth noting: the error count went 88 → 83 → and then *revealed* 5 new `TS2741`s. Fixing one layer exposes the next. It's also why the ratchet's exact-count check matters.

## A latent crash found next door

`TaskDetail` rendered `task.tags.join(', ')`, but `Task.tags` is optional. `createEmptyTask` sets `tags: []`, so **create mode was safe** — but any task loaded from the API *without* tags would throw a `TypeError` the moment you opened it. Now `task.tags?.join(', ') ?? ''`.

## Verification

- **CORE 88 → 77, STRICT 1950 → 1939.**
- Gate holds; lint 0 warnings; build green; **1135 unit tests pass**.

## Resolved: the Description field is now deleted

**Owner's call: TestCase/TestPlan aren't fully implemented yet, so the field was aspirational — deleted from the components rather than adding a column.** The type system was right; the UI was wrong.

Removed the textarea and the `description: ''` seed from both `createEmpty*()` literals. The confirm-dialog `description` options in the same files are `AlertOptions` and are untouched.

Removing it **unmasked the same missing `itemType`** the sibling five had — TypeScript reports one error per object literal — so both now set it too. Same masking effect as above, twice over.

**Final: CORE 88 → 69, STRICT 1950 → 1931.** Gate holds; lint clean; build green; 1135 tests pass.
