### PR TITLE
Render composed assembly STEP in-house via the CadQuery/OCCT worker

### DIFF
--- a/docs/features/cad-services.md
+++ b/docs/features/cad-services.md
@@ -245,13 +245,13 @@ The stage:
 
 When a part is regenerated, `cascade-recompose.ts` identifies all ancestor assemblies and marks them as stale for recomposition.
 
-## Assembly Composition (KCL)
+## Assembly Composition
 
-After individual part STEP files are generated, assemblies must be composed by positioning child parts relative to each other.
+After individual part STEP files are generated, assemblies are composed by positioning child parts relative to each other. Composition has three parts: an LLM **plans** placements, the plan is serialized to **KCL** as a portable artifact, and the CadQuery/OCCT worker **renders** the composed STEP file into the vault.
 
 ### KCL (KittyCAD Language)
 
-KCL is a domain-specific language for describing CAD assemblies. Cascadia generates KCL code that imports child STEP files and applies spatial transforms (translation, rotation).
+KCL is a domain-specific language for describing CAD assemblies. Cascadia generates KCL code that imports child STEP files and applies spatial transforms (translation, rotation). The KCL is stored on the BOM node (`kclProjectRef`) as a portable side artifact — actual geometry rendering happens in-house via the OCCT worker (below), not via a KittyCAD engine.
 
 A generated KCL project looks like:
 
@@ -289,6 +289,28 @@ The LLM produces a JSON response with:
 - `reasoning`: explanation of the assembly strategy.
 - `placements`: list of transforms (translation + rotation) for each child.
 - `kclCode`: KCL assembly code.
+
+The `placements` list is the engine-agnostic source of truth: each entry carries a `Transform3D` (translation in mm, rotation as Euler XYZ in degrees) plus the child's vault STEP file key. KCL is one serialization of it; the OCCT render consumes it directly.
+
+### STEP Rendering (OCCT Worker)
+
+After planning, the stage submits a `generation.cad.assemble` job (`src/lib/cad-generation/assembly-render.ts`) to the CadQuery worker at `workers/cad-generator/`, which:
+
+1. Resolves each child STEP from the vault by file ID (`get_vault_file()` in the worker's `db.py` — the workers' only vault *read* path; everything else is write-only).
+2. Imports each child with `cq.importers.importStep()` and applies the placement transform (`assembly.py`).
+3. Combines the transformed shapes into a structured `cq.Assembly` with deduplicated part names, exported via XDE so the CAD converter's decomposer can read the output back.
+4. Stores the composed STEP in the vault and returns `{ vaultFileId, fileName, boundingBox }`.
+
+On success the BOM node gets `assemblyComposition = { status: 'complete', assemblyStepFileKey, boundingBox, ... }`. The bounding box feeds the *parent* assembly's planning and overlap validation — this is what makes multi-level composition work, since sub-assemblies have no `cadGeneration.boundingBox` of their own.
+
+**Rotation convention** (pinned by `workers/cad-generator/tests/test_assembly.py`): rotateX → rotateY → rotateZ, each about the **global** axis through the origin, in degrees, followed by translation — identical to the KCL serialization in `kcl-generator.ts`. Transforms are baked into each shape before it joins the assembly, so the exported XDE holds identity locations plus part names.
+
+Two deliberate fallbacks:
+
+- The stage re-keys every placement's `stepFileKey` from its own child data before submission — LLM-echoed file keys are never trusted.
+- If the assembly has no materialized item or ECO branch to attach a file to, the node falls back to `status: 'code_only'` (plan + KCL retained, no geometry). `code_only` nodes are not skipped on re-run, so they gain geometry once the context exists.
+
+`quantity > 1` placements currently render a single instance (the plan carries one transform per placement); the worker logs a warning when this happens.
 
 ### Bottom-Up Assembly Order
 
@@ -340,7 +362,7 @@ Each vault file record includes:
 
 ### Background Job Processing
 
-CAD operations use two job types registered in the background job system:
+CAD operations use these job types registered in the background job system:
 
 **`conversion.cad.step-to-stl`**: Converts existing STEP/IGES files to STL + GLB.
 
@@ -356,7 +378,20 @@ CAD operations use two job types registered in the background job system:
 - Timeout: 1 minute
 - Max attempts: 3
 - Retry delays: 5s, 15s, 30s
-- Consumed by a CadQuery worker.
+- Consumed by the CadQuery worker (`workers/cad-generator/`).
+
+**`generation.cad.mechanism`**: Generates coordinated multi-part mechanisms (e.g. rack-and-pinion via cq-gears), one STEP per role.
+
+- Routing key: `jobs.generation.cad.mechanism`
+- Consumed by the CadQuery worker.
+
+**`generation.cad.assemble`**: Composes child STEP files into one structured assembly STEP from planned placements.
+
+- Routing key: `jobs.generation.cad.assemble`
+- Timeout: 3 minutes
+- Max attempts: 3
+- Retry delays: 5s, 15s, 30s
+- Consumed by the CadQuery worker.
 
 Jobs are submitted via `JobService.submit()` and tracked in the `jobs` table with progress updates, log entries, and result storage.
 
@@ -397,6 +432,7 @@ Jobs are submitted via `JobService.submit()` and tracked in the `jobs` table wit
 | `src/lib/cad-generation/assembly-order.ts`        | Bottom-up traversal order computation          |
 | `src/lib/cad-generation/assembly-validator.ts`    | Pre/post assembly plan validation              |
 | `src/lib/cad-generation/kcl-generator.ts`         | KCL project generation from assembly plans     |
+| `src/lib/cad-generation/assembly-render.ts`       | Assembly STEP render job submission + polling  |
 | `src/lib/cad-generation/interface-propagation.ts` | Exposed interface computation                  |
 | `src/lib/cad-generation/cascade-recompose.ts`     | Stale assembly detection on part regeneration  |
 | `src/lib/cad-generation/types.ts`                 | Shared type definitions                        |
