### PR TITLE
Fix service-layer type tail (CORE 38→29)

### DIFF
--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -26,8 +26,8 @@
 
 import { spawnSync } from 'node:child_process'
 
-const CORE_MAX = 38
-const STRICT_MAX = 1900
+const CORE_MAX = 29
+const STRICT_MAX = 1891
 
 /** Runs tsc against one config and returns its error count plus raw output. */
 function typecheck(project) {

--- a/src/lib/hooks/useServerDataGrid.ts
+++ b/src/lib/hooks/useServerDataGrid.ts
@@ -126,7 +126,7 @@ export function useServerDataGrid<T>(
 
   // Debounced global search state
   const [debouncedSearch, setDebouncedSearch] = useState(urlState.search)
-  const debounceTimerRef = useRef<NodeJS.Timeout>()
+  const debounceTimerRef = useRef<NodeJS.Timeout | undefined>(undefined)
 
   // Update debounced search when URL search changes
   useEffect(() => {
@@ -145,7 +145,10 @@ export function useServerDataGrid<T>(
     // Convert column filters to server format
     const columnFiltersMap: ServerDataGridParams['columnFilters'] = {}
     for (const filter of urlState.columnFilters) {
-      columnFiltersMap[filter.id] = filter.value
+      // TanStack Table types a filter value as `unknown`; the DataGrid only
+      // ever stores the shapes ServerDataGridParams allows.
+      columnFiltersMap[filter.id] =
+        filter.value as NonNullable<ServerDataGridParams['columnFilters']>[string]
     }
 
     return {
@@ -169,6 +172,9 @@ export function useServerDataGrid<T>(
   // Update URL when state changes
   const updateUrl = useCallback(
     (updates: Record<string, unknown>, resetPage = false) => {
+      // Type assertion for the navigate options since this hook is
+      // route-agnostic and TanStack Router's strict typing requires knowing
+      // the specific route (see useVersionContext for the same pattern).
       navigate({
         search: (prev: Record<string, unknown>) => {
           const newParams = { ...prev, ...updates }
@@ -188,7 +194,7 @@ export function useServerDataGrid<T>(
           return newParams
         },
         replace: true, // Don't add to history stack for state changes
-      })
+      } as Parameters<typeof navigate>[0])
     },
     [navigate],
   )

--- a/src/lib/services/CatalogService.ts
+++ b/src/lib/services/CatalogService.ts
@@ -689,6 +689,6 @@ function hydrateEntry(row: {
     suppliers: row.entry.suppliers,
     designNotes: row.entry.designNotes,
     tags: row.entry.tags,
-    verified: row.entry.verified,
+    verified: row.entry.verified ?? false,
   }
 }

--- a/src/lib/services/ThreadCacheService.ts
+++ b/src/lib/services/ThreadCacheService.ts
@@ -213,7 +213,7 @@ export class ThreadCacheService {
 
     // Drizzle doesn't return row count directly, we need to count affected
     // This is a workaround since PostgreSQL UPDATE doesn't return count in Drizzle
-    return result.rowCount ?? 0
+    return result.count
   }
 
   /**
@@ -321,7 +321,7 @@ export class ThreadCacheService {
       ),
     )
 
-    return result.rowCount ?? 0
+    return result.count
   }
 
   /**
@@ -330,7 +330,7 @@ export class ThreadCacheService {
    */
   static async clearAll(): Promise<number> {
     const result = await db.delete(threadPathCache)
-    return result.rowCount ?? 0
+    return result.count
   }
 
   /**

--- a/src/lib/services/UsageService.ts
+++ b/src/lib/services/UsageService.ts
@@ -13,6 +13,7 @@ import {
 } from '../db/schema/items'
 import { NotFoundError } from '../errors'
 import type { BaseItem } from '../items/types/base'
+import type { TestStep } from '../items/types/testcase'
 
 /**
  * Transaction client type for database operations
@@ -213,7 +214,10 @@ export class UsageService {
     const client = tx ?? db
 
     // 1. Resolve the canonical definition (follows usageOf chain)
-    const definition = await this.resolveDefinition(input.definitionId, client)
+    // Pass tx, not client: resolveDefinition applies its own `?? db` fallback,
+    // and its param is TransactionClient (a transaction), which the
+    // `tx ?? db` union of `client` does not satisfy.
+    const definition = await this.resolveDefinition(input.definitionId, tx)
     if (!definition) {
       throw new NotFoundError('Definition', input.definitionId, {
         operation: 'createUsage',
@@ -742,7 +746,7 @@ export class UsageService {
           testPlanId: (data.testPlanId as string | undefined) ?? null,
           testType: (data.testType as string | undefined) ?? null,
           preconditions: (data.preconditions as string | undefined) ?? null,
-          steps: (data.steps as Array<unknown> | undefined) ?? null,
+          steps: (data.steps as Array<TestStep> | undefined) ?? null,
           executionStatus: (data.executionStatus as string | undefined) ?? null,
           lastExecutedAt: (data.lastExecutedAt as Date | undefined) ?? null,
           lastExecutedBy: (data.lastExecutedBy as string | undefined) ?? null,


### PR DESCRIPTION
Nine errors across four service/hook files, each its own cause. Two are driver/framework-version issues worth calling out. Branches from `main`.

## `ThreadCacheService` (×3) — wrong driver's property name

`result.rowCount` on `UPDATE`/`DELETE`. `rowCount` is **node-postgres's** property; this app uses **postgres-js**, where the affected-row count is `result.count`. Renamed. The `?? 0` fallbacks became dead once `.count` typed as a plain `number`, so they went too.

## `CatalogService` — nullable column onto non-null field

`verified` is `boolean | null` (nullable column) mapped onto a `verified: boolean` result. Now `?? false`, matching the column's own `default(false)`.

## `useServerDataGrid` (×3)

- **`useRef<NodeJS.Timeout>()`** — React 19 made `useRef`'s initial argument **required**; now `useRef<NodeJS.Timeout | undefined>(undefined)`. (A framework-version tightening, like the earlier ones.)
- A column-filter value typed `unknown` by TanStack Table, assigned to the app's concrete filter-value union — cast, since the DataGrid only ever stores those shapes.
- A route-agnostic `navigate()` search updater TanStack can't type (resolves to `never`) — asserted via `Parameters<typeof navigate>[0]`, **the exact pattern `useVersionContext` already uses** for the same reason.

## `UsageService` (×2)

- `resolveDefinition(client)` where `client` is `tx ?? db` — a union the param's `TransactionClient` (a transaction) doesn't accept. Pass `tx` instead; `resolveDefinition` applies its own `?? db`, so it's equivalent.
- A TestCase insert cast `steps` to `Array<unknown>`, but the column is `jsonb().$type<Array<TestStep>>()`; cast to `Array<TestStep>` like the sibling fields.

## Verification

- **CORE 38 → 29, STRICT 1900 → 1891.**
- Gate holds; lint 0 warnings; build green; **1135 unit tests pass** (touches ThreadCache invalidation and UsageService inserts, so that matters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc6rXCR5cB2LAWdzU2fxTZ