### PR TITLE
Fix broken main typecheck: restore CI Build to green

### DIFF
--- a/src/lib/items/services/ChangeOrderService.test.ts
+++ b/src/lib/items/services/ChangeOrderService.test.ts
@@ -388,35 +388,41 @@ describe('ChangeOrderService', () => {
 
   // Helper: create a second design with a main branch (mirrors beforeEach).
   async function createDesign(codeSuffix: string): Promise<string> {
-    const [d] = await testDb.db
-      .insert(designs)
-      .values({
-        name: `Test Design ${codeSuffix}`,
-        code: `PROD-${uniquePrefix}-${codeSuffix}`,
-        designType: 'Engineering',
-        createdBy: user.id,
-      })
-      .returning()
-    const [c] = await testDb.db
-      .insert(commits)
-      .values({
-        designId: d.id,
-        branchId: d.id,
-        message: 'Initial commit',
-        createdBy: user.id,
-      })
-      .returning()
-    const [b] = await testDb.db
-      .insert(branches)
-      .values({
-        designId: d.id,
-        name: 'main',
-        branchType: 'main',
-        headCommitId: c.id,
-        baseCommitId: c.id,
-        createdBy: user.id,
-      })
-      .returning()
+    const d = takeFirst(
+      await testDb.db
+        .insert(designs)
+        .values({
+          name: `Test Design ${codeSuffix}`,
+          code: `PROD-${uniquePrefix}-${codeSuffix}`,
+          designType: 'Engineering',
+          createdBy: user.id,
+        })
+        .returning(),
+    )
+    const c = takeFirst(
+      await testDb.db
+        .insert(commits)
+        .values({
+          designId: d.id,
+          branchId: d.id,
+          message: 'Initial commit',
+          createdBy: user.id,
+        })
+        .returning(),
+    )
+    const b = takeFirst(
+      await testDb.db
+        .insert(branches)
+        .values({
+          designId: d.id,
+          name: 'main',
+          branchType: 'main',
+          headCommitId: c.id,
+          baseCommitId: c.id,
+          createdBy: user.id,
+        })
+        .returning(),
+    )
     await testDb.db
       .update(commits)
       .set({ branchId: b.id })

--- a/src/lib/services/ChangeOrderMergeService.test.ts
+++ b/src/lib/services/ChangeOrderMergeService.test.ts
@@ -1627,21 +1627,23 @@ describe('ChangeOrderMergeService', () => {
       )
 
       // Branch content: a working copy of the assembly, so a branch merges.
-      const [workingCopy] = await testDb.db
-        .insert(items)
-        .values({
-          itemNumber: assembly.itemNumber,
-          itemType: 'Part',
-          revision: '-',
-          name: 'Branch Working Copy',
-          state: 'Draft',
-          masterId: assembly.masterId,
-          designId: assembly.designId,
-          isCurrent: false,
-          createdBy: user.id,
-          modifiedBy: user.id,
-        })
-        .returning()
+      const workingCopy = takeFirst(
+        await testDb.db
+          .insert(items)
+          .values({
+            itemNumber: assembly.itemNumber,
+            itemType: 'Part',
+            revision: '-',
+            name: 'Branch Working Copy',
+            state: 'Draft',
+            masterId: assembly.masterId,
+            designId: assembly.designId,
+            isCurrent: false,
+            createdBy: user.id,
+            modifiedBy: user.id,
+          })
+          .returning(),
+      )
 
       await testDb.db.insert(branchItems).values({
         branchId: branch.id,
@@ -1687,7 +1689,7 @@ describe('ChangeOrderMergeService', () => {
 
       // The branch still merged — this does not replace the branch path.
       expect(result.designs.length).toBe(1)
-      expect(result.designs[0].mergeResult.itemsMerged).toBe(1)
+      expect(result.designs[0]!.mergeResult.itemsMerged).toBe(1)
       const releasedAssembly = await ItemService.findById(workingCopy.id)
       expect(releasedAssembly?.state).toBe('Released')
 

--- a/src/lib/services/ChangeOrderMergeService.ts
+++ b/src/lib/services/ChangeOrderMergeService.ts
@@ -763,7 +763,7 @@ export class ChangeOrderMergeService {
       for (const affected of affectedItems) {
         if (!affected.affectedItemId) continue
 
-        const action = affected.changeAction as ChangeAction
+        const action = affected.changeAction
         if (action !== 'obsolete' && action !== 'release') continue
 
         const item = await ItemService.findById(affected.affectedItemId)


### PR DESCRIPTION
## What

Restores the **Build → Typecheck** job to green. `main` has been red since the **#48 merge** (`fix/eco-state-actions-with-branch-merge`, `054e71a`); every other CI job passes because only the Build job runs `tsc --noEmit` (vitest/esbuild and eslint don't typecheck).

## Root cause

Three independent regressions, all from branches cut **before** the STRICT-typecheck cleanup and merged **without rebasing** onto it — so `noUncheckedIndexedAccess`/scope violations that the cleanup had already eliminated came back in:

| File | Error | Fix |
|------|-------|-----|
| `ChangeOrderMergeService.ts:766` | `Cannot find name 'ChangeAction'` — `054e71a` added `affected.changeAction as ChangeAction`, but the cleanup had removed the now-unused `ChangeAction` import | The cast is a **no-op** (`changeAction` is already `ChangeAction`), so drop it rather than re-import an unused type |
| `ChangeOrderMergeService.test.ts` | `const [workingCopy] = …returning()` + unguarded `result.designs[0]` | `takeFirst()` and the `[0]!` idiom already used elsewhere in this file |
| `ChangeOrderService.test.ts:403–428` | three `const [d]/[c]/[b] = …returning()` destructures in `createDesign` | `takeFirst()`, matching the rest of the file |

## Scope

Type-only. No runtime behavior changes. `npm run typecheck` and `eslint` both clean.

The same stale-base issue affects two downstream-fork branches being landed on top of this: #51 and #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pz4JFs25qTFzzUdNyonhzE
