### PR TITLE
CORE reaches ZERO — the substantive type errors are gone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,18 +151,20 @@ Keep it at zero. **Do not raise `--max-warnings` in `package.json` to accommodat
 
 ## Typecheck Ratchet
 
-`tsc --noEmit` is not clean yet, so CI ratchets it instead of demanding zero. `npm run typecheck:ci` (`scripts/typecheck.mjs`, run in the **Build** job) enforces two ceilings:
+CI enforces two typecheck ceilings via `npm run typecheck:ci` (`scripts/typecheck.mjs`, run in the **Build** job):
 
-| Ceiling | Config | Start | Behaviour |
-| ------- | ------ | ----- | --------- |
-| **CORE** | `tsconfig.ci.json` (`noUncheckedIndexedAccess` **off**) | 170 | Fails if it rises **or** falls. Fix errors → lower `CORE_MAX` in the same PR. |
-| **STRICT** | `tsconfig.json` (what your editor sees) | 2032 | Fails if it rises; only **warns** when it can be lowered. |
+| Ceiling | Config | Now | Behaviour |
+| ------- | ------ | --- | --------- |
+| **CORE** | `tsconfig.ci.json` (`noUncheckedIndexedAccess` **off**) | **0** | A plain zero gate. Any new error fails CI, exactly like `eslint --max-warnings 0`. |
+| **STRICT** | `tsconfig.json` (what your editor sees) | ~1859 | Fails if it rises; only **warns** when it can be lowered. |
 
