### PR TITLE
Fix ConflictDetectionService test fixtures (CORE 55→43)

### DIFF
--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -26,8 +26,8 @@
 
 import { spawnSync } from 'node:child_process'
 
-const CORE_MAX = 55
-const STRICT_MAX = 1917
+const CORE_MAX = 43
+const STRICT_MAX = 1905
 
 /** Runs tsc against one config and returns its error count plus raw output. */
 function typecheck(project) {

--- a/src/lib/services/ConflictDetectionService.test.ts
+++ b/src/lib/services/ConflictDetectionService.test.ts
@@ -1439,7 +1439,7 @@ describe('ConflictDetectionService', () => {
       expect(result.hasConflicts).toBe(true)
       // Should have cross-ECO conflict
       const crossEcoConflicts = result.conflicts.filter(
-        (c) => c.type === 'cross_eco',
+        (c) => c.conflictType === 'cross_eco',
       )
       expect(crossEcoConflicts.length).toBeGreaterThanOrEqual(0) // May be 0 if not yet detected
     })
@@ -1497,7 +1497,7 @@ describe('ConflictDetectionService', () => {
           name: 'Second Design',
           code: `DESIGN2-${Date.now()}`,
           designType: 'Engineering',
-        },
+        } as any,
         user.id,
       )
 
@@ -1514,7 +1514,7 @@ describe('ConflictDetectionService', () => {
           revision: 'A',
           name: 'Part in Design 2',
           state: 'Draft',
-        },
+        } as any,
         user.id,
       )
 
@@ -1572,7 +1572,7 @@ describe('ConflictDetectionService', () => {
           revision: 'A',
           name: 'Brand New Part',
           state: 'Draft',
-        },
+        } as any,
         user.id,
       )
 
@@ -1584,7 +1584,7 @@ describe('ConflictDetectionService', () => {
           itemMasterId: newPart.masterId,
           currentItemId: newPart.id,
           baseItemId: null, // No base - new item
-          isNewItem: true,
+          changeType: 'added',
         })
         .returning()
 
@@ -1598,7 +1598,7 @@ describe('ConflictDetectionService', () => {
           revision: 'B',
           name: 'Base Version',
           state: 'Draft',
-        },
+        } as any,
         user.id,
       )
 
@@ -1668,7 +1668,7 @@ describe('ConflictDetectionService', () => {
           itemMasterId: masterId,
           currentItemId: ourWorkingCopy.id,
           baseItemId: basePart.id, // Explicit base for three-way merge
-          action: 'edit' as const,
+          changeType: 'modified',
         })
         .returning()
 
@@ -1745,7 +1745,7 @@ describe('ConflictDetectionService', () => {
           revision: 'B',
           name: 'Different Name',
           state: 'Draft',
-        },
+        } as any,
         user.id,
       )
 
@@ -1795,7 +1795,7 @@ describe('ConflictDetectionService', () => {
           revision: 'B',
           name: 'New Base',
           state: 'Draft',
-        },
+        } as any,
         user.id,
       )
 


### PR DESCRIPTION
Twelve errors in one test file, three causes — **two of them tests written against APIs that don't exist**, which TypeScript had been flagging all along. Branches from `main`.

## 1. Wrong field name — a filter matching nothing

`c.type === 'cross_eco'` — `ItemConflict` has no `type` field; it's `conflictType` (and `'cross_eco'` is a valid `ConflictType`). So the filter matched nothing, which the adjacent `toBeGreaterThanOrEqual(0)` assertion happily masked. Fixed to `conflictType`.

## 2. Inserts writing columns that don't exist

Two `branchItems` inserts wrote `isNewItem: true` and `action: 'edit'`. The `branch_items` table has **neither** — the column is `changeType` (`'added' | 'modified' | 'deleted'`).

Drizzle drops unknown keys at runtime, so these values **silently never persisted** — the tests' stated intent (mark the item added / edited) never took effect. Replaced with `changeType: 'added'` / `'modified'`. **All 45 tests in the file still pass**, confirming the corrected column doesn't change outcomes.

## 3. `create()` calls missing `itemType`

Five inline `ItemService.create('Part', {...})` calls omitted `itemType`, so the literal failed `T extends BaseItem`, `T` fell back to `BaseItem`, and the result's `id`/`masterId` came back `string | undefined` — which then couldn't feed the `branchItems` inserts.

Matched this file's own `createPartOnMain` helper, which casts the create input `as any`. Same convention, same file.

## The deeper cause (noted, not fixed)

That last group traces to `ItemService.create<T>()` returning `T` — the *input* shape, with optional `id`/`masterId` — even though it always inserts and returns a persisted row. `create()` returning a persisted type (as `findById` now does after #36/#39) would remove the need for the `as any` here. But that's a `create`-signature change touching every caller — out of scope for a test-fixture fix, worth its own PR.

## Verification

- **CORE 55 → 43, STRICT 1917 → 1905.**
- Gate holds; lint 0 warnings; build green; **1135 unit tests pass** (45/45 in the touched file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc6rXCR5cB2LAWdzU2fxTZ