@@ -409,6 +445,23 @@ Jobs are submitted via `JobService.submit()` and tracked in the `jobs` table wit
 | `src/lib/jobs/definitions/conversion/types.ts`             | Payload and result Zod schemas               |
 | `src/lib/jobs/definitions/parametric-generation/config.ts` | `generation.cad.parametric` job type config  |
 | `src/lib/jobs/definitions/parametric-generation/types.ts`  | Payload and result Zod schemas               |
+| `src/lib/jobs/definitions/mechanism-generation/config.ts`  | `generation.cad.mechanism` job type config   |
+| `src/lib/jobs/definitions/mechanism-generation/types.ts`   | Payload and result Zod schemas               |
+| `src/lib/jobs/definitions/assembly-composition/config.ts`  | `generation.cad.assemble` job type config    |
+| `src/lib/jobs/definitions/assembly-composition/types.ts`   | Payload and result Zod schemas               |
+
+### CAD Generator (Python)
+
+| File                                                              | Purpose                                          |
+| ----------------------------------------------------------------- | ------------------------------------------------ |
+| `workers/cad-generator/src/cad_generator/worker.py`               | RabbitMQ consumer: parametric/mechanism/assemble |
+| `workers/cad-generator/src/cad_generator/templates/`              | CadQuery parametric part templates               |
+| `workers/cad-generator/src/cad_generator/mechanism_generators/`   | Multi-part mechanism generators (cq-gears)       |
+| `workers/cad-generator/src/cad_generator/assembly.py`             | Placement transforms + structured STEP assembly  |
+| `workers/cad-generator/src/cad_generator/export.py`               | STEP export and bounding box computation         |
+| `workers/cad-generator/src/cad_generator/models.py`               | Pydantic models for payloads and results         |
+| `workers/cad-generator/src/cad_generator/db.py`                   | PostgreSQL operations (jobs, vault_files)        |
+| `workers/cad-generator/tests/test_assembly.py`                    | Rotation-convention and STEP round-trip tests    |
 
 ### Design Engine Stages
 

--- a/docs/features/design-engine.md
+++ b/docs/features/design-engine.md
@@ -223,7 +223,7 @@ When satisfied, the user clicks **Confirm CAD & Proceed to Assembly**.
 
 **Stage key**: `assembly_composition`
 
-Composes assemblies bottom-up using LLM-planned transforms and KCL code generation.
+Composes assemblies bottom-up: LLM-planned transforms, KCL code generation, and STEP rendering via the CadQuery/OCCT worker.
 
 **Processing order**: Assemblies are processed via post-order traversal (deepest sub-assemblies first, root last) computed by `computeAssemblyOrder()`.
 
@@ -236,8 +236,9 @@ Composes assemblies bottom-up using LLM-planned transforms and KCL code generati
    - Placement transforms (translation + rotation) for each child
    - KCL code that imports each child STEP file and applies transforms
 4. **Plan validation**: `validateAssemblyPlan()` checks for collisions, out-of-bounds placements, and missing children.
-5. **KCL project generation**: `generateKclProject()` produces a multi-file KCL project from the plan.
+5. **KCL project generation**: `generateKclProject()` produces a multi-file KCL project from the plan (kept as a portable side artifact).
 6. **Interface propagation**: `computeExposedInterfaces()` determines which child interfaces are not consumed by internal mappings and propagates them up for parent-level use.
+7. **STEP rendering**: `renderAssemblyStep()` submits a `generation.cad.assemble` job to the CadQuery/OCCT worker, which imports each child STEP from the vault, applies the plan's transforms, and stores one composed STEP assembly back in the vault. On success the node gets `status: 'complete'` with `assemblyStepFileKey` and a `boundingBox` (used by the parent assembly's planning). Without a materialized item or ECO branch the node falls back to `status: 'code_only'` (plan + KCL, no geometry). See `docs/features/cad-services.md` for the rendering details and rotation convention.
 
 ### Stage 9: Assembly Review
 

--- a/src/lib/cad-generation/assembly-render.ts
+++ b/src/lib/cad-generation/assembly-render.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Cascadia PLM contributors
+
+/**
+ * Assembly Render
+ *
+ * Submits a `generation.cad.assemble` job to the CadQuery/OCCT worker, which
+ * imports each child STEP from the vault, applies the plan's placement
+ * transforms (rotateX → rotateY → rotateZ about the global origin, in
+ * degrees, then translate — the same convention kcl-generator serializes),
+ * and exports one structured STEP assembly back into the vault.
+ */
+
+import type { AssemblyPlan, BoundingBox3D } from './types'
+
+export interface AssemblyRenderChild {
+  tempId: string
+  name: string
+  stepFileKey: string
+}
+
+export interface AssemblyRenderResult {
+  vaultFileId: string
+  fileName: string
+  boundingBox?: BoundingBox3D
+}
+
+/**
+ * Render an assembly plan to a STEP file via the worker. Throws on job
+ * failure, timeout, or abort — callers treat any throw as a failed
+ * composition for this node.
+ */
+export async function renderAssemblyStep(options: {
+  plan: AssemblyPlan
+  assemblyName: string
+  /** Children with geometry — the source of truth for STEP file keys */
+  children: Array<AssemblyRenderChild>
+  itemId: string
+  branchId: string
+  userId: string
+  signal?: AbortSignal
+  maxWaitMs?: number
+}): Promise<AssemblyRenderResult> {
+  const childByTempId = new Map(options.children.map((c) => [c.tempId, c]))
+
+  // Re-key stepFileKeys from our own child data — the plan's keys are
+  // LLM-echoed and must not be trusted. Placements for unknown tempIds
+  // are dropped.
+  const placements = options.plan.placements.flatMap((p) => {
+    const child = childByTempId.get(p.tempId)
+    if (!child) return []
+    return [
+      {
+        tempId: p.tempId,
+        partName: child.name,
+        stepFileKey: child.stepFileKey,
+        transform: p.transform,
+        quantity: Math.max(1, Math.round(p.quantity || 1)),
+      },
+    ]
+  })
+
+  if (placements.length === 0) {
+    throw new Error('Assembly plan has no placements matching known children')
+  }
+
+  // Dynamic import keeps the DB out of the client bundle
+  const { JobService } = await import('@/lib/jobs/JobService')
+
+  const job = await JobService.submit(
+    'generation.cad.assemble',
+    {
+      assemblyTempId: options.plan.assemblyTempId,
+      assemblyName: options.assemblyName,
+      itemId: options.itemId,
+      branchId: options.branchId,
+      userId: options.userId,
+      placements,
+    },
+    options.userId,
+    { priority: 'high', itemId: options.itemId },
+  )
+
+  const maxWaitMs = options.maxWaitMs ?? 180_000
+  const pollIntervalMs = 500
+  const startTime = Date.now()
+
+  while (Date.now() - startTime < maxWaitMs) {
+    if (options.signal?.aborted) {
+      throw new Error('Assembly render aborted')
+    }
+    const current = await JobService.get(job.id)
+    if (!current) break
+
+    if (current.status === 'completed' && current.result) {
+      const result = current.result as {
+        vaultFileId: string
+        fileName: string
+        boundingBox?: BoundingBox3D
+      }
+      return {
+        vaultFileId: result.vaultFileId,
+        fileName: result.fileName,
+        boundingBox: result.boundingBox,
+      }
+    }
+
+    if (current.status === 'failed') {
+      throw new Error(current.error ?? 'Assembly render job failed')
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
+  }
+
+  throw new Error(`Assembly render timed out after ${maxWaitMs}ms`)
+}

--- a/src/lib/cad-generation/cascade-recompose.ts
+++ b/src/lib/cad-generation/cascade-recompose.ts
@@ -52,6 +52,7 @@ export function markAssembliesStale(
           ...node.assemblyComposition,
           status: 'pending',
           assemblyStepFileKey: undefined,
+          boundingBox: undefined,
         }
       }
     }