-**Neither ceiling may ever be raised to accommodate a new error** — fix the error, exactly like the lint ratchet above. CORE is the priority: it excludes the ~1862 `noUncheckedIndexedAccess` artifacts (`arr[0]`, `map.get()`, loop indices) and isolates the ~170 substantive errors, several of which are real user-visible bugs. STRICT only warns when lowerable because those artifacts shift under any refactor, and a hard lower bound would mean constant line-churn and conflicts between concurrent PRs.
+**CORE is at zero** — the substantive type errors are gone (cleared over PRs #32–#44; several were real user-visible bugs). It now behaves like the lint gate: fix any new error, never raise the ceiling.
 
-**Expect `npm run typecheck` and your editor to disagree.** Your editor and ESLint read `tsconfig.json` (nUIA on, ~2032 errors); `npm run typecheck` reads `tsconfig.ci.json` (nUIA off, ~170). This gap is deliberate. `noUncheckedIndexedAccess` **must** stay on in `tsconfig.json`: `@tanstack/eslint-config` sets `project: true`, which resolves to the nearest file named `tsconfig.json`, and turning it off there makes every legitimate `if (arr[0])` guard a `no-unnecessary-condition` warning — measured at **266 lint problems (35 errors, 231 warnings)**, which `--max-warnings 0` rejects. That is why the CI config is a separate file, not a flag flip.
+**STRICT is the remaining `noUncheckedIndexedAccess` grind** (~1859 `arr[0]`, `map.get()`, loop-index artifacts). It only warns when lowerable because those shift under any refactor, and a hard lower bound would mean constant line-churn and conflicts between concurrent PRs. Lower `STRICT_MAX` deliberately in cleanup PRs; never raise it.
 
-A TypeScript version bump can legitimately shift both counts — review such a change, never rubber-stamp it. When CORE reaches zero, delete `scripts/typecheck.mjs` and `tsconfig.ci.json` and let CI run `npm run typecheck:strict` directly.
+**Expect `npm run typecheck` and your editor to disagree.** Your editor and ESLint read `tsconfig.json` (nUIA on, ~1859 errors); `npm run typecheck` reads `tsconfig.ci.json` (nUIA off, 0). This gap is deliberate. `noUncheckedIndexedAccess` **must** stay on in `tsconfig.json`: `@tanstack/eslint-config` sets `project: true`, which resolves to the nearest file named `tsconfig.json`, and turning it off there makes every legitimate `if (arr[0])` guard a `no-unnecessary-condition` warning — measured at **266 lint problems (35 errors, 231 warnings)**, which `--max-warnings 0` rejects. That is why the CI config is a separate file, not a flag flip.
+
+A TypeScript version bump can legitimately shift both counts — review such a change, never rubber-stamp it. When STRICT also reaches zero, delete `scripts/typecheck.mjs` and `tsconfig.ci.json` and let CI run `npm run typecheck:strict` directly.
 
 ## Documentation Reference
 

--- a/scripts/seed-demo-robot-arm.ts
+++ b/scripts/seed-demo-robot-arm.ts
@@ -431,7 +431,7 @@ if (SKIP_FILES) {
     }
     if (thumbFileId) {
       await ingest(thumbFileId, thumbSrc, `${part.cadFileBase}.png`, 'thumbnail', false)
-      const linkIds = [glbFileId, stepFileId].filter((x): x is string => x !== null)
+      const linkIds = [glbFileId, stepFileId].filter((x): x is NonNullable<typeof x> => x !== null)
       for (const id of linkIds) {
         await db
           .update(vaultFiles)

--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -8,26 +8,26 @@
  * hand-diffing tsc output against a baseline; this automates exactly that.
  *
  *   CORE   (tsconfig.ci.json, noUncheckedIndexedAccess off)
- *          The substantive errors. Drive to zero first - they include real
- *          user-visible bugs. Hard ratchet in BOTH directions: fixing errors
- *          without lowering the ceiling fails, so the number cannot go stale.
+ *          The substantive errors - now at ZERO. This is a plain gate: any
+ *          new error fails CI, exactly like `eslint --max-warnings 0`. It
+ *          reached zero over PRs #32-#44; several were real user-visible bugs.
  *
  *   STRICT (tsconfig.json, as the editor and ESLint see it)
- *          CORE plus the noUncheckedIndexedAccess artifacts. Blocks
- *          regressions, but only WARNS when it could be lowered: these
+ *          CORE plus the noUncheckedIndexedAccess artifacts (~1859 left).
+ *          Blocks regressions, but only WARNS when it could be lowered: these
  *          shift under any refactor, and a hard lower bound would mean
  *          constant line-churn and conflicts between concurrent PRs for
  *          little gain. Lower it deliberately in cleanup PRs.
  *
  * Neither number may be raised to accommodate a new error - fix the error.
- * When CORE reaches 0, delete this script and tsconfig.ci.json and let CI run
- * `npm run typecheck:strict` directly, exactly like `eslint --max-warnings 0`.
+ * When STRICT also reaches 0, delete this script and tsconfig.ci.json and let
+ * CI run `npm run typecheck:strict` directly.
  */
 
 import { spawnSync } from 'node:child_process'
 
-const CORE_MAX = 19
-const STRICT_MAX = 1881
+const CORE_MAX = 0
+const STRICT_MAX = 1859
 
 /** Runs tsc against one config and returns its error count plus raw output. */
 function typecheck(project) {

--- a/src/components/work-instructions/OperationEditor.tsx
+++ b/src/components/work-instructions/OperationEditor.tsx
@@ -28,7 +28,7 @@ interface OperationEditorProps {
     stepId: string,
     data: Partial<WorkInstructionStep>,
   ) => Promise<void>
-  onDeleteStep: (stepId: string) => Promise<void>
+  onDeleteStep: (stepId: string) => void | Promise<void>
   onReorderSteps: (
     steps: Array<{ id: string; orderIndex: number }>,
   ) => Promise<void>

--- a/src/components/work-instructions/StepEditor.tsx
+++ b/src/components/work-instructions/StepEditor.tsx
@@ -37,7 +37,7 @@ interface StepEditorProps {
     stepId: string,
     data: Partial<WorkInstructionStep>,
   ) => Promise<void>
-  onDeleteStep: (stepId: string) => Promise<void>
+  onDeleteStep: (stepId: string) => void | Promise<void>
   onReorderSteps: (
     steps: Array<{ id: string; orderIndex: number }>,
   ) => Promise<void>

--- a/src/lib/ai/KnowledgeService.ts
+++ b/src/lib/ai/KnowledgeService.ts
@@ -143,10 +143,15 @@ export class KnowledgeService {
    */
   private extractFields(schema: z.ZodSchema): Array<FieldDefinition> {
     try {
-      const jsonSchema = zodToJsonSchema(schema, {
-        $refStrategy: 'none',
-        target: 'openApi3',
-      }) as {
+      // zod-to-json-schema's parameter type is built against a different Zod
+      // version's internals than the one installed; the runtime call is fine.
+      const jsonSchema = zodToJsonSchema(
+        schema as unknown as Parameters<typeof zodToJsonSchema>[0],
+        {
+          $refStrategy: 'none',
+          target: 'openApi3',
+        },
+      ) as {
         properties?: Record<string, any>
         required?: Array<string>
       }

--- a/src/lib/errors/handleApiError.ts
+++ b/src/lib/errors/handleApiError.ts
@@ -198,7 +198,7 @@ function logError(
           pgCause.cause instanceof Error
             ? {
                 message: pgCause.cause.message,
-                ...(pgCause.cause as Record<string, unknown>),
+                ...(pgCause.cause as unknown as Record<string, unknown>),
               }
             : pgCause.cause
       }

--- a/src/lib/items/services/ChangeOrderService.ts
+++ b/src/lib/items/services/ChangeOrderService.ts
@@ -1214,7 +1214,7 @@ export class ChangeOrderService {
     return results.map((r) => ({
       id: r.id,
       itemNumber: r.itemNumber,
-      name: r.name,
+      name: r.name ?? '',
       state: r.state,
       changeType: r.changeType,
     }))

--- a/src/lib/items/types/change-order.ts
+++ b/src/lib/items/types/change-order.ts
@@ -155,6 +155,9 @@ export const affectedItemSchema = z.object({
   affectedItemId: z.string().uuid().nullable(),
   affectedItemMasterId: z.string().uuid().nullable(),
   changeAction: changeActionSchema,
+  // The working copy checked out for this affected item (branch_items row),
+  // present on the persisted record returned by addAffectedItem.
+  workingCopyId: z.string().uuid().nullable().optional(),
   currentState: z.string().max(50).nullable(),
   currentRevision: z.string().max(10).nullable(),
   targetState: z.string().max(50).nullable(),

--- a/src/lib/services/ChangeOrderMergeService.test.ts
+++ b/src/lib/services/ChangeOrderMergeService.test.ts
@@ -1090,7 +1090,6 @@ describe('ChangeOrderMergeService', () => {
           itemNumber: originalItem.itemNumber,
           itemType: originalItem.itemType,
           name: originalItem.name,
-          description: originalItem.description,
           state: originalItem.state,
           masterId: originalItem.masterId,
           designId: originalItem.designId,

--- a/src/lib/workflows/WorkflowService.test.ts
+++ b/src/lib/workflows/WorkflowService.test.ts
@@ -18,7 +18,7 @@ import {
 } from 'vitest'
 import { eq } from 'drizzle-orm'
 import { WorkflowService } from './WorkflowService'
-import type { CreateWorkflowInput } from './types'
+import type { CreateWorkflowInput, TransitionAction } from './types'
 import { TestDatabase } from '@/__tests__/helpers/db'
 import { insertTestUser } from '@/__tests__/fixtures/users'
 import { insertTestPart } from '@/__tests__/fixtures/items'
@@ -2595,7 +2595,8 @@ describe('WorkflowService Transition Actions', () => {
                 name: 'Unknown Action',
                 type: 'unknown_type_xyz' as 'update_field',
                 executeOn: 'after',
-                config: {},
+                // Deliberately malformed action for the unknown-type path.
+                config: {} as TransitionAction['config'],
               },
             ],
           },
@@ -4041,7 +4042,7 @@ describe('WorkflowService send_notification Design Access', () => {
 
         const transitions = await WorkflowService.getAvailableTransitions(
           instance.id,
-          actorUser.id,
+          { item: { id: item.id }, user: { id: actorUser.id, roles: [] } },
         )
 
         expect(transitions).toHaveLength(1)

--- a/src/routes/admin/ai.tsx
+++ b/src/routes/admin/ai.tsx
@@ -132,7 +132,7 @@ function AISettingsPage() {
             enabled: s.enabled ?? false,
             provider: s.provider ?? 'openai',
             apiKey: s.config?.apiKey ?? '',
-            model: s.config?.model ?? DEFAULT_MODELS[s.provider ?? 'openai'][0],
+            model: s.config?.model ?? DEFAULT_MODELS[(s.provider ?? 'openai') as ProviderType][0],
             baseURL: s.config?.baseURL ?? '',
           })
           setOriginalSettings({
@@ -140,7 +140,7 @@ function AISettingsPage() {
             enabled: s.enabled ?? false,
             provider: s.provider ?? 'openai',
             apiKey: s.config?.apiKey ?? '',
-            model: s.config?.model ?? DEFAULT_MODELS[s.provider ?? 'openai'][0],
+            model: s.config?.model ?? DEFAULT_MODELS[(s.provider ?? 'openai') as ProviderType][0],
             baseURL: s.config?.baseURL ?? '',
           })
         }

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -303,6 +303,7 @@ app.post(
         // Make a simple test request with minimal tokens using chatStream
         const testMessage = { role: 'user' as const, content: 'Hi' }
         const stream = adapter.chatStream({
+          model,
           messages: [testMessage],
           // `maxTokens` is TanStack AI's portable option; it maps to each
           // provider's native field. `maxOutputTokens` is Gemini's native name
@@ -912,7 +913,9 @@ app.delete(
 // ============================================
 
 const jobListQuerySchema = z.object({
-  status: z.string().optional(),
+  status: z
+    .enum(['pending', 'queued', 'running', 'completed', 'failed', 'cancelled'])
+    .optional(),
   type: z.string().optional(),
   limit: z.coerce.number().int().min(1).max(1000).optional().default(100),
   offset: z.coerce.number().int().min(0).optional().default(0),

--- a/src/server/routes/ai.ts
+++ b/src/server/routes/ai.ts
@@ -201,10 +201,13 @@ app.post(
           ? createSearchTools(toolContext)
           : createServerTools(toolContext)
 
-      // Stream chat response with tools
+      // Stream chat response with tools.
+      // The local ModelMessage shape matches at runtime; TanStack AI's
+      // ConstrainedModelMessage narrows role/content in a way this plain
+      // {role, content} list doesn't satisfy structurally.
       const stream = chat({
         adapter,
-        messages,
+        messages: messages as Parameters<typeof chat>[0]['messages'],
         tools,
         abortController,
       })

--- a/src/server/routes/import.ts
+++ b/src/server/routes/import.ts
@@ -207,11 +207,10 @@ app.post(
           // Issues use free lifecycle - created directly with 'Open' state
           // Issues don't follow Part/Document versioning, so revision is always '-'
 
-          // Convert date strings to Date objects for Drizzle timestamp columns
+          // Convert date strings to Date objects for Drizzle timestamp columns.
+          // Import rows are parsed from CSV/JSON, so this is always a string.
           const reportedDate = row.reportedDate
-            ? row.reportedDate instanceof Date
-              ? row.reportedDate
-              : new Date(row.reportedDate)
+            ? new Date(row.reportedDate)
             : undefined
 
           const issueData = {

--- a/src/server/routes/items.ts
+++ b/src/server/routes/items.ts
@@ -590,7 +590,7 @@ app.post(
           // Create the item using ItemService
           // Use createOnBranch if branchId is provided (for ECO/workspace branches)
           let createdItem: BaseItem
-          const itemData = data as BaseItem & {
+          const itemData = data as unknown as BaseItem & {
             branchId?: string
             commitMessage?: string
           }


### PR DESCRIPTION
**The milestone.** `tsconfig.ci.json` (`noUncheckedIndexedAccess` off) is now **clean**. `CORE_MAX` is set to **0**, so the gate behaves exactly like `eslint --max-warnings 0` — any new substantive type error fails CI. Branches from `main`.

This clears the final 19 errors. Started at **170** eight PRs ago (#32).

## Production fixes — several with real behaviour

- **`admin.ts` AI connection test was missing the required `model` field** on `chatStream` — it would not have run. Added it (`model` is in scope).
- **`admin.ts` job-list `status`** was `z.string()`; `JobService.list` wants `JobStatus`. Made the schema a `z.enum` of the six values — validates rather than casts.
- **`admin/ai.tsx`** indexed `DEFAULT_MODELS` (`Record<ProviderType,…>`) with a raw string; narrowed to `ProviderType`.
- **work-instructions handlers**: `StepEditor`/`OperationEditor` typed `onDeleteStep` as `() => Promise<void>`, but the handler is a sync fire-and-forget `confirm()`. Widened the prop to `() => void | Promise<void>`.
- **`import.ts`** guarded `row.reportedDate instanceof Date` on a value typed `string` (invalid `instanceof` LHS); it's always a string from CSV/JSON.
- **`ChangeOrderService`** coerced a nullable `name` to `''` to match its declared `name: string` return.
- **`ai.ts` / `KnowledgeService`**: version-driven library type mismatches (TanStack AI `ConstrainedModelMessage`; `zod-to-json-schema` built against a different Zod). Runtime shapes are correct — scoped casts with comments.
- **`items.ts` / `handleApiError`**: `Record`/`Error` conversions needing `as unknown`.

## Test/seed fixes — two more tests asserting things that don't exist

- **`affectedItemSchema` was missing `workingCopyId`** — a real column `addAffectedItem` returns (it returns the raw row `as AffectedItem`, and the Zod type omitted the field). The test asserting it was **right**; the schema was incomplete. Added it.
- **`ChangeOrderMergeService.test`** copied `description` off an `items` row — not a column there (it's type-specific). Removed.
- **`WorkflowService.test`** passed a userId string where `getAvailableTransitions` now takes a `GuardContext`; built the context like the passing tests.
- **`seed-demo-robot-arm`**: `randomUUID()` now returns a **branded UUID template type** (newer `@types/node`), so `x is string` failed; narrowed via `NonNullable<typeof x>`.

## The ratchet's endgame

- **CORE: 19 → 0** — now a permanent hard-zero gate.
- **STRICT: 1881 → 1859** — the `noUncheckedIndexedAccess` grind continues to ratchet. When it also reaches 0, `scripts/typecheck.mjs` and `tsconfig.ci.json` retire and CI runs `npm run typecheck:strict` directly.

CLAUDE.md and the script header updated to reflect CORE=0.

## Verification

- Gate holds (CORE 0 / STRICT 1859); lint 0 warnings; build green; **OpenAPI snapshot unchanged**; **1135 unit tests pass**.

## Tally: what the CORE cleanup found

Beyond the type fixes, the compiler surfaced these genuine bugs along the way: AI settings unsaveable (403 for everyone), a `TaskDetail` crash on tasks without tags, a silently-dropped `programId` filter, a wrong dialog button label, an ignored AI token limit, an AI connection test with no `model`, a component-catalog page header that never rendered, an overwritten `className`, an invalid driver.js side, and several tests asserting fields/columns that don't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc6rXCR5cB2LAWdzU2fxTZ