### PR TITLE
Apply release/obsolete affected-item actions when an ECO also merges …

### DIFF
--- a/src/lib/services/ChangeOrderMergeService.test.ts
+++ b/src/lib/services/ChangeOrderMergeService.test.ts
@@ -16,7 +16,7 @@ import {
   expect,
   it,
 } from 'vitest'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import { ItemService } from '../items/services/ItemService'
 import { ChangeOrderService } from '../items/services/ChangeOrderService'
 import { ChangeOrderMergeService } from './ChangeOrderMergeService'
@@ -1524,6 +1524,114 @@ describe('ChangeOrderMergeService', () => {
         releasedPartForObsolete.id,
       )
       expect(obsoletedPart?.state).toBe('Obsolete')
+    })
+
+    it('applies release/obsolete actions even when the ECO also merges a branch', async () => {
+      // Regression: these actions used to be gated behind "no branches
+      // merged", so an end-of-life ECO that both edited an assembly on its
+      // branch AND obsoleted the superseded part silently dropped the
+      // obsoletion. 'revise' stays the merge's job — it creates a new
+      // version — but release/obsolete only restate an existing one.
+      // Create every part while the design is still clean — branch protection
+      // blocks creating on main once it holds released items — then release
+      // the two that need to start out Released.
+      const assembly = await createPart('branch-and-obsolete-assy')
+      const eolPart = await createPart('branch-and-obsolete-eol')
+      const draftPart = await createPart('branch-and-obsolete-draft')
+      await testDb.db
+        .update(items)
+        .set({ state: 'Released' })
+        .where(inArray(items.id, [assembly.id, eolPart.id]))
+
+      const mainBranch = await BranchService.getMainBranch(designId)
+
+      await testDb.db.insert(branchItems).values({
+        branchId: mainBranch!.id,
+        itemMasterId: assembly.masterId!,
+        currentItemId: assembly.id,
+        baseItemId: assembly.id,
+        changeType: null,
+      })
+
+      const eco = await createChangeOrder()
+      const { branch } = await BranchService.getOrCreateEcoBranch(
+        designId,
+        eco.id,
+        user.id,
+      )
+
+      // Branch content: a working copy of the assembly, so a branch merges.
+      const [workingCopy] = await testDb.db
+        .insert(items)
+        .values({
+          itemNumber: assembly.itemNumber,
+          itemType: 'Part',
+          revision: '-',
+          name: 'Branch Working Copy',
+          state: 'Draft',
+          masterId: assembly.masterId,
+          designId: assembly.designId,
+          isCurrent: false,
+          createdBy: user.id,
+          modifiedBy: user.id,
+        })
+        .returning()
+
+      await testDb.db.insert(branchItems).values({
+        branchId: branch.id,
+        itemMasterId: assembly.masterId!,
+        currentItemId: workingCopy.id,
+        baseItemId: assembly.id,
+        changeType: 'modified',
+      })
+
+      await testDb.db.insert(changeOrderDesigns).values({
+        changeOrderId: eco.id,
+        designId: designId,
+        branchId: branch.id,
+        mergeStatus: 'pending',
+        itemsAffected: 1,
+      })
+
+      // Affected items that are NOT branch content: state-only actions.
+      await testDb.db.insert(changeOrderAffectedItems).values([
+        {
+          changeOrderId: eco.id,
+          affectedItemId: eolPart.id,
+          affectedItemMasterId: eolPart.masterId,
+          changeAction: 'obsolete',
+          currentState: 'Released',
+          targetState: 'Obsolete',
+          createdBy: user.id,
+        },
+        {
+          changeOrderId: eco.id,
+          affectedItemId: draftPart.id,
+          affectedItemMasterId: draftPart.masterId,
+          changeAction: 'release',
+          currentState: 'Draft',
+          targetState: 'Released',
+          createdBy: user.id,
+        },
+      ])
+
+      await approveEco(eco.id)
+
+      const result = await ChangeOrderMergeService.merge(eco.id, user.id)
+
+      // The branch still merged — this does not replace the branch path.
+      expect(result.designs.length).toBe(1)
+      expect(result.designs[0].mergeResult.itemsMerged).toBe(1)
+      const releasedAssembly = await ItemService.findById(workingCopy.id)
+      expect(releasedAssembly?.state).toBe('Released')
+
+      // ...and the state-only actions were applied rather than dropped.
+      const obsoleted = await ItemService.findById(eolPart.id)
+      expect(obsoleted?.state).toBe('Obsolete')
+
+      const released = await ItemService.findById(draftPart.id)
+      expect(released?.state).toBe('Released')
+      expect(released?.revision).not.toBe('-')
     })
   })
 

