### PR TITLE
Land #35 + #36 on main (they merged into stacked branches, not main)

### DIFF
--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -26,8 +26,8 @@
 
 import { spawnSync } from 'node:child_process'
 
-const CORE_MAX = 65
-const STRICT_MAX = 1927
+const CORE_MAX = 60
+const STRICT_MAX = 1922
 
 /** Runs tsc against one config and returns its error count plus raw output. */
 function typecheck(project) {

--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -26,8 +26,8 @@
 
 import { spawnSync } from 'node:child_process'
 
-const CORE_MAX = 69
-const STRICT_MAX = 1931
+const CORE_MAX = 65
+const STRICT_MAX = 1927
 
 /** Runs tsc against one config and returns its error count plus raw output. */
 function typecheck(project) {

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -23,6 +23,12 @@ export type ResourceType =
   | 'requirements'
   | 'tasks'
   | 'tools'
+  // Mapped to from itemType in server/routes/items.ts. No role grants these
+  // yet, and hasPermission() denies any resource a role does not declare, so
+  // TestPlan/TestCase items stay inaccessible until those features land and
+  // ROLE_DEFINITIONS below is extended.
+  | 'test_plans'
+  | 'test_cases'
   | 'work_instructions'
   | 'work_orders'
   | 'issues'

--- a/src/lib/items/services/ItemService.ts
+++ b/src/lib/items/services/ItemService.ts
@@ -34,7 +34,7 @@ import type {
   VersionContext,
 } from '../../services/VersionResolver'
 import type { ItemHistoryEntry } from '../../services/CommitService'
-import type { BaseItem } from '../types/base'
+import type { BaseItem, PersistedItem } from '../types/base'
 import type { SearchCriteria, SearchResult } from './ItemSearchService'
 import { itemLogger } from '@/lib/logging/logger'
 
@@ -488,7 +488,7 @@ export class ItemService {
   static async findById(
     id: string,
     tx?: TransactionClient,
-  ): Promise<BaseItem | null> {
+  ): Promise<PersistedItem | null> {
     const run = tx ?? db
     const result = await run
       .select()

--- a/src/lib/items/types/base.ts
+++ b/src/lib/items/types/base.ts
@@ -22,6 +22,20 @@ export interface BaseItem {
   usageOf?: string // If set, this is a usage referencing a definition (SysML v2 pattern)
 }
 
+/**
+ * An item as returned by a read path.
+ *
+ * BaseItem marks id/itemNumber/state optional because it doubles as the shape
+ * you pass to create(), where they are not known yet. A row that came back from
+ * the database always has them - all three are NOT NULL columns - so read paths
+ * return this instead and callers stop guarding against states that cannot occur.
+ */
+export type PersistedItem = BaseItem & {
+  id: string
+  itemNumber: string
+  state: string
+}
+
 // Base Zod schema for validation
 export const baseItemSchema = z.object({
   id: z.string().uuid().optional(),

--- a/src/lib/services/ConflictDetectionService.ts
+++ b/src/lib/services/ConflictDetectionService.ts
@@ -360,7 +360,7 @@ export class ConflictDetectionService {
 
         const conflict: ItemConflict = {
           itemMasterId: branchItem.itemMasterId,
-          itemNumber: ourFullItem.itemNumber ?? '',
+          itemNumber: ourFullItem.itemNumber,
           itemName: ourFullItem.name ?? null,
           conflictType: hasFieldConflicts
             ? 'field_conflict'
@@ -368,12 +368,12 @@ export class ConflictDetectionService {
           severity: hasFieldConflicts ? 'error' : 'warning',
 
           ourBranchItemId: branchItem.id,
-          ourItemId: ourFullItem.id ?? '',
+          ourItemId: ourFullItem.id,
           ourRevision: ourFullItem.revision,
           ourBranchId: branch.id,
           ourBranchName: branch.name,
 
-          theirItemId: latestMainItem.id ?? '',
+          theirItemId: latestMainItem.id,
           theirRevision: latestMainItem.revision,
           theirBranchId: mainBranch.id,
           theirBranchName: 'main',
@@ -700,13 +700,13 @@ export class ConflictDetectionService {
           // Other ECO doesn't have a working copy yet, just show as co-modification warning
           conflicts.push({
             itemMasterId: masterId,
-            itemNumber: ourFullItem.itemNumber ?? '',
+            itemNumber: ourFullItem.itemNumber,
             itemName: ourFullItem.name ?? null,
             conflictType: 'cross_eco',
             severity: 'warning',
 
             ourBranchItemId: ourModified.branchItem.id,
-            ourItemId: ourFullItem.id ?? '',
+            ourItemId: ourFullItem.id,
             ourRevision: ourFullItem.revision,
             ourBranchId: ourModified.branchItem.branchId,
             ourBranchName: 'This ECO',
@@ -752,13 +752,13 @@ export class ConflictDetectionService {
 
         conflicts.push({
           itemMasterId: masterId,
-          itemNumber: ourFullItem.itemNumber ?? '',
+          itemNumber: ourFullItem.itemNumber,
           itemName: ourFullItem.name ?? null,
           conflictType: hasFieldConflicts ? 'field_conflict' : 'cross_eco',
           severity: hasFieldConflicts ? 'error' : 'warning',
 
           ourBranchItemId: ourModified.branchItem.id,
-          ourItemId: ourFullItem.id ?? '',
+          ourItemId: ourFullItem.id,
           ourRevision: ourFullItem.revision,
           ourBranchId: ourModified.branchItem.branchId,
           ourBranchName: 'This ECO',

--- a/src/server/routes/ai.ts
+++ b/src/server/routes/ai.ts
@@ -460,7 +460,11 @@ app.post(
   '/settings',
   adapt(
     apiHandler(
-      { permission: ['ai_settings', 'create'] },
+      // 'ai_settings' was never a ResourceType, and hasPermission() denies any
+      // resource no role declares - so this endpoint 403'd for everyone,
+      // Global Admin included. Admin config is 'system' everywhere else,
+      // including admin.ts's own AI provider routes.
+      { permission: ['system', 'manage'] },
       async ({ request }) => {
         const body: SettingsRequest = await request.json()
         const { programId, provider, config, enabled = true } = body
@@ -521,7 +525,9 @@ app.put(
   '/settings',
   adapt(
     apiHandler(
-      { permission: ['ai_settings', 'update'] },
+      // See POST /settings above: 'ai_settings' is not a ResourceType, so this
+      // denied everyone. Admin config is 'system' everywhere else.
+      { permission: ['system', 'manage'] },
       async ({ request }) => {
         const body: SettingsRequest = await request.json()
         const { programId, provider, config, enabled } = body

--- a/src/server/routes/change-orders.ts
+++ b/src/server/routes/change-orders.ts
@@ -896,7 +896,7 @@ app.get(
         }
 
         const result: EcoBranchHistory = {
-          ecoNumber: eco.itemNumber ?? '',
+          ecoNumber: eco.itemNumber,
           ecoName: eco.name || '',
           mainBranch: { commits: [] },
           ecoBranches: [],
@@ -1566,7 +1566,7 @@ app.get(
 
         if (affectedDesigns.length === 0) {
           return {
-            ecoNumber: eco.itemNumber ?? '',
+            ecoNumber: eco.itemNumber,
             ecoName: eco.name || '',
             nodes: [],
             edges: [],
@@ -1583,7 +1583,7 @@ app.get(
 
         if (!targetDesign.branchId) {
           return {
-            ecoNumber: eco.itemNumber ?? '',
+            ecoNumber: eco.itemNumber,
             ecoName: eco.name || '',
             nodes: [],
             edges: [],
@@ -1623,7 +1623,7 @@ app.get(
 
         return {
           ...graphData,
-          ecoNumber: eco.itemNumber ?? '',
+          ecoNumber: eco.itemNumber,
           ecoName: eco.name || '',
           affectedDesigns: affectedDesignsWithBranches,
         }

--- a/src/server/routes/designs.ts
+++ b/src/server/routes/designs.ts
@@ -1367,7 +1367,7 @@ app.post(
         chainItemIds.map(async (id: string) => {
           const item = await ItemService.findById(id)
           if (!item || !item.id) throw new NotFoundError('Item', id)
-          return item as typeof item & { id: string; itemNumber: string }
+          return item
         }),
       )
 

--- a/src/server/routes/items.ts
+++ b/src/server/routes/items.ts
@@ -1826,7 +1826,7 @@ app.get(
           if (isUsage && item.usageOf) {
             const definition = await ItemService.findById(item.usageOf)
             if (definition) {
-              definitionItemNumber = definition.itemNumber ?? undefined
+              definitionItemNumber = definition.itemNumber
             }
           }
 
@@ -2648,7 +2648,7 @@ app.get(
             hasColors: (f as any).cadMetadata?.hasColors ?? false,
             source: 'cad_doc' as const,
             sourceItemId: rel.targetId,
-            sourceItemNumber: rel.targetItem!.itemNumber ?? null,
+            sourceItemNumber: rel.targetItem!.itemNumber,
           }))
 
         relatedCADFiles.push(...viewable)


### PR DESCRIPTION
## Why this exists

**#35 and #36 show MERGED, but their commits never reached `main`.** GitHub marked them merged because they merged into their *stacked base branches* (`fix-assignability`, `fix-ai-tool-types`), which weren't deleted, so no auto-retarget happened — the same trap as #30/#31, one level deeper because the stack was six PRs tall.

Proof `main` is missing them: its ceilings read `CORE 69 / STRICT 1931`, and `PersistedItem`, `test_plans`/`test_cases` in `ResourceType`, and the `ai_settings` → `system` permission fix are all absent.

This is my fault for stacking that deep instead of retargeting each PR to `main` as its parent merged. I'll stop stacking now that `main` is caught up.

## What's in it

The two orphaned commits, **cherry-picked onto current `main`** (not the divergent branch, so nothing already-merged reapplies):

- **b5fcd90** — #35: permission resources. `ai_settings` writes 403'd for everyone (`ai_settings` isn't a `ResourceType`, no role grants it, no Global Admin bypass on resource perms); switched to `['system','manage']`. Added `test_plans`/`test_cases` to `ResourceType` without granting them.
- **b85736d** — #36: `PersistedItem` on `findById()`, removing 13 now-dead null guards.

Both cherry-picks applied with **no conflicts**.

## Verification (on this branch, against fresh `main`)

- **CORE 69 → 60, STRICT 1931 → 1922.**
- Gate holds; lint 0 warnings; build green; **1135 unit tests pass**.

Full rationale in #35 and #36 — nothing here is new code, only correctly-placed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc6rXCR5cB2LAWdzU2fxTZ