### PR TITLE
Stop findById() discarding what the DB guarantees (CORE 65→60)

### DIFF
--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -26,8 +26,8 @@
 
 import { spawnSync } from 'node:child_process'
 
-const CORE_MAX = 65
-const STRICT_MAX = 1927
+const CORE_MAX = 60
+const STRICT_MAX = 1922
 
 /** Runs tsc against one config and returns its error count plus raw output. */
 function typecheck(project) {

--- a/src/lib/items/services/ItemService.ts
+++ b/src/lib/items/services/ItemService.ts
@@ -34,7 +34,7 @@ import type {
   VersionContext,
 } from '../../services/VersionResolver'
 import type { ItemHistoryEntry } from '../../services/CommitService'
-import type { BaseItem } from '../types/base'
+import type { BaseItem, PersistedItem } from '../types/base'
 import type { SearchCriteria, SearchResult } from './ItemSearchService'
 import { itemLogger } from '@/lib/logging/logger'
 
@@ -488,7 +488,7 @@ export class ItemService {
   static async findById(
     id: string,
     tx?: TransactionClient,
-  ): Promise<BaseItem | null> {
+  ): Promise<PersistedItem | null> {
     const run = tx ?? db
     const result = await run
       .select()

--- a/src/lib/items/types/base.ts
+++ b/src/lib/items/types/base.ts
@@ -22,6 +22,20 @@ export interface BaseItem {
   usageOf?: string // If set, this is a usage referencing a definition (SysML v2 pattern)
 }
 
+/**
+ * An item as returned by a read path.
+ *
+ * BaseItem marks id/itemNumber/state optional because it doubles as the shape
+ * you pass to create(), where they are not known yet. A row that came back from
+ * the database always has them - all three are NOT NULL columns - so read paths
+ * return this instead and callers stop guarding against states that cannot occur.
+ */
+export type PersistedItem = BaseItem & {
+  id: string
+  itemNumber: string
+  state: string
+}
+
 // Base Zod schema for validation
 export const baseItemSchema = z.object({
   id: z.string().uuid().optional(),

--- a/src/lib/services/ConflictDetectionService.ts
+++ b/src/lib/services/ConflictDetectionService.ts
@@ -360,7 +360,7 @@ export class ConflictDetectionService {
 
         const conflict: ItemConflict = {
           itemMasterId: branchItem.itemMasterId,
-          itemNumber: ourFullItem.itemNumber ?? '',
+          itemNumber: ourFullItem.itemNumber,
           itemName: ourFullItem.name ?? null,
           conflictType: hasFieldConflicts
             ? 'field_conflict'
@@ -368,12 +368,12 @@ export class ConflictDetectionService {
           severity: hasFieldConflicts ? 'error' : 'warning',
 
           ourBranchItemId: branchItem.id,
-          ourItemId: ourFullItem.id ?? '',
+          ourItemId: ourFullItem.id,
           ourRevision: ourFullItem.revision,
           ourBranchId: branch.id,
           ourBranchName: branch.name,
 
-          theirItemId: latestMainItem.id ?? '',
+          theirItemId: latestMainItem.id,
           theirRevision: latestMainItem.revision,
           theirBranchId: mainBranch.id,
           theirBranchName: 'main',
@@ -700,13 +700,13 @@ export class ConflictDetectionService {
           // Other ECO doesn't have a working copy yet, just show as co-modification warning
           conflicts.push({
             itemMasterId: masterId,
-            itemNumber: ourFullItem.itemNumber ?? '',
+            itemNumber: ourFullItem.itemNumber,
             itemName: ourFullItem.name ?? null,
             conflictType: 'cross_eco',
             severity: 'warning',
 
             ourBranchItemId: ourModified.branchItem.id,
-            ourItemId: ourFullItem.id ?? '',
+            ourItemId: ourFullItem.id,
             ourRevision: ourFullItem.revision,
             ourBranchId: ourModified.branchItem.branchId,
             ourBranchName: 'This ECO',
@@ -752,13 +752,13 @@ export class ConflictDetectionService {
 
         conflicts.push({
           itemMasterId: masterId,
-          itemNumber: ourFullItem.itemNumber ?? '',
+          itemNumber: ourFullItem.itemNumber,
           itemName: ourFullItem.name ?? null,
           conflictType: hasFieldConflicts ? 'field_conflict' : 'cross_eco',
           severity: hasFieldConflicts ? 'error' : 'warning',
 
           ourBranchItemId: ourModified.branchItem.id,
-          ourItemId: ourFullItem.id ?? '',
+          ourItemId: ourFullItem.id,
           ourRevision: ourFullItem.revision,
           ourBranchId: ourModified.branchItem.branchId,
           ourBranchName: 'This ECO',

--- a/src/server/routes/change-orders.ts
+++ b/src/server/routes/change-orders.ts
@@ -896,7 +896,7 @@ app.get(
         }
 
         const result: EcoBranchHistory = {
-          ecoNumber: eco.itemNumber ?? '',
+          ecoNumber: eco.itemNumber,
           ecoName: eco.name || '',
           mainBranch: { commits: [] },
           ecoBranches: [],
@@ -1566,7 +1566,7 @@ app.get(
 
         if (affectedDesigns.length === 0) {
           return {
-            ecoNumber: eco.itemNumber ?? '',
+            ecoNumber: eco.itemNumber,
             ecoName: eco.name || '',
             nodes: [],
             edges: [],
@@ -1583,7 +1583,7 @@ app.get(
 
         if (!targetDesign.branchId) {
           return {
-            ecoNumber: eco.itemNumber ?? '',
+            ecoNumber: eco.itemNumber,
             ecoName: eco.name || '',
             nodes: [],
             edges: [],
@@ -1623,7 +1623,7 @@ app.get(
 
         return {
           ...graphData,
-          ecoNumber: eco.itemNumber ?? '',
+          ecoNumber: eco.itemNumber,
           ecoName: eco.name || '',
           affectedDesigns: affectedDesignsWithBranches,
         }

--- a/src/server/routes/designs.ts
+++ b/src/server/routes/designs.ts
@@ -1367,7 +1367,7 @@ app.post(
         chainItemIds.map(async (id: string) => {
           const item = await ItemService.findById(id)
           if (!item || !item.id) throw new NotFoundError('Item', id)
-          return item as typeof item & { id: string; itemNumber: string }
+          return item
         }),
       )
 

--- a/src/server/routes/items.ts
+++ b/src/server/routes/items.ts
@@ -1826,7 +1826,7 @@ app.get(
           if (isUsage && item.usageOf) {
             const definition = await ItemService.findById(item.usageOf)
             if (definition) {
-              definitionItemNumber = definition.itemNumber ?? undefined
+              definitionItemNumber = definition.itemNumber
             }
           }
 
@@ -2648,7 +2648,7 @@ app.get(
             hasColors: (f as any).cadMetadata?.hasColors ?? false,
             source: 'cad_doc' as const,
             sourceItemId: rel.targetId,
-            sourceItemNumber: rel.targetItem!.itemNumber ?? null,
+            sourceItemNumber: rel.targetItem!.itemNumber,
           }))
 
         relatedCADFiles.push(...viewable)


### PR DESCRIPTION
> **Stacked on #35** (→ #34 → #33 → #32). I retarget each to `main` as its parent merges.

I went looking for the AI tool-shape errors and found they weren't an AI problem at all — **68% of the remaining CORE errors (44 of 65) involve `string | undefined` from one root cause.**

## The root cause

`BaseItem` marks `id`/`itemNumber`/`state` optional because it **doubles as the shape passed to `create()`**, where they aren't known yet. But all three are `NOT NULL` columns, and `findById()` returns the Drizzle row verbatim:

```ts
return { ...item, ...typeSpecificData }
```

So `Promise<BaseItem | null>` was **throwing away information the query already guarantees**, and every caller had to re-guard against a state that cannot occur.

Adds `PersistedItem = BaseItem & { id: string; itemNumber: string; state: string }` and returns it from `findById()`. **Pure annotation change — the runtime value is identical.**

## The evidence this was the real problem

`server/routes/designs.ts` had **already hand-rolled the same idea locally**:

```ts
return item as typeof item & { id: string; itemNumber: string }
```

Someone hit this exact wall and worked around the annotation instead of fixing it. That cast is now redundant and gone.

## Dead code it exposed

Tightening the type made **13 defensive fallbacks provably dead** — `ourFullItem.itemNumber ?? ''`, `eco.itemNumber ?? ''`, etc. across conflict detection and the ECO routes. All removed; lint stays at zero warnings.

This is the same dynamic as the typescript-eslint bump in #27: better types reveal dead defensive code. The difference is that here the improvement is *deliberate*.

## Verification

- **CORE 65 → 60, STRICT 1927 → 1922.**
- Gate holds; lint 0 warnings; build green; **1135 unit tests pass** (this touches conflict detection and ECO routes, so that matters).

## Deliberate scope limit

Only `findById()`. The other read paths — `findByNumber`, `searchByItemNumber`, `getRelated`, `getAtContext` — **delegate** to `ItemSearchService` and `ItemVersioningFacade`, so widening them means verifying those return raw rows too. Worth doing; not worth bundling here unverified.

Doing so should clear a good chunk of the remaining `string | undefined` errors — the single biggest lever left on CORE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc6rXCR5cB2LAWdzU2fxTZ