--- a/src/lib/services/ChangeOrderMergeService.ts
+++ b/src/lib/services/ChangeOrderMergeService.ts
@@ -746,6 +746,68 @@ export class ChangeOrderMergeService {
       }) // end db.transaction
     }
 
+    // 3c. State-only affected-item actions, when branches DID merge.
+    //
+    // 'revise' creates a NEW version of an item, which is exactly what a
+    // branch merge performs — so on the branch path the merge owns it.
+    // 'release' and 'obsolete' are different in kind: they take the version
+    // that already exists and only change its state. A branch merge neither
+    // performs those nor conflicts with them, so gating them behind
+    // "no branches merged" silently dropped them. An ECO that both edits a
+    // BOM on its branch and obsoletes a part is an ordinary end-of-life
+    // change, and it must do both.
+    //
+    // Items the merge already moved into the target state are skipped, which
+    // keeps this idempotent and stops it double-handling branch content.
+    if (branchesMerged > 0) {
+      const affectedItems =
+        await ChangeOrderService.getAffectedItems(changeOrderId)
+
+      for (const affected of affectedItems) {
+        if (!affected.affectedItemId) continue
+
+        const action = affected.changeAction as ChangeAction
+        if (action !== 'obsolete' && action !== 'release') continue
+
+        const item = await ItemService.findById(affected.affectedItemId)
+        if (!item) continue
+
+        const targetState = await LifecycleService.getTargetState(
+          item.itemType,
+          action,
+        )
+        const resolvedState =
+          targetState || (action === 'obsolete' ? 'Obsolete' : 'Released')
+
+        if (item.state === resolvedState) continue
+
+        const updates: { state: string; revision?: string } = {
+          state: resolvedState,
+        }
+
+        // Releasing a version that never carried one still needs a revision;
+        // obsoleting keeps whatever revision the item already has.
+        if (action === 'release') {
+          const needsRevision =
+            !item.revision ||
+            item.revision === '-' ||
+            item.revision === 'DRAFT' ||
+            item.revision.startsWith('-')
+          if (needsRevision) {
+            const releaseScheme = await LifecycleService.getRevisionScheme(
+              item.itemType,
+            )
+            updates.revision = RevisionService.getInitialRevision(releaseScheme)
+            results.totalRevisionsAssigned++
+          }
+        }
+
+        await ItemService.update(affected.affectedItemId, updates, userId, {
+          bypassBranchProtection: true,
+        })
+      }
+    }
+
     // Note: Don't update ECO state here - let the workflow handle it via ChangeOrderService.close()
     // The workflow will transition from Approved -> Released
 


### PR DESCRIPTION
…a branch

Affected-item actions were processed only when branchesMerged === 0, so an ECO that merged any branch content silently dropped them — no error, no warning. An end-of-life change is the ordinary case that hits this: it edits the parent assembly's BOM on its branch AND obsoletes the superseded part, and the obsoletion simply never happened.

The two kinds of action differ. 'revise' creates a NEW version of an item, which is exactly what a branch merge performs, so on the branch path the merge rightly owns it. 'release' and 'obsolete' only change the state of the version that already exists — a branch merge neither performs those nor conflicts with them, so there is no reason to gate them behind the absence of a merge.

After the branch merges, walk the affected items and apply the state-only actions. Items already in the target state are skipped, which keeps this idempotent and stops it double-handling anything the merge covered.


Claude-Session: https://claude.ai/code/session_01QNoEeuzgzS6JYNnJrqSW8R