--- a/src/lib/design-engine/stages/assembly-composition.ts
+++ b/src/lib/design-engine/stages/assembly-composition.ts
@@ -3,9 +3,11 @@
  *
  * Composes assemblies bottom-up: for each assembly node where all children
  * have STEP files, generates an assembly plan via LLM, produces KCL code,
- * and stores the assembled STEP file in the vault.
+ * renders the composed STEP via the CadQuery/OCCT worker
+ * (generation.cad.assemble), and stores the assembled STEP file in the vault.
  *
- * Multi-level assemblies are processed in topological order (leaves first).
+ * Multi-level assemblies are processed in topological order (leaves first);
+ * a composed sub-assembly's STEP + bounding box feed its parent's planning.
  */
 
 import { DesignSessionService } from '../session-service'
@@ -27,6 +29,7 @@ import {
 } from '@/lib/cad-generation/assembly-validator'
 import { generateKclProject } from '@/lib/cad-generation/kcl-generator'
 import { computeExposedInterfaces } from '@/lib/cad-generation/interface-propagation'
+import { renderAssemblyStep } from '@/lib/cad-generation/assembly-render'
 
 export async function* runAssemblyCompositionStage(
   session: DesignSession,
@@ -60,6 +63,36 @@ export async function* runAssemblyCompositionStage(
   }
 
   const rootAssembly = artifacts.bom.rootAssembly
+
+  // tempId → itemId from materialization, for attaching assembly STEP files
+  const tempIdToItemId = new Map<string, string>()
+  for (const item of artifacts.materializationResult.createdItems) {
+    tempIdToItemId.set(item.tempId, item.itemId)
+  }
+
+  // Resolve branchId from the materialized design's ECO-design relationship
+  // (assembly STEP files are written into the ECO branch, like part CAD).
+  let branchId: string | undefined
+  if (artifacts.materializationResult.ecoId) {
+    try {
+      const { db } = await import('@/lib/db')
+      const { changeOrderDesigns } = await import('@/lib/db/schema/items')
+      const { eq } = await import('drizzle-orm')
+      const [cod] = await db
+        .select({ branchId: changeOrderDesigns.branchId })
+        .from(changeOrderDesigns)
+        .where(
+          eq(
+            changeOrderDesigns.changeOrderId,
+            artifacts.materializationResult.ecoId,
+          ),
+        )
+        .limit(1)
+      branchId = cod?.branchId ?? undefined
+    } catch {
+      // Non-critical — assemblies fall back to KCL-only below
+    }
+  }
 
   try {
     // Compute bottom-up processing order
@@ -95,9 +128,11 @@ export async function* runAssemblyCompositionStage(
       if (signal?.aborted) break
 
       // Resume-idempotent: skip assemblies that already composed (a
-      // clarification pause must not redo finished work).
+      // clarification pause must not redo finished work). Legacy
+      // 'code_only' nodes are NOT skipped — re-running now renders the
+      // geometry they never got.
       const priorStatus = assemblyNode.assemblyComposition?.status
-      if (priorStatus === 'complete' || priorStatus === 'code_only') {
+      if (priorStatus === 'complete') {
         completed++
         continue
       }
@@ -174,7 +209,10 @@ export async function* runAssemblyCompositionStage(
               child.cadGeneration?.stepFileKey ??
               child.assemblyComposition?.assemblyStepFileKey ??
               '',
-            boundingBox: child.cadGeneration?.boundingBox,
+            // Sub-assemblies carry their bounds on assemblyComposition
+            boundingBox:
+              child.cadGeneration?.boundingBox ??
+              child.assemblyComposition?.boundingBox,
             interfaces: (child.interfaces ?? []).map((i) => ({
               id: i.id,
               description: i.description,
@@ -248,11 +286,11 @@ export async function* runAssemblyCompositionStage(
         // Validate the plan
         const childBoundingBoxes = new Map<string, BoundingBox3D>()
         for (const child of assemblyNode.children) {
-          if (child.cadGeneration?.boundingBox) {
-            childBoundingBoxes.set(
-              child.tempId,
-              child.cadGeneration.boundingBox,
-            )
+          const bb =
+            child.cadGeneration?.boundingBox ??
+            child.assemblyComposition?.boundingBox
+          if (bb) {
+            childBoundingBoxes.set(child.tempId, bb)
           }
         }
 
@@ -279,7 +317,7 @@ export async function* runAssemblyCompositionStage(
 
         yield {
           type: 'llm_text',
-          text: `Generated KCL project for "${assemblyNode.name}" (${kclProject.files.length} file(s)). Assembly rendering via external engine would happen here.`,
+          text: `Generated KCL project for "${assemblyNode.name}" (${kclProject.files.length} file(s)).`,
         }
 
         // Compute exposed interfaces for parent-level use
@@ -291,16 +329,57 @@ export async function* runAssemblyCompositionStage(
           }
         }
 
-        // KCL code generated but no STEP file produced — requires Zoo Modeling API
-        // or local KittyCAD engine to render KCL to STEP. Until then, multi-level
-        // assembly composition cannot find sub-assembly geometry.
-        assemblyNode.assemblyComposition = {
-          status: 'code_only',
-          assemblyPlan: JSON.stringify(plan),
-          kclProjectRef: plan.kclCode,
-        }
+        // Render the composed STEP via the CadQuery/OCCT worker. Without a
+        // materialized item + branch there is nowhere to attach the file, so
+        // fall back to the KCL-only result rather than failing the node.
+        const assemblyItemId =
+          tempIdToItemId.get(assemblyNode.tempId) ??
+          assemblyNode.existingItemId
+        if (!assemblyItemId || !branchId) {
+          assemblyNode.assemblyComposition = {
+            status: 'code_only',
+            assemblyPlan: JSON.stringify(plan),
+            kclProjectRef: plan.kclCode,
+          }
+          yield {
+            type: 'llm_text',
+            text: `No materialized item or branch for "${assemblyNode.name}" — keeping KCL only, no STEP rendered.`,
+          }
+          completed++
+        } else {
+          yield {
+            type: 'llm_text',
+            text: `Rendering assembly "${assemblyNode.name}" (${childData.length} children)...`,
+          }
 
-        completed++
+          const rendered = await renderAssemblyStep({
+            plan,
+            assemblyName: assemblyNode.name,
+            children: childData.map((c) => ({
+              tempId: c.tempId,
+              name: c.name,
+              stepFileKey: c.stepFileKey,
+            })),
+            itemId: assemblyItemId,
+            branchId,
+            userId: session.userId,
+            signal,
+          })
+
+          assemblyNode.assemblyComposition = {
+            status: 'complete',
+            assemblyPlan: JSON.stringify(plan),
+            kclProjectRef: plan.kclCode,
+            assemblyStepFileKey: rendered.vaultFileId,
+            boundingBox: rendered.boundingBox,
+          }
+
+          yield {
+            type: 'llm_text',
+            text: `Assembly "${assemblyNode.name}" composed → ${rendered.fileName}.`,
+          }
+          completed++
+        }
       } catch (error) {
         const errMsg =
           error instanceof Error ? error.message : 'Assembly composition failed'
@@ -308,7 +387,9 @@ export async function* runAssemblyCompositionStage(
           type: 'llm_text',
           text: `Failed to compose "${assemblyNode.name}": ${errMsg}`,
         }
+        // Preserve any plan/KCL captured before the failure
         assemblyNode.assemblyComposition = {
+          ...assemblyNode.assemblyComposition,
           status: 'failed',
           errorMessage: errMsg,
         }

--- a/src/lib/design-engine/types.ts
+++ b/src/lib/design-engine/types.ts
@@ -395,6 +395,15 @@ export interface AssemblyCompositionStatus {
   kclProjectRef?: string
   assemblyStepFileKey?: string
   errorMessage?: string
+  /** Composed-assembly bounds from the render job — parent planning context */
+  boundingBox?: {
+    minX: number
+    minY: number
+    minZ: number
+    maxX: number
+    maxY: number
+    maxZ: number
+  }
 }
 
 // ============================================================================

--- a/src/lib/jobs/definitions/assembly-composition/config.ts
+++ b/src/lib/jobs/definitions/assembly-composition/config.ts
@@ -1,0 +1,21 @@
+import {
+  assemblyComposePayloadSchema,
+  assemblyComposeResultSchema,
+} from './types'
+import type { AssemblyComposePayload, AssemblyComposeResult } from './types'
+import type { JobTypeConfig } from '../../types'
+
+export const assemblyComposeConfig: JobTypeConfig<
+  AssemblyComposePayload,
+  AssemblyComposeResult
+> = {
+  type: 'generation.cad.assemble',
+  label: 'Assembly STEP Composition',
+  routingKey: 'jobs.generation.cad.assemble',
+  payloadSchema: assemblyComposePayloadSchema,
+  resultSchema: assemblyComposeResultSchema,
+  timeout: 180000, // 3 minutes — STEP import of many children can be slow
+  maxAttempts: 3,
+  retryDelays: [5000, 15000, 30000],
+  priority: 'high',
+}

--- a/src/lib/jobs/definitions/assembly-composition/types.ts
+++ b/src/lib/jobs/definitions/assembly-composition/types.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod'
+
+const vector3Schema = z.object({
+  x: z.number(),
+  y: z.number(),
+  z: z.number(),
+})
+
+export const assemblyComposePayloadSchema = z.object({
+  assemblyTempId: z.string(),
+  assemblyName: z.string(),
+  itemId: z.string().uuid(),
+  branchId: z.string().uuid(),
+  userId: z.string().uuid(),
+  placements: z
+    .array(
+      z.object({
+        tempId: z.string(),
+        partName: z.string(),
+        stepFileKey: z.string().uuid(),
+        transform: z.object({
+          // Euler angles in degrees, applied rotateX → rotateY → rotateZ about
+          // the global origin, then translated — matching kcl-generator.ts.
+          translation: vector3Schema,
+          rotation: vector3Schema,
+        }),
+        quantity: z.number().int().min(1),
+      }),
+    )
+    .min(1),
+})
+
+export type AssemblyComposePayload = z.infer<
+  typeof assemblyComposePayloadSchema
+>
+
+export const assemblyComposeResultSchema = z.object({
+  assemblyTempId: z.string(),
+  vaultFileId: z.string().uuid(),
+  fileName: z.string(),
+  generationTimeMs: z.number(),
+  boundingBox: z
+    .object({
+      minX: z.number(),
+      minY: z.number(),
+      minZ: z.number(),
+      maxX: z.number(),
+      maxY: z.number(),
+      maxZ: z.number(),
+    })
+    .optional(),
+})
+
+export type AssemblyComposeResult = z.infer<typeof assemblyComposeResultSchema>

--- a/src/lib/jobs/definitions/register.ts
+++ b/src/lib/jobs/definitions/register.ts
@@ -32,6 +32,9 @@ import { parametricGenerationConfig } from './parametric-generation/config'
 // Mechanism CAD generation jobs (Python CadQuery worker)
 import { mechanismGenerationConfig } from './mechanism-generation/config'
 
+// Assembly STEP composition jobs (Python CadQuery/OCCT worker)
+import { assemblyComposeConfig } from './assembly-composition/config'
+
 // Zoo Text-to-CAD generation jobs (Node.js worker)
 import { zooGenerationConfig } from './zoo-generation/config'
 import { jobLogger } from '@/lib/logging/logger'
@@ -45,6 +48,7 @@ JobTypeRegistry.register(wiPartChangedConfig)
 JobTypeRegistry.register(cadConversionConfig)
 JobTypeRegistry.register(parametricGenerationConfig)
 JobTypeRegistry.register(mechanismGenerationConfig)
+JobTypeRegistry.register(assemblyComposeConfig)
 JobTypeRegistry.register(zooGenerationConfig)
 
 // Mark registry definitions as loaded

--- a/workers/cad-generator/src/cad_generator/assembly.py
+++ b/workers/cad-generator/src/cad_generator/assembly.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Cascadia PLM contributors
+
+"""Assembly composition — position child STEP shapes and export one STEP assembly.
+
+Rotation convention (MUST match src/lib/cad-generation/kcl-generator.ts):
+rotateX, then rotateY, then rotateZ — each about the GLOBAL axis through the
+origin, in degrees — followed by translation. Transforms are baked into each
+shape before it is added to the cq.Assembly with an identity location, so the
+exported XDE structure carries per-part names that the cad-converter worker's
+decomposer reads back.
+"""
+
+from __future__ import annotations
+
+import cadquery as cq
+
+from .models import BoundingBox6, PlacementTransform
+
+
+def apply_placement_transform(
+    workplane: cq.Workplane, transform: PlacementTransform
+) -> cq.Workplane:
+    """Apply a placement transform: Euler XYZ rotation about the global
+    origin (degrees), then translation. Order matters and must match the
+    KCL serialization exactly."""
+    r = transform.rotation
+    t = transform.translation
+
+    if r.x != 0:
+        workplane = workplane.rotate((0, 0, 0), (1, 0, 0), r.x)
+    if r.y != 0:
+        workplane = workplane.rotate((0, 0, 0), (0, 1, 0), r.y)
+    if r.z != 0:
+        workplane = workplane.rotate((0, 0, 0), (0, 0, 1), r.z)
+
+    if t.x != 0 or t.y != 0 or t.z != 0:
+        workplane = workplane.translate((t.x, t.y, t.z))
+
+    return workplane
+
+
+def compose_assembly(
+    assembly_name: str,
+    parts: list[tuple[str, cq.Workplane]],
+) -> cq.Assembly:
+    """Build a structured assembly from (name, already-transformed workplane)
+    pairs. Names are deduplicated so the XDE document stays unambiguous."""
+    assembly = cq.Assembly(name=_sanitize_name(assembly_name) or "assembly")
+
+    seen: dict[str, int] = {}
+    for part_name, workplane in parts:
+        name = _sanitize_name(part_name) or "part"
+        if name in seen:
+            seen[name] += 1
+            name = f"{name}_{seen[name]}"
+        else:
+            seen[name] = 0
+        assembly.add(workplane, name=name)
+
+    return assembly
+
+
+def compute_assembly_bounding_box(assembly: cq.Assembly) -> BoundingBox6:
+    """Axis-aligned bounding box of the composed assembly."""
+    bb = assembly.toCompound().BoundingBox()
+    return BoundingBox6(
+        minX=bb.xmin,
+        minY=bb.ymin,
+        minZ=bb.zmin,
+        maxX=bb.xmax,
+        maxY=bb.ymax,
+        maxZ=bb.zmax,
+    )
+
+
+def _sanitize_name(name: str) -> str:
+    """Sanitize a part/assembly name for use as an XDE component name."""
+    cleaned = "".join(ch if ch.isalnum() or ch in "_-" else "_" for ch in name)
+    while "__" in cleaned:
+        cleaned = cleaned.replace("__", "_")
+    return cleaned.strip("_")[:100]

--- a/workers/cad-generator/src/cad_generator/db.py
+++ b/workers/cad-generator/src/cad_generator/db.py
@@ -175,6 +175,28 @@ def insert_vault_file(
     return file_id
 
 
+def get_vault_file(file_id: str) -> Optional[VaultFileRecord]:
+    """Fetch a vault file record by ID (to read previously generated STEPs)."""
+    conn = get_connection()
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, item_id, branch_id, file_name, storage_path, uploaded_by "
+            "FROM vault_files WHERE id = %s",
+            (file_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            return None
+        return VaultFileRecord(
+            id=str(row[0]),
+            item_id=str(row[1]),
+            branch_id=str(row[2]) if row[2] else None,
+            file_name=row[3],
+            storage_path=row[4],
+            uploaded_by=str(row[5]),
+        )
+
+
 def compute_file_hash(file_path: str) -> str:
     """Compute SHA-256 hash of a file."""
     h = hashlib.sha256()

--- a/workers/cad-generator/src/cad_generator/models.py
+++ b/workers/cad-generator/src/cad_generator/models.py
@@ -120,3 +120,59 @@ class MechanismGenerationResult(BaseModel):
     generationTimeMs: int
     outputs: dict[str, MechanismPartOutput]
     metadata: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Assembly composition models
+# ---------------------------------------------------------------------------
+
+
+class Vector3(BaseModel):
+    """3D vector — translation in mm or Euler rotation in degrees."""
+
+    x: float
+    y: float
+    z: float
+
+
+class PlacementTransform(BaseModel):
+    """Child placement transform.
+
+    Rotation is Euler XYZ in degrees, applied rotateX -> rotateY -> rotateZ
+    about the GLOBAL origin, then translated — the same convention the
+    TypeScript KCL generator serializes (src/lib/cad-generation/kcl-generator.ts).
+    """
+
+    translation: Vector3
+    rotation: Vector3
+
+
+class AssemblyPlacement(BaseModel):
+    """One child part placement within an assembly."""
+
+    tempId: str
+    partName: str
+    stepFileKey: str  # vault_files.id of the child STEP
+    transform: PlacementTransform
+    quantity: int = 1
+
+
+class AssemblyComposePayload(BaseModel):
+    """Payload for assembly STEP composition jobs."""
+
+    assemblyTempId: str
+    assemblyName: str
+    itemId: str
+    branchId: str
+    userId: str
+    placements: list[AssemblyPlacement]
+
+
+class AssemblyComposeResult(BaseModel):
+    """Result for assembly STEP composition jobs."""
+
+    assemblyTempId: str
+    vaultFileId: str
+    fileName: str
+    generationTimeMs: int
+    boundingBox: Optional[BoundingBox6] = None

--- a/workers/cad-generator/src/cad_generator/worker.py
+++ b/workers/cad-generator/src/cad_generator/worker.py
@@ -15,16 +15,23 @@ import tempfile
 import time
 from typing import Optional
 
+import cadquery as cq
 import pika
 import pika.channel
 import pika.spec
 
+from .assembly import (
+    apply_placement_transform,
+    compose_assembly,
+    compute_assembly_bounding_box,
+)
 from .config import settings
 from .db import (
     add_job_log,
     close_connection,
     compute_file_hash,
     get_job,
+    get_vault_file,
     insert_vault_file,
     mark_job_completed,
     mark_job_failed,
@@ -34,6 +41,8 @@ from .db import (
 from .export import compute_bounding_box, export_step
 from .health import set_health_check, start_health_server
 from .models import (
+    AssemblyComposePayload,
+    AssemblyComposeResult,
     JobMessage,
     MechanismGenerationPayload,
     MechanismGenerationResult,
@@ -55,6 +64,7 @@ DLQ_QUEUE = "jobs.dead-letter"
 MAX_PRIORITY = 10
 BINDING_PATTERN = "jobs.generation.cad.parametric.#"
 BINDING_PATTERN_MECHANISM = "jobs.generation.cad.mechanism.#"
+BINDING_PATTERN_ASSEMBLE = "jobs.generation.cad.assemble.#"
 
 # Worker state
 _shutdown_requested = False
@@ -138,7 +148,27 @@ def _process_message(
         )
 
         # Dispatch based on job type
-        if msg.type == "generation.cad.mechanism":
+        if msg.type == "generation.cad.assemble":
+            payload_asm = AssemblyComposePayload(**job.payload)
+            result = _execute_assembly_composition(msg.jobId, payload_asm)
+            mark_job_completed(msg.jobId, result.model_dump())
+            add_job_log(
+                msg.jobId,
+                "info",
+                "Assembly STEP composition completed",
+                {
+                    "assemblyTempId": result.assemblyTempId,
+                    "fileName": result.fileName,
+                    "generationTimeMs": result.generationTimeMs,
+                },
+            )
+            logger.info(
+                "Job %s completed: %s in %dms",
+                msg.jobId,
+                result.fileName,
+                result.generationTimeMs,
+            )
+        elif msg.type == "generation.cad.mechanism":
             payload_mech = MechanismGenerationPayload(**job.payload)
             result = _execute_mechanism_generation(msg.jobId, payload_mech)
             mark_job_completed(msg.jobId, result.model_dump())
@@ -436,6 +466,116 @@ def _execute_mechanism_generation(
     )
 
 
+def _execute_assembly_composition(
+    job_id: str, payload: AssemblyComposePayload
+) -> AssemblyComposeResult:
+    """Compose child STEP files into one assembly STEP and store it in vault."""
+    start_time = time.monotonic()
+
+    if not payload.placements:
+        raise ValueError("Assembly composition requires at least one placement")
+
+    update_job_progress(job_id, 5, "Loading child STEP files...")
+
+    total = len(payload.placements)
+    parts = []
+    for idx, placement in enumerate(payload.placements):
+        record = get_vault_file(placement.stepFileKey)
+        if not record:
+            raise ValueError(
+                f"Vault file {placement.stepFileKey} not found "
+                f"(part '{placement.partName}')"
+            )
+        step_path = os.path.join(settings.vault_root, record.storage_path)
+        if not os.path.exists(step_path):
+            raise ValueError(
+                f"STEP file missing on disk: {record.storage_path} "
+                f"(part '{placement.partName}')"
+            )
+
+        workplane = cq.importers.importStep(step_path)
+        workplane = apply_placement_transform(workplane, placement.transform)
+
+        if placement.quantity > 1:
+            # The plan carries one transform per placement, so duplicate
+            # instances have nowhere distinct to go (same gap as the KCL
+            # clone() output). Place a single instance and record the gap.
+            add_job_log(
+                job_id,
+                "warning",
+                f"Placement '{placement.partName}' has quantity "
+                f"{placement.quantity} but only one transform — "
+                "placing a single instance",
+            )
+
+        parts.append((placement.partName, workplane))
+        progress = 5 + int(50 * (idx + 1) / total)
+        update_job_progress(
+            job_id, progress, f"Loaded {placement.partName} ({idx + 1}/{total})"
+        )
+
+    update_job_progress(job_id, 60, "Composing assembly...")
+    assembly = compose_assembly(payload.assemblyName, parts)
+    bbox = compute_assembly_bounding_box(assembly)
+
+    update_job_progress(job_id, 75, "Exporting assembly STEP...")
+
+    with tempfile.TemporaryDirectory(prefix="cad_asm_") as tmp_dir:
+        safe_name = payload.assemblyName.replace(" ", "_")
+        step_filename = f"{safe_name}_assembly.step"
+        tmp_step_path = os.path.join(tmp_dir, step_filename)
+        assembly.save(tmp_step_path, exportType="STEP")
+
+        update_job_progress(job_id, 85, "Storing in vault...")
+
+        vault_subdir = os.path.join("cad-output", job_id)
+        vault_storage_path = os.path.join(vault_subdir, step_filename)
+        dest_path = os.path.join(settings.vault_root, vault_storage_path)
+        os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+        shutil.copy2(tmp_step_path, dest_path)
+
+        file_size = os.path.getsize(dest_path)
+        file_hash = compute_file_hash(dest_path)
+
+        cad_metadata = {
+            "software": "cadquery",
+            "composition": "assembly",
+            "childCount": total,
+            "boundingBox": bbox.model_dump(),
+        }
+
+        vault_file_id = insert_vault_file(
+            item_id=payload.itemId,
+            branch_id=payload.branchId,
+            file_name=step_filename,
+            original_file_name=step_filename,
+            file_size=file_size,
+            mime_type="application/step",
+            file_hash=file_hash,
+            storage_path=vault_storage_path,
+            uploaded_by=payload.userId,
+            file_category="cad_model",
+            cad_metadata=cad_metadata,
+        )
+
+        add_job_log(
+            job_id,
+            "info",
+            f"Assembly STEP stored: {step_filename}",
+            {"vaultFileId": vault_file_id, "size": file_size},
+        )
+
+    elapsed_ms = int((time.monotonic() - start_time) * 1000)
+
+    return AssemblyComposeResult(
+        assemblyTempId=payload.assemblyTempId,
+        vaultFileId=vault_file_id,
+        fileName=step_filename,
+        generationTimeMs=elapsed_ms,
+        boundingBox=bbox,
+    )
+
+
 def run_worker() -> None:
     """Start the RabbitMQ consumer worker."""
     global _connection, _channel, _shutdown_requested
@@ -450,7 +590,7 @@ def run_worker() -> None:
 
     queue_name = _generate_queue_name()
     logger.info(
-        "Starting CAD generator worker (queue=%s, concurrency=%d, types=[parametric, mechanism])",
+        "Starting CAD generator worker (queue=%s, concurrency=%d, types=[parametric, mechanism, assemble])",
         queue_name,
         settings.worker_concurrency,
     )
@@ -494,6 +634,11 @@ def run_worker() -> None:
                 queue=queue_name,
                 exchange=EXCHANGE_NAME,
                 routing_key=BINDING_PATTERN_MECHANISM,
+            )
+            _channel.queue_bind(
+                queue=queue_name,
+                exchange=EXCHANGE_NAME,
+                routing_key=BINDING_PATTERN_ASSEMBLE,
             )
 
             # Set prefetch (concurrency limit)

--- a/workers/cad-generator/tests/test_assembly.py
+++ b/workers/cad-generator/tests/test_assembly.py
@@ -1,0 +1,114 @@
+"""Tests for assembly composition — transform convention and STEP round-trip.
+
+The rotation convention (rotateX -> rotateY -> rotateZ about the global
+origin, degrees, then translate) must match the TypeScript KCL generator
+(src/lib/cad-generation/kcl-generator.ts). A silent order/axis mismatch
+would produce plausible-but-wrong assemblies, so these tests pin it.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import cadquery as cq
+import pytest
+
+from cad_generator.assembly import (
+    apply_placement_transform,
+    compose_assembly,
+    compute_assembly_bounding_box,
+)
+from cad_generator.models import PlacementTransform, Vector3
+
+
+def _transform(tx=0.0, ty=0.0, tz=0.0, rx=0.0, ry=0.0, rz=0.0) -> PlacementTransform:
+    return PlacementTransform(
+        translation=Vector3(x=tx, y=ty, z=tz),
+        rotation=Vector3(x=rx, y=ry, z=rz),
+    )
+
+
+class TestPlacementTransform:
+    def test_identity_is_noop(self):
+        wp = cq.Workplane("XY").box(10, 20, 30)
+        out = apply_placement_transform(wp, _transform())
+        bb = out.val().BoundingBox()
+        assert bb.xmax - bb.xmin == pytest.approx(10, abs=0.1)
+        assert bb.ymax - bb.ymin == pytest.approx(20, abs=0.1)
+        assert bb.zmax - bb.zmin == pytest.approx(30, abs=0.1)
+
+    def test_rotation_z90_swaps_xy_extents(self):
+        wp = cq.Workplane("XY").box(10, 20, 30)
+        out = apply_placement_transform(wp, _transform(rz=90))
+        bb = out.val().BoundingBox()
+        assert bb.xmax - bb.xmin == pytest.approx(20, abs=0.1)
+        assert bb.ymax - bb.ymin == pytest.approx(10, abs=0.1)
+        assert bb.zmax - bb.zmin == pytest.approx(30, abs=0.1)
+
+    def test_rotate_before_translate(self):
+        # Rotation happens about the global origin BEFORE translation, so a
+        # translated part keeps its translation instead of being swept
+        # around the origin.
+        wp = cq.Workplane("XY").box(10, 20, 30)
+        out = apply_placement_transform(wp, _transform(tx=100, rz=90))
+        bb = out.val().BoundingBox()
+        assert (bb.xmin + bb.xmax) / 2 == pytest.approx(100, abs=0.1)
+        assert (bb.ymin + bb.ymax) / 2 == pytest.approx(0, abs=0.1)
+        # Extents reflect the rotation
+        assert bb.xmax - bb.xmin == pytest.approx(20, abs=0.1)
+        assert bb.ymax - bb.ymin == pytest.approx(10, abs=0.1)
+
+    def test_euler_order_is_x_then_z(self):
+        # A bar along +Z (10x10x100). Rx(90) maps +Z to -Y; Rz(90) then maps
+        # -Y to +X. Applied X -> Y -> Z, the long axis ends along X.
+        # If the order were Z-first, Rz would leave +Z unchanged and Rx
+        # would put the long axis along Y — distinguishable by extents.
+        wp = cq.Workplane("XY").box(10, 10, 100)
+        out = apply_placement_transform(wp, _transform(rx=90, rz=90))
+        bb = out.val().BoundingBox()
+        assert bb.xmax - bb.xmin == pytest.approx(100, abs=0.1)
+        assert bb.ymax - bb.ymin == pytest.approx(10, abs=0.1)
+        assert bb.zmax - bb.zmin == pytest.approx(10, abs=0.1)
+
+
+class TestComposeAssembly:
+    def test_two_parts_bounding_box(self):
+        a = cq.Workplane("XY").box(10, 10, 10)
+        b = apply_placement_transform(
+            cq.Workplane("XY").box(10, 10, 10), _transform(tx=20)
+        )
+        asm = compose_assembly("Test Assembly", [("part_a", a), ("part_b", b)])
+        bb = compute_assembly_bounding_box(asm)
+        # a spans -5..5, b spans 15..25
+        assert bb.minX == pytest.approx(-5, abs=0.1)
+        assert bb.maxX == pytest.approx(25, abs=0.1)
+        assert bb.maxY - bb.minY == pytest.approx(10, abs=0.1)
+
+    def test_step_roundtrip(self):
+        a = cq.Workplane("XY").box(10, 10, 10)
+        b = apply_placement_transform(
+            cq.Workplane("XY").box(10, 10, 10), _transform(tx=20)
+        )
+        asm = compose_assembly("Roundtrip", [("part_a", a), ("part_b", b)])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "roundtrip.step")
+            asm.save(path, exportType="STEP")
+            assert os.path.exists(path)
+            assert os.path.getsize(path) > 0
+
+            # Re-import: transforms must be baked into the geometry
+            reimported = cq.importers.importStep(path)
+            bb = reimported.val().BoundingBox()
+            assert bb.xmax - bb.xmin == pytest.approx(30, abs=0.5)
+
+    def test_duplicate_names_are_deduplicated(self):
+        a = cq.Workplane("XY").box(5, 5, 5)
+        b = apply_placement_transform(
+            cq.Workplane("XY").box(5, 5, 5), _transform(tx=10)
+        )
+        # Same part name twice must not collide in the XDE document
+        asm = compose_assembly("Dedup", [("bracket", a), ("bracket", b)])
+        names = [child.name for child in asm.children]
+        assert len(names) == len(set(names))


### PR DESCRIPTION
## What

The design engine's Assembly Composition stage previously stopped at `code_only`: it LLM-planned child placements and generated KCL, but produced **no geometry** — executing KCL requires Zoo's proprietary modeling engine, which an open-source deployment can't assume. That also blocked multi-level assemblies, since `isAssemblyReady`/`hasComposableGeometry` gate parents on a child `assemblyStepFileKey` that was never set.

This PR renders the composed STEP **in-house** using the OCCT toolchain the repo already ships (CadQuery in `workers/cad-generator`), keeping the LLM planning half unchanged:

- **New `generation.cad.assemble` job** (`src/lib/jobs/definitions/assembly-composition/`), consumed by the CadQuery worker alongside parametric/mechanism jobs. The handler imports each child STEP from the vault, applies the placement transform, combines into a structured `cq.Assembly` (XDE export, deduplicated names — readable by the cad-converter's decomposer), and stores the composed STEP + bounding box in the vault.
- **New `get_vault_file()` read helper** in the worker's `db.py` — the workers' vault plumbing was previously write-only.
- **Stage wiring** (`assembly-composition.ts`): resolves the ECO branch and materialized itemId, submits/polls via the new `renderAssemblyStep()` (`src/lib/cad-generation/assembly-render.ts`), and sets `status: 'complete'` + `assemblyStepFileKey` + `boundingBox`. `code_only` survives only as the no-item/no-branch fallback and **no longer short-circuits resume**, so legacy sessions gain geometry on re-run. Failures preserve the captured plan/KCL.
- **`AssemblyCompositionStatus.boundingBox`** added and fed into parent-level planning and overlap validation — this is what actually unblocks multi-level composition (sub-assemblies have no `cadGeneration.boundingBox`).
- KCL is still emitted as a portable side artifact (`kclProjectRef`).

## Why

Zoo's geometry engine is closed-source; the only closed dependency assembly composition actually had was the render step. The plan's `placements` (per-child `Transform3D` + vault STEP key) are engine-agnostic, and OCCT can do STEP-in/STEP-out composition natively.

## Reviewer notes

- **The highest-risk detail is the rotation convention.** The worker applies rotateX → rotateY → rotateZ about the **global** axes through the origin, in degrees, then translates — matching the KCL serialization in `kcl-generator.ts` exactly. A silent order/axis mismatch would produce plausible-but-wrong assemblies. `workers/cad-generator/tests/test_assembly.py` pins this (Euler order distinguishability, rotate-before-translate, STEP round-trip, name dedup).
- `renderAssemblyStep()` re-keys every placement's `stepFileKey` from the stage's own child data — LLM-echoed file keys are never trusted.
- **Known gap:** `quantity > 1` placements render a single instance (the plan carries one transform per placement — same gap the KCL `clone()` output had). The worker logs a warning; fixing it needs per-instance transforms from the planner.
- **Not verified end-to-end:** the Python tests need the worker's conda/Docker env (`cadquery` isn't importable on a bare dev machine), and a live RabbitMQ + worker session hasn't been exercised. Heads-up: cad-generator cold builds in CI have historically hit ENOSPC due to cache eviction — not a regression from this change.
- Docs: `cad-services.md` gained a "STEP Rendering (OCCT Worker)" section (plus corrections — the job list was missing the pre-existing `generation.cad.mechanism`, and the cad-generator worker had no source-file table); `design-engine.md` Stage 8 now includes the render step.

## Validation

- `npm run typecheck` — clean
- `npm run lint` (`--max-warnings 0`) — clean
- `npx vitest run src/lib/design-engine/fork.test.ts` — 4/4 passed
- Python files `py_compile` clean; pytest suite pending a worker-env run (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)