### PR TITLE
Fix UI-component type tail (CORE 29→19)

### DIFF
--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -26,8 +26,8 @@
 
 import { spawnSync } from 'node:child_process'
 
-const CORE_MAX = 29
-const STRICT_MAX = 1891
+const CORE_MAX = 19
+const STRICT_MAX = 1881
 
 /** Runs tsc against one config and returns its error count plus raw output. */
 function typecheck(project) {

--- a/src/components/change-orders/WorkflowInstanceEditor.tsx
+++ b/src/components/change-orders/WorkflowInstanceEditor.tsx
@@ -336,13 +336,17 @@ function WorkflowInstanceEditorInner({
       }))
 
       // Extract transitions from edges
-      const updatedTransitions: Array<InstanceWorkflowTransition> = edges.map(
-        (edge) => ({
-          ...edge.data?.transition,
-          fromStateId: edge.source,
-          toStateId: edge.target,
-        }),
-      )
+      // React Flow types an edge's `data` as optional; every edge here is
+      // created with it set, so skip any that somehow lack a transition rather
+      // than emit a partial one.
+      const updatedTransitions: Array<InstanceWorkflowTransition> =
+        edges.flatMap((edge) => {
+          const transition = edge.data?.transition
+          if (!transition) return []
+          return [
+            { ...transition, fromStateId: edge.source, toStateId: edge.target },
+          ]
+        })
 
       const response = await fetch(
         `/api/v1/change-orders/${changeOrderId}/workflow/structure`,

--- a/src/components/dashboard/DashboardCharts.tsx
+++ b/src/components/dashboard/DashboardCharts.tsx
@@ -93,7 +93,7 @@ export function ChangeOrdersChart({ data }: { data: Array<WeeklyDataPoint> }) {
                 className="text-slate-600 dark:text-slate-400"
               />
               <Tooltip
-                labelFormatter={formatDate}
+                labelFormatter={(value) => formatDate(String(value))}
                 contentStyle={{
                   backgroundColor: 'var(--tooltip-bg, #fff)',
                   borderColor: 'var(--tooltip-border, #e2e8f0)',
@@ -146,7 +146,7 @@ export function PartsReleasedChart({ data }: { data: Array<WeeklyDataPoint> }) {
                 className="text-slate-600 dark:text-slate-400"
               />
               <Tooltip
-                labelFormatter={formatDate}
+                labelFormatter={(value) => formatDate(String(value))}
                 contentStyle={{
                   backgroundColor: 'var(--tooltip-bg, #fff)',
                   borderColor: 'var(--tooltip-border, #e2e8f0)',

--- a/src/components/documents/DocumentTable.tsx
+++ b/src/components/documents/DocumentTable.tsx
@@ -145,7 +145,7 @@ export function DocumentTable({
       cell: ({ row }) => (
         <PhaseBadge
           itemType="Document"
-          state={row.original.state}
+          state={row.original.state ?? ''}
           className="text-xs"
         />
       ),

--- a/src/components/parts/CADViewerToolbar.tsx
+++ b/src/components/parts/CADViewerToolbar.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react'
 import { BACKGROUND_PRESETS, MATERIAL_PRESETS } from './CADViewerTypes'
 import type { BackgroundPreset, MaterialPreset } from './CADViewerTypes'
+import { cn } from '@/lib/utils'
 import {
   Button,
   DropdownMenu,
@@ -181,19 +182,18 @@ export function CADViewerToolbar({
               ).map(([key, config]) => (
                 <DropdownMenuRadioItem key={key} value={key}>
                   <span
-                    className="inline-block w-3 h-3 rounded-full mr-2 border border-slate-300 dark:border-slate-600"
+                    className={cn(
+                      'inline-block w-3 h-3 rounded-full mr-2 border border-slate-300 dark:border-slate-600',
+                      key === 'default' &&
+                        hasEmbeddedColors &&
+                        'bg-gradient-to-br from-red-400 via-green-400 to-blue-400',
+                    )}
                     style={{
                       backgroundColor:
                         key === 'default' && hasEmbeddedColors
                           ? undefined
                           : config.color,
                     }}
-                    {...(key === 'default' && hasEmbeddedColors
-                      ? {
-                          className:
-                            'inline-block w-3 h-3 rounded-full mr-2 border border-slate-300 dark:border-slate-600 bg-gradient-to-br from-red-400 via-green-400 to-blue-400',
-                        }
-                      : {})}
                   />
                   {key === 'default' && hasEmbeddedColors
                     ? 'Original Colors'

--- a/src/components/parts/GenerateCadDialog.tsx
+++ b/src/components/parts/GenerateCadDialog.tsx
@@ -115,7 +115,7 @@ export function GenerateCadDialog({
         )
         const job = response.data
         setJobProgress(job.progress)
-        setJobMessage(job.progressMessage)
+        setJobMessage(job.progressMessage ?? '')
 
         if (job.status === 'completed' && job.result) {
           cleanup()

--- a/src/components/parts/PartTable.tsx
+++ b/src/components/parts/PartTable.tsx
@@ -201,7 +201,7 @@ export function PartTable({
       cell: ({ row }) => (
         <PhaseBadge
           itemType="Part"
-          state={row.original.state}
+          state={row.original.state ?? ''}
           className="text-xs"
         />
       ),

--- a/src/lib/tour/tour-steps.ts
+++ b/src/lib/tour/tour-steps.ts
@@ -7,7 +7,6 @@ export const tourSteps: Array<DriveStep> = [
       title: 'Welcome to Cascadia PLM',
       description:
         "Let's take a quick tour of the key features to help you get started with your product lifecycle management.",
-      side: 'over',
       align: 'center',
     },
   },
@@ -114,7 +113,6 @@ export const tourSteps: Array<DriveStep> = [
       title: "You're Ready!",
       description:
         "That's the basics! Start by exploring the Parts library or creating your first Design. You can restart this tour anytime from the help button in the header.",
-      side: 'over',
       align: 'center',
     },
   },

--- a/src/routes/admin/component-catalog.tsx
+++ b/src/routes/admin/component-catalog.tsx
@@ -111,11 +111,21 @@ function ComponentCatalogPage() {
     categories.filter((c) => c.parentId === parentId)
 
   return (
-    <PageContainer
-      title="Component Catalog"
-      icon={<Database className="w-6 h-6" />}
-      description="Manage the reference library of real, purchasable components and raw stock materials"
-    >
+    <PageContainer>
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Database className="w-8 h-8 text-slate-700 dark:text-slate-300" />
+        <div>
+          <h1 className="text-4xl font-bold text-slate-900 dark:text-white">
+            Component Catalog
+          </h1>
+          <p className="text-slate-600 dark:text-slate-400 mt-2">
+            Manage the reference library of real, purchasable components and raw
+            stock materials
+          </p>
+        </div>
+      </div>
+
       <div className="flex gap-6 h-[calc(100vh-12rem)]">
         {/* Category Sidebar */}
         <div className="w-64 flex-shrink-0 overflow-y-auto border-r border-slate-200 dark:border-slate-700 pr-4">


### PR DESCRIPTION
Ten errors across eight components. **Three were latent UI bugs** the compiler had flagged; the rest are library-version tightenings. Branches from `main`.

## Latent bugs

**A page header that never rendered** — `component-catalog` passed `title` / `icon` / `description` props to `PageContainer`, which accepts **none of them** (only `children` / `maxWidth` / `className`). React drops unknown props, so the "Component Catalog" header silently didn't render. Replaced with the inline header markup every other admin page uses (`admin/index.tsx`). *This one changes rendered output — restores a missing header.*

**A className overwritten** — `CADViewerToolbar` set `className` twice on one `<span>`: a static attribute *and* a conditional spread. JSX overwrote the first whenever the gradient branch fired. Merged into one `cn()` call.

**An invalid driver.js side** — `tour-steps` used `side: 'over'`, not a valid `Side` (`'top'|'right'|'bottom'|'left'`). Both steps are elementless (centered welcome/completion popovers), where `side` is ignored anyway. Removed.

## Library-version tightenings

- **recharts 3**: `Tooltip.labelFormatter`'s first arg is now `ReactNode`, not `string`; wrapped `formatDate` as `(v) => formatDate(String(v))`.
- **PartTable / DocumentTable**: `PhaseBadge.state` is `string`, `row.original.state` is `string | undefined`; `?? ''` (`resolvePhase` already returns `null` for an unknown state).
- **GenerateCadDialog**: `setJobMessage` is `useState<string>`, `progressMessage` is `string | null`; `?? ''`.
- **WorkflowInstanceEditor**: React Flow types `edge.data` as optional, so mapping off `edge.data.transition` is possibly-undefined. Switched to `flatMap` that skips any edge lacking a transition rather than spreading a partial one.

## Verification

- **CORE 29 → 19, STRICT 1891 → 1881.**
- Gate holds; lint 0 warnings; build green; **1135 unit tests pass**.

The `component-catalog` header change alters rendered output; it mirrors `admin/index.tsx` exactly and compiles clean, but it's the one thing here worth a visual glance on review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc6rXCR5cB2LAWdzU2fxTZ