### PR TITLE
Add Serialized<T> for the HTTP boundary; fix Program dates (CORE 43→38)

### DIFF
--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -26,8 +26,8 @@
 
 import { spawnSync } from 'node:child_process'
 
-const CORE_MAX = 43
-const STRICT_MAX = 1905
+const CORE_MAX = 38
+const STRICT_MAX = 1900
 
 /** Runs tsc against one config and returns its error count plus raw output. */
 function typecheck(project) {

--- a/src/lib/types/program.ts
+++ b/src/lib/types/program.ts
@@ -1,6 +1,11 @@
 import type { programs } from '@/lib/db/schema/programs'
+import type { Serialized } from './serialized'
 
-export type Program = typeof programs.$inferSelect & {
+/**
+ * A program as the client receives it: the DB row serialized over HTTP, so
+ * timestamp columns arrive as ISO strings, not Date objects.
+ */
+export type Program = Serialized<typeof programs.$inferSelect> & {
   userRole?: string
 }
 

--- a/src/lib/types/serialized.ts
+++ b/src/lib/types/serialized.ts
@@ -1,0 +1,21 @@
+/**
+ * The shape a value has after a round-trip through JSON over HTTP.
+ *
+ * Drizzle's `$inferSelect` row types describe the DATABASE row - `Date` for
+ * timestamp columns. But a client route never sees a Date: `JSON.stringify`
+ * turns Dates into ISO strings, and the client parses them back as strings.
+ * Typing client-side data with the raw row type is a lie the compiler can't
+ * catch until you call a Date method on a string.
+ *
+ * `Serialized<T>` rewrites that row type to what actually arrives on the
+ * client: every `Date` becomes `string`, recursively through arrays and
+ * nested objects. Use it wherever a `$inferSelect` type crosses the HTTP
+ * boundary into browser code.
+ */
+export type Serialized<T> = T extends Date
+  ? string
+  : T extends Array<infer U>
+    ? Array<Serialized<U>>
+    : T extends object
+      ? { [K in keyof T]: Serialized<T[K]> }
+      : T

--- a/src/routes/programs/$id.tsx
+++ b/src/routes/programs/$id.tsx
@@ -118,7 +118,9 @@ function ProgramDetailPage() {
         code: editProgram.code,
         name: editProgram.name,
         description: editProgram.description || '',
-        status: editProgram.status,
+        // The DB column is a plain varchar (typed `string`), but the Status
+        // control only ever sets one of the four enum values.
+        status: editProgram.status as CreateProgramInput['status'],
         customer: editProgram.customer || '',
         contractNumber: editProgram.contractNumber || '',
         startDate: editProgram.startDate || '',


### PR DESCRIPTION
The last *thematic* cluster: the "Drizzle row type used in browser code" date lie the original plan flagged. Branches from `main`.

## The lie

`programs/$id.tsx` imports `Program = typeof programs.$inferSelect` — the Drizzle **row** type, whose timestamp columns are `Date`. But a client route never sees a `Date`: the API `JSON.stringify`s rows, so `startDate`/`targetEndDate` arrive as **ISO strings**. The type was a lie the compiler could only catch where the code called a date method on a string — exactly the 4 date errors here (`toDateInputValue` wants a `string`; the row type handed it `Date | null`).

## The fix: `Serialized<T>`

A mapped type (`src/lib/types/serialized.ts`) that rewrites a row type to its **post-JSON shape** — every `Date → string`, recursively through arrays and nested objects:

```ts
export type Serialized<T> = T extends Date
  ? string
  : T extends Array<infer U> ? Array<Serialized<U>>
  : T extends object ? { [K in keyof T]: Serialized<T[K]> }
  : T
```

This is the **reusable** fix for the general problem; `Program` is the first consumer:

```ts
export type Program = Serialized<typeof programs.$inferSelect> & { userRole?: string }
```

## Blast radius: measured, zero

`Program` is imported by **10 route/component files**. Widening its dates to `string` produced **zero new errors** in the other nine — confirming they already treated these as strings at runtime. The type just now says what was always true.

## The one non-date error

`status` is a plain `varchar` (typed `string`), but `CreateProgramInput.status` is a four-value enum. The Status control only ever sets one of those four, so it's **cast at the submit boundary with a comment** rather than widening the input type.

## Verification

- **CORE 43 → 38, STRICT 1905 → 1900.**
- Gate holds; lint 0 warnings; build green; **1135 unit tests pass**.

## Follow-up

`Serialized<T>` now exists and can retire the same lie in the other `$inferSelect`-based client types (`design.ts`, `product.ts`). They don't currently error, so I didn't force it here — but they carry the same latent risk and should adopt it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc6rXCR5cB2LAWdzU2fxTZ