### PR TITLE
Extend + complete PersistedItem (CORE 60→55)

### DIFF
--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -26,8 +26,8 @@
 
 import { spawnSync } from 'node:child_process'
 
-const CORE_MAX = 60
-const STRICT_MAX = 1922
+const CORE_MAX = 55
+const STRICT_MAX = 1917
 
 /** Runs tsc against one config and returns its error count plus raw output. */
 function typecheck(project) {

--- a/src/lib/ai/tools/handlers.ts
+++ b/src/lib/ai/tools/handlers.ts
@@ -276,9 +276,9 @@ export const getItemDetailsHandler = withPermissionAndAudit(
       state,
       itemType,
       designId: designId ?? null,
-      createdAt: createdAt?.toISOString() ?? new Date().toISOString(),
+      createdAt: createdAt.toISOString(),
       createdBy,
-      modifiedAt: modifiedAt?.toISOString() ?? new Date().toISOString(),
+      modifiedAt: modifiedAt.toISOString(),
       modifiedBy,
       typeSpecificData:
         Object.keys(typeSpecificData).length > 0 ? typeSpecificData : undefined,

--- a/src/lib/items/services/ChangeOrderService.ts
+++ b/src/lib/items/services/ChangeOrderService.ts
@@ -210,7 +210,7 @@ export class ChangeOrderService {
 
       // Check if working copy already exists on this branch (idempotency)
       const existingWorkingCopy = await this.findExistingWorkingCopy(
-        affectedItem.masterId!,
+        affectedItem.masterId,
         ecoDesign.branchId,
       )
 
@@ -758,9 +758,7 @@ export class ChangeOrderService {
           valid: false,
           severity: 'warning',
           message: `${unreleased.length} BOM components are not released`,
-          affectedItems: unreleased
-            .map((u) => u.itemNumber)
-            .filter((n): n is string => n !== undefined),
+          affectedItems: unreleased.map((u) => u.itemNumber),
           suggestion: 'Add these items to change order with "release" action',
         }
       }
@@ -1328,7 +1326,7 @@ export class ChangeOrderService {
     if (item.state === 'Released') {
       // Check if working copy already exists
       const existingWorkingCopy = await this.findExistingWorkingCopy(
-        item.masterId!,
+        item.masterId,
         branch.id,
       )
 
@@ -1342,7 +1340,7 @@ export class ChangeOrderService {
           .where(
             and(
               eq(branchItems.branchId, branch.id),
-              eq(branchItems.itemMasterId, item.masterId!),
+              eq(branchItems.itemMasterId, item.masterId),
             ),
           )
           .limit(1)
@@ -1363,7 +1361,7 @@ export class ChangeOrderService {
       // For non-released items, use standard checkout
       branchItem = await CheckoutService.checkout(
         {
-          itemMasterId: item.masterId!,
+          itemMasterId: item.masterId,
           branchId: branch.id,
         },
         userId,
@@ -1377,7 +1375,7 @@ export class ChangeOrderService {
       .where(
         and(
           eq(changeOrderAffectedItems.changeOrderId, changeOrderId),
-          eq(changeOrderAffectedItems.affectedItemMasterId, item.masterId!),
+          eq(changeOrderAffectedItems.affectedItemMasterId, item.masterId),
         ),
       )
       .limit(1)
@@ -1386,7 +1384,7 @@ export class ChangeOrderService {
       await db.insert(changeOrderAffectedItems).values({
         changeOrderId,
         affectedItemId: itemId,
-        affectedItemMasterId: item.masterId!,
+        affectedItemMasterId: item.masterId,
         changeAction: item.state === 'Released' ? 'revise' : 'release',
         currentState: item.state,
         currentRevision: item.revision,

--- a/src/lib/items/services/ItemRelationshipService.ts
+++ b/src/lib/items/services/ItemRelationshipService.ts
@@ -8,7 +8,7 @@ import { NotFoundError } from '../../errors'
 import { BranchService } from '../../services/BranchService'
 import { CommitService } from '../../services/CommitService'
 import { ThreadCacheService } from '../../services/ThreadCacheService'
-import type { BaseItem } from '../types/base'
+import type { PersistedItem } from '../types/base'
 import { itemLogger } from '@/lib/logging/logger'
 
 /**
@@ -22,7 +22,7 @@ export class ItemRelationshipService {
   static async getRelated(
     id: string,
     relationshipType?: string,
-  ): Promise<Array<BaseItem>> {
+  ): Promise<Array<PersistedItem>> {
     // Lazy import to avoid circular dependency
     const { ItemService } = await import('./ItemService')
 
@@ -39,7 +39,7 @@ export class ItemRelationshipService {
       relationships.map((rel) => ItemService.findById(rel.targetId)),
     )
 
-    return relatedItems.filter((item): item is BaseItem => item !== null)
+    return relatedItems.filter((item): item is PersistedItem => item !== null)
   }
 
   /**
@@ -105,7 +105,7 @@ export class ItemRelationshipService {
       .where(
         and(
           eq(branchItems.branchId, mainBranch.id),
-          eq(branchItems.itemMasterId, item.masterId!),
+          eq(branchItems.itemMasterId, item.masterId),
         ),
       )
       .limit(1)

--- a/src/lib/items/services/ItemService.ts
+++ b/src/lib/items/services/ItemService.ts
@@ -519,7 +519,7 @@ export class ItemService {
   static async findByNumber(
     itemNumber: string,
     revision?: string,
-  ): Promise<BaseItem | null> {
+  ): Promise<PersistedItem | null> {
     const query = revision
       ? and(
           eq(items.itemNumber, itemNumber),
@@ -593,7 +593,7 @@ export class ItemService {
   static async getRelated(
     id: string,
     relationshipType?: string,
-  ): Promise<Array<BaseItem>> {
+  ): Promise<Array<PersistedItem>> {
     return ItemRelationshipService.getRelated(id, relationshipType)
   }
 

--- a/src/lib/items/types/base.ts
+++ b/src/lib/items/types/base.ts
@@ -25,15 +25,22 @@ export interface BaseItem {
 /**
  * An item as returned by a read path.
  *
- * BaseItem marks id/itemNumber/state optional because it doubles as the shape
- * you pass to create(), where they are not known yet. A row that came back from
- * the database always has them - all three are NOT NULL columns - so read paths
- * return this instead and callers stop guarding against states that cannot occur.
+ * BaseItem marks these fields optional because it doubles as the shape you pass
+ * to create(), where they are not known yet. Every field overridden here is a
+ * NOT NULL column on the `items` table, so a row that came back from the
+ * database always has it - read paths return this instead and callers stop
+ * guarding against states that cannot occur. (revision and itemType are already
+ * required on BaseItem, so they don't need repeating.)
  */
 export type PersistedItem = BaseItem & {
   id: string
+  masterId: string
   itemNumber: string
   state: string
+  createdAt: Date
+  createdBy: string
+  modifiedAt: Date
+  modifiedBy: string
 }
 
 // Base Zod schema for validation

--- a/src/lib/services/ChangeOrderMergeService.ts
+++ b/src/lib/services/ChangeOrderMergeService.ts
@@ -438,7 +438,7 @@ export class ChangeOrderMergeService {
                       isCurrent: false,
                       state: oldVersionState || 'Superseded',
                     })
-                    .where(eq(items.masterId, item.masterId!))
+                    .where(eq(items.masterId, item.masterId))
 
                   // Calculate final revision - if placeholder (starts with "-"), use next revision from source item
                   const reviseScheme = await LifecycleService.getRevisionScheme(

--- a/src/server/routes/items.ts
+++ b/src/server/routes/items.ts
@@ -1252,7 +1252,7 @@ app.get(
 
       // Get item at specific context
       const item = await ItemService.getAtContext(
-        baseItem.masterId!,
+        baseItem.masterId,
         baseItem.designId,
         context,
       )
@@ -1384,7 +1384,7 @@ app.delete(
 
       // Soft delete on branch
       const commit = await ItemService.deleteOnBranch(
-        item.masterId!,
+        item.masterId,
         branchId,
         commitMessage || `Deleted ${item.itemNumber}`,
         user.id,
@@ -1466,7 +1466,7 @@ app.get(
 
       // Get the item at the specified version context
       const itemAtContext = await VersionResolver.getItemAtContext(
-        baseItem.masterId!,
+        baseItem.masterId,
         baseItem.designId,
         context,
       )
@@ -1566,7 +1566,7 @@ app.get(
 
       // Get available contexts for the item
       const contexts = await VersionResolver.getAvailableContextsForItem(
-        item.masterId!,
+        item.masterId,
         item.designId,
       )
 
@@ -1596,7 +1596,7 @@ app.post(
       // Check access to branch/design
       await requireBranchAccess(user.id, branchId)
 
-      await CheckoutService.cancelCheckout(item.masterId!, branchId, user.id)
+      await CheckoutService.cancelCheckout(item.masterId, branchId, user.id)
 
       return { success: true }
     }),
@@ -1624,7 +1624,7 @@ app.post(
       // Check access to branch/design
       await requireBranchAccess(user.id, branchId)
 
-      await CheckoutService.checkin(item.masterId!, branchId, user.id)
+      await CheckoutService.checkin(item.masterId, branchId, user.id)
 
       return { success: true }
     }),
@@ -1653,7 +1653,7 @@ app.get(
       await requireBranchAccess(user.id, branchId)
 
       const status = await CheckoutService.getCheckoutStatus(
-        item.masterId!,
+        item.masterId,
         branchId,
       )
 
@@ -1684,7 +1684,7 @@ app.post(
       await requireBranchAccess(user.id, branchId)
 
       const branchItem = await CheckoutService.checkout(
-        { itemMasterId: item.masterId!, branchId },
+        { itemMasterId: item.masterId, branchId },
         user.id,
       )
 
@@ -1711,7 +1711,7 @@ app.delete(
         throw new NotFoundError('Item', params.id)
       }
 
-      await CheckoutService.cancelCheckout(item.masterId!, branchId, user.id)
+      await CheckoutService.cancelCheckout(item.masterId, branchId, user.id)
 
       return { success: true }
     }),
@@ -2101,7 +2101,7 @@ app.get(
 
       // designId and masterId are guaranteed to be non-null at this point (checked above)
       const history = await ItemService.getHistory(
-        item.masterId!,
+        item.masterId,
         item.designId,
         {
           untilCommitId,


### PR DESCRIPTION
Follow-up to #36. Branches from `main` directly — **no more stacking**, so this can't strand commits on a dead branch the way #35/#36 did.

## Two parts

### 1. Complete `PersistedItem`

#36 only overrode `id`/`itemNumber`/`state` — the three fields that happened to error at the time. But `masterId`, `createdAt`, `createdBy`, `modifiedAt`, `modifiedBy` are **all `NOT NULL` columns** on `items` too, so a read always has them. The AI `get_item_details` tool output requires `masterId`/`createdBy`/`modifiedBy` as `string`, which surfaced the moment `id` was fixed.

Added all five, so `PersistedItem` now **matches the schema** rather than just the fields that complained. This is the "fixing one layer reveals the next" pattern again — better to model the whole truth than chase errors one at a time.

### 2. Widen the read paths that provably return rows

- **`findByNumber`** — returns `{ ...item, ...typeSpecificData }`, identical to `findById`.
- **`getRelated`** (both `ItemRelationshipService` and the `ItemService` delegator) — filters `findById` results, so every element is a `PersistedItem`. Its type predicate was `item is BaseItem`, which post-#36 narrowed to a **wider** type than `findById` returns (`TS2677`); now `item is PersistedItem`.

**Left alone**, same discipline as #36: `searchByItemNumber` and `getAtContext` delegate into `ItemSearchService` / `ItemVersioningFacade`, whose return shapes I haven't verified return raw rows.

## Dead code exposed

Completing the type made **23 more pieces of defensive code provably dead** — `affectedItem.masterId!`, `item.masterId!`, `createdAt?.toISOString() ?? new Date()`, a `.filter(n => n !== undefined)` over values now typed `string`. All removed; lint stays at zero. That's why **STRICT also dropped (1922 → 1917)**, not just CORE.

## Verification

- **CORE 60 → 55, STRICT 1922 → 1917.**
- Gate holds; lint 0 warnings; build green; **1135 unit tests pass**; **no new error locations** — the widening only removed errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc6rXCR5cB2LAWdzU2fxTZ