### PR TITLE
Let ECO branches edit an assembly's BOM (deletes included)

### DIFF
--- a/src/lib/items/services/ChangeOrderService.ts
+++ b/src/lib/items/services/ChangeOrderService.ts
@@ -13,6 +13,7 @@ import {
   changeOrders,
   designs,
   documents,
+  itemRelationships,
   items,
   parts,
   requirements,
@@ -582,7 +583,36 @@ export class ChangeOrderService {
         wc.id,
       )
 
-      // 3. Create branchItem entry to track this on the ECO branch
+      // 3. Copy the item's outgoing relationships (BOM lines, document links)
+      //    onto the working copy. Without this the branch copy of an assembly
+      //    has an empty structure: you cannot see its children on the ECO
+      //    branch, let alone re-quantify or DELETE a line there. With it, the
+      //    working copy carries the real structure and is the thing the merge
+      //    releases, so edits made on the branch are what ship.
+      const sourceRelationships = await tx
+        .select()
+        .from(itemRelationships)
+        .where(eq(itemRelationships.sourceId, sourceItem.id))
+
+      if (sourceRelationships.length > 0) {
+        await tx
+          .insert(itemRelationships)
+          .values(
+            sourceRelationships.map((rel) => ({
+              sourceId: wc.id,
+              targetId: rel.targetId,
+              relationshipType: rel.relationshipType,
+              quantity: rel.quantity,
+              referenceDesignator: rel.referenceDesignator,
+              findNumber: rel.findNumber,
+              metadata: rel.metadata,
+              createdBy: userId,
+            })),
+          )
+          .onConflictDoNothing()
+      }
+
+      // 4. Create branchItem entry to track this on the ECO branch
       const bi = takeFirst(
         await tx
           .insert(branchItems)

--- a/src/lib/services/ChangeOrderMergeService.test.ts
+++ b/src/lib/services/ChangeOrderMergeService.test.ts
@@ -30,6 +30,7 @@ import {
   changeOrderAffectedItems,
   changeOrderDesigns,
   changeOrders,
+  itemRelationships,
   items,
   programs,
   tags,
@@ -601,6 +602,82 @@ describe('ChangeOrderMergeService', () => {
         .from(tags)
         .where(eq(tags.designId, designId))
       expect(designTags.some((t) => t.name === baselineName)).toBe(true)
+    })
+
+    it('carries BOM onto the working copy and honours branch edits (add + delete) on release', async () => {
+      // Released assembly with two children. Create them all before anything is
+      // Released — branch protection blocks creating on main once the design
+      // holds released items — then flip them to Released.
+      const assembly = await createPart('bom-assy')
+      const keepChild = await createPart('bom-keep')
+      const dropChild = await createPart('bom-drop')
+      const addChild = await createPart('bom-add')
+      for (const p of [assembly, keepChild, dropChild, addChild]) {
+        await testDb.db
+          .update(items)
+          .set({ state: 'Released' })
+          .where(eq(items.id, p.id))
+      }
+      await testDb.db.insert(itemRelationships).values([
+        { sourceId: assembly.id, targetId: keepChild.id, relationshipType: 'BOM', quantity: '1', findNumber: 10, createdBy: user.id },
+        { sourceId: assembly.id, targetId: dropChild.id, relationshipType: 'BOM', quantity: '2', findNumber: 20, createdBy: user.id },
+      ])
+
+      const eco = await createChangeOrder()
+      const { workingCopyId } = await ChangeOrderService.addAffectedItem(
+        eco.id,
+        { affectedItemId: assembly.id, changeAction: 'revise' },
+        user.id,
+      )
+      expect(workingCopyId).toBeTruthy()
+
+      // The branch copy must arrive carrying the real structure, otherwise
+      // there is nothing to edit on the ECO branch.
+      const onBranch = await testDb.db
+        .select()
+        .from(itemRelationships)
+        .where(eq(itemRelationships.sourceId, workingCopyId!))
+      expect(onBranch.map((r) => r.targetId).sort()).toEqual(
+        [keepChild.id, dropChild.id].sort(),
+      )
+
+      // Edit the BOM on the branch: drop one line, add another.
+      await testDb.db
+        .delete(itemRelationships)
+        .where(
+          and(
+            eq(itemRelationships.sourceId, workingCopyId!),
+            eq(itemRelationships.targetId, dropChild.id),
+          ),
+        )
+      await testDb.db.insert(itemRelationships).values({
+        sourceId: workingCopyId!,
+        targetId: addChild.id,
+        relationshipType: 'BOM',
+        quantity: '3',
+        findNumber: 30,
+        createdBy: user.id,
+      })
+
+      await approveEco(eco.id)
+      await ChangeOrderMergeService.merge(eco.id, user.id)
+
+      // The released revision reflects the branch edits: deleted line gone,
+      // added line present, untouched line kept.
+      const released = await testDb.db
+        .select()
+        .from(items)
+        .where(and(eq(items.masterId, assembly.masterId), eq(items.isCurrent, true)))
+        .then((r) => r.at(0))
+      expect(released).toBeDefined()
+      const finalBom = await testDb.db
+        .select()
+        .from(itemRelationships)
+        .where(eq(itemRelationships.sourceId, released!.id))
+      const targets = finalBom.map((r) => r.targetId)
+      expect(targets).toContain(keepChild.id)
+      expect(targets).toContain(addChild.id)
+      expect(targets).not.toContain(dropChild.id)
     })
   })
 

--- a/src/lib/services/ChangeOrderMergeService.ts
+++ b/src/lib/services/ChangeOrderMergeService.ts
@@ -1223,18 +1223,39 @@ export class ChangeOrderMergeService {
 
             if (!releasedItemId) continue
 
-            // Get source of BOM relationships:
-            // - For modified items: copy from baseItemId (old revision)
-            // - For added items: copy from currentItemId (draft item may have relationships)
-            const sourceItemId =
-              bi.changeType === 'modified' ? bi.baseItemId : bi.currentItemId
-            if (!sourceItemId) continue
+            // The branch's own version of the item is the authority on its
+            // structure: it is created carrying the item's relationships and is
+            // what the user edits on the ECO branch (adding, re-quantifying or
+            // DELETING lines). Reading from baseItemId instead would resurrect
+            // every line deleted on the branch.
+            let sourceItemId = bi.currentItemId
 
-            // Get all relationships where source item is the parent
-            const parentRelationships = await tx
+            let parentRelationships = await tx
               .select()
               .from(itemRelationships)
               .where(eq(itemRelationships.sourceId, sourceItemId))
+
+            // Compatibility: working copies created before branch checkout
+            // carried relationships have none of their own. Fall back to the
+            // previous revision so an in-flight ECO does not lose its BOM.
+            if (parentRelationships.length === 0 && bi.baseItemId) {
+              const baseRelationships = await tx
+                .select()
+                .from(itemRelationships)
+                .where(eq(itemRelationships.sourceId, bi.baseItemId))
+              if (baseRelationships.length > 0) {
+                sourceItemId = bi.baseItemId
+                parentRelationships = baseRelationships
+              }
+            }
+
+            // Replace the released item's structure with the branch's, so a
+            // line deleted on the branch does not come back.
+            if (releasedItemId !== sourceItemId) {
+              await tx
+                .delete(itemRelationships)
+                .where(eq(itemRelationships.sourceId, releasedItemId))
+            }
 
             // Copy each relationship, resolving child references to new revisions
             for (const rel of parentRelationships) {
@@ -1265,18 +1286,30 @@ export class ChangeOrderMergeService {
                 }
               }
 
-              await tx
-                .insert(itemRelationships)
-                .values({
-                  sourceId: releasedItemId,
-                  targetId: resolvedTargetId,
-                  relationshipType: rel.relationshipType,
-                  quantity: rel.quantity,
-                  findNumber: rel.findNumber,
-                  referenceDesignator: rel.referenceDesignator,
-                  createdBy: userId,
-                })
-                .onConflictDoNothing()
+              if (releasedItemId === sourceItemId) {
+                // The working copy was released in place, so its rows already
+                // hang off the released item — only re-point a child that was
+                // revised in this same ECO.
+                if (resolvedTargetId !== rel.targetId) {
+                  await tx
+                    .update(itemRelationships)
+                    .set({ targetId: resolvedTargetId })
+                    .where(eq(itemRelationships.id, rel.id))
+                }
+              } else {
+                await tx
+                  .insert(itemRelationships)
+                  .values({
+                    sourceId: releasedItemId,
+                    targetId: resolvedTargetId,
+                    relationshipType: rel.relationshipType,
+                    quantity: rel.quantity,
+                    findNumber: rel.findNumber,
+                    referenceDesignator: rel.referenceDesignator,
+                    createdBy: userId,
+                  })
+                  .onConflictDoNothing()
+              }
             }
           }
         },


### PR DESCRIPTION
## What

Editing a released assembly's BOM through an ECO didn't work. Two causes, both fixed here:

1. **`createRevisionWorkingCopy` copied the item row + type-specific data but not its relationships**, so the branch copy of an assembly had an *empty* structure — its children weren't visible on the ECO branch, and there was nothing to re-quantify or delete there.
2. **On merge, BOM relationships for a modified item were re-copied from `baseItemId`** (the previous revision), so anything deleted on the branch came straight back.

Now the working copy carries the item's relationships, and the merge treats the **branch's version as authoritative**: it replaces the released item's structure with the branch's, still resolving child references to revisions made in the same ECO. A working copy with no relationships of its own falls back to the previous revision, so ECOs already in flight keep their BOM.

Regression test covers add + delete across the merge, plus the working copy arriving with the structure attached.

## Notes for review

- Rebased from the original downstream-fork commit onto current `main`; conflicts resolved by adopting the `takeFirst()` idiom the codebase moved to (the fork predated it).
- **Stacked on #50** — `main`'s Build job is currently red for reasons unrelated to this change, so this targets that branch to stay green. Once #50 merges, GitHub will retarget this to `main` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pz4JFs25qTFzzUdNyonhzE
