### PR TITLE
Fix permission resources — AI settings were unsaveable (CORE 69→65)

### DIFF
--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -26,8 +26,8 @@
 
 import { spawnSync } from 'node:child_process'
 
-const CORE_MAX = 69
-const STRICT_MAX = 1931
+const CORE_MAX = 65
+const STRICT_MAX = 1927
 
 /** Runs tsc against one config and returns its error count plus raw output. */
 function typecheck(project) {

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -23,6 +23,12 @@ export type ResourceType =
   | 'requirements'
   | 'tasks'
   | 'tools'
+  // Mapped to from itemType in server/routes/items.ts. No role grants these
+  // yet, and hasPermission() denies any resource a role does not declare, so
+  // TestPlan/TestCase items stay inaccessible until those features land and
+  // ROLE_DEFINITIONS below is extended.
+  | 'test_plans'
+  | 'test_cases'
   | 'work_instructions'
   | 'work_orders'
   | 'issues'

--- a/src/server/routes/ai.ts
+++ b/src/server/routes/ai.ts
@@ -460,7 +460,11 @@ app.post(
   '/settings',
   adapt(
     apiHandler(
-      { permission: ['ai_settings', 'create'] },
+      // 'ai_settings' was never a ResourceType, and hasPermission() denies any
+      // resource no role declares - so this endpoint 403'd for everyone,
+      // Global Admin included. Admin config is 'system' everywhere else,
+      // including admin.ts's own AI provider routes.
+      { permission: ['system', 'manage'] },
       async ({ request }) => {
         const body: SettingsRequest = await request.json()
         const { programId, provider, config, enabled = true } = body
@@ -521,7 +525,9 @@ app.put(
   '/settings',
   adapt(
     apiHandler(
-      { permission: ['ai_settings', 'update'] },
+      // See POST /settings above: 'ai_settings' is not a ResourceType, so this
+      // denied everyone. Admin config is 'system' everywhere else.
+      { permission: ['system', 'manage'] },
       async ({ request }) => {
         const body: SettingsRequest = await request.json()
         const { programId, provider, config, enabled } = body


### PR DESCRIPTION
> **Stacked on #34** (→ #33 → #32) — shared ceiling constants. I retarget each to `main` as its parent merges.

**Collection PR: every place a permission resource wasn't a `ResourceType`.** TypeScript had flagged all four. One is a live access-control bug.

## 🔴 AI settings were readable but unsaveable — 403 for everyone

`POST` and `PUT /api/v1/ai/settings` declared `permission: ['ai_settings', ...]`. But `'ai_settings'` is not in `ResourceType`, **no role declares it**, and `hasPermission()` hard-denies any resource absent from a role's permissions:

```ts
if (!(resource in rolePermissions)) return false
```

There's no wildcard. And Global Admin's bypass covers **program/design access, not resource permissions** — it never reaches this check. So both writes returned **403 for every user, including Global Admin**, while `GET /settings` is auth-only and worked fine.

Net effect: **you could read AI settings but never save them.**

Fixed by using `['system', 'manage']` — what every other admin endpoint uses, including `admin.ts`'s own AI provider routes (line 458), and which Global Admin and Administrator both hold (`system: ['read','manage']`). That **restores the endpoints** rather than inventing a resource nobody grants, which would have silenced the type error while leaving the 403 in place.

## `test_plans` / `test_cases` — type fix only, no behaviour change

`server/routes/items.ts` maps those itemTypes to those resources for permission checks, so they belong in `ResourceType`.

**Deliberately NOT granted in `ROLE_DEFINITIONS.`** TestPlan/TestCase are unfinished, so they stay inaccessible exactly as they are today. This is a pure type fix, and the comment in `permissions.ts` says so. Granting them is a policy decision for whoever finishes those features — not something to slip into a typecheck cleanup.

## Verification

- **CORE 69 → 65, STRICT 1931 → 1927.**
- Gate holds; lint clean; build green; **OpenAPI snapshot unchanged**; **1135 unit tests pass**, including all **72 auth/access-control tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc6rXCR5cB2LAWdzU2fxTZ