### PR TITLE
Fix: persist ChangeOrder isBaseline/baselineName so release auto-tags…

### DIFF
--- a/src/lib/items/type-handlers/change-order.ts
+++ b/src/lib/items/type-handlers/change-order.ts
@@ -20,6 +20,8 @@ registerTypeHandler('ChangeOrder', {
       closedAt: data.closedAt || null,
       impactAssessmentStatus: data.impactAssessmentStatus || 'pending',
       riskLevel: data.riskLevel || null,
+      isBaseline: data.isBaseline ?? false,
+      baselineName: data.baselineName || null,
     })
   },
 
@@ -60,6 +62,9 @@ registerTypeHandler('ChangeOrder', {
         data.impactAssessmentStatus || 'pending'
     if (data.riskLevel !== undefined)
       updateData.riskLevel = data.riskLevel || null
+    if (data.isBaseline !== undefined) updateData.isBaseline = data.isBaseline
+    if (data.baselineName !== undefined)
+      updateData.baselineName = data.baselineName || null
 
     if (Object.keys(updateData).length > 0) {
       await run

--- a/src/lib/services/ChangeOrderMergeService.test.ts
+++ b/src/lib/services/ChangeOrderMergeService.test.ts
@@ -29,8 +29,10 @@ import {
   branchItems,
   changeOrderAffectedItems,
   changeOrderDesigns,
+  changeOrders,
   items,
   programs,
+  tags,
   workflowDefinitions,
   workflowInstances,
 } from '@/lib/db/schema'
@@ -546,6 +548,54 @@ describe('ChangeOrderMergeService', () => {
       // Verify the part was released
       const releasedPart = await ItemService.findById(part.id)
       expect(releasedPart?.state).toBe('Released')
+    })
+
+    it('persists isBaseline/baselineName and tags the design on release (regression: type-handler dropped both)', async () => {
+      const part = await createPart('baseline-tag-test', 'Draft')
+      const baselineName = `BL-${uniquePrefix}`
+
+      const eco = await ItemService.create(
+        'ChangeOrder',
+        {
+          revision: '-',
+          name: 'Baseline ECO',
+          changeType: 'ECO',
+          priority: 'medium',
+          reasonForChange: 'Baseline test',
+          isBaseline: true,
+          baselineName,
+        } as any,
+        user.id,
+      )
+      await testDb.db.insert(workflowInstances).values({
+        workflowDefinitionId: workflowId,
+        itemId: eco.id,
+        currentState: 'Draft',
+      })
+
+      // The fix: the ChangeOrder type-handler must persist these, or the
+      // merge-time auto-tag never fires.
+      const [coRow] = await testDb.db
+        .select()
+        .from(changeOrders)
+        .where(eq(changeOrders.itemId, eco.id))
+      expect(coRow?.isBaseline).toBe(true)
+      expect(coRow?.baselineName).toBe(baselineName)
+
+      await ChangeOrderService.addAffectedItem(
+        eco.id,
+        { affectedItemId: part.id, changeAction: 'release' },
+        user.id,
+      )
+      await approveEco(eco.id)
+      await ChangeOrderMergeService.merge(eco.id, user.id)
+
+      // On release the baseline tag lands on the affected design.
+      const designTags = await testDb.db
+        .select()
+        .from(tags)
+        .where(eq(tags.designId, designId))
+      expect(designTags.some((t) => t.name === baselineName)).toBe(true)
     })
   })
 
@@ -1227,7 +1277,6 @@ describe('ChangeOrderMergeService', () => {
       const eco = await createChangeOrder()
 
       // Query change_orders table directly to verify default behavior
-      const { changeOrders } = await import('@/lib/db/schema')
       const [dbRecord] = await testDb.db
         .select()
         .from(changeOrders)


### PR DESCRIPTION
… a baseline

The ChangeOrder type-handler's insert and update dropped isBaseline and baselineName entirely, so a ChangeOrder created with isBaseline:true stored is_baseline=false / baseline_name=null. ChangeOrderMergeService's baseline tagging on release gates on changeOrder.isBaseline, so it silently skipped and no baseline tag was ever created via the auto-tag path.

Map both fields through the type-handler's insert and update. Regression test (ChangeOrderMergeService.test.ts): an isBaseline ECO release persists both fields and creates the baseline tag on the affected design.


Claude-Session: https://claude.ai/code/session_01QNoEeuzgzS6JYNnJrqSW8R