### PR TITLE
Notify derived MBOMs when an ECO branch merges to main

### DIFF
--- a/src/lib/services/ChangeOrderMergeService.test.ts
+++ b/src/lib/services/ChangeOrderMergeService.test.ts
@@ -30,10 +30,12 @@ import {
   changeOrderAffectedItems,
   changeOrderDesigns,
   changeOrders,
+  designs,
   itemRelationships,
   items,
   programs,
   tags,
+  upstreamChanges,
   workflowDefinitions,
   workflowInstances,
 } from '@/lib/db/schema'
@@ -1494,6 +1496,169 @@ describe('ChangeOrderMergeService', () => {
       const releasedWorkingCopy = await ItemService.findById(workingCopy.id)
       expect(releasedWorkingCopy?.state).toBe('Released')
       expect(releasedWorkingCopy?.revision).toBe('B')
+    })
+  })
+
+  describe('upstream change notification to derived MBOMs', () => {
+    it('notifies MBOMs derived from the design when an ECO branch merges', async () => {
+      // Regression: notifyDerivedMboms had no caller anywhere, so
+      // upstream_changes was never written and the whole MBOM
+      // upstream-review feature was unreachable — GET upstream-changes could
+      // only ever return empty.
+      const part = await createPart('upstream-notify', 'Released')
+      const mainBranch = await BranchService.getMainBranch(designId)
+
+      await testDb.db.insert(branchItems).values({
+        branchId: mainBranch!.id,
+        itemMasterId: part.masterId!,
+        currentItemId: part.id,
+        baseItemId: part.id,
+        changeType: null,
+      })
+
+      // A Manufacturing design derived from this one. Inserted directly:
+      // MbomService.createFromEbom is the only legal producer, and this test
+      // only needs the sourceDesignId link it establishes.
+      const mbom = takeFirst(
+        await testDb.db
+          .insert(designs)
+          .values({
+            programId,
+            name: 'Derived MBOM',
+            code: `MBOM-${uniquePrefix}`,
+            designType: 'Manufacturing',
+            sourceDesignId: designId,
+            createdBy: user.id,
+          })
+          .returning(),
+      )
+
+      const eco = await createChangeOrder()
+      const { branch } = await BranchService.getOrCreateEcoBranch(
+        designId,
+        eco.id,
+        user.id,
+      )
+
+      const workingCopy = takeFirst(
+        await testDb.db
+          .insert(items)
+          .values({
+            itemNumber: part.itemNumber,
+            itemType: 'Part',
+            revision: '-',
+            name: 'Branch Working Copy',
+            state: 'Draft',
+            masterId: part.masterId,
+            designId: part.designId,
+            isCurrent: false,
+            createdBy: user.id,
+            modifiedBy: user.id,
+          })
+          .returning(),
+      )
+
+      await testDb.db.insert(branchItems).values({
+        branchId: branch.id,
+        itemMasterId: part.masterId!,
+        currentItemId: workingCopy.id,
+        baseItemId: part.id,
+        changeType: 'modified',
+      })
+
+      await testDb.db.insert(changeOrderDesigns).values({
+        changeOrderId: eco.id,
+        designId: designId,
+        branchId: branch.id,
+        mergeStatus: 'pending',
+        itemsAffected: 1,
+      })
+
+      await approveEco(eco.id)
+      await ChangeOrderMergeService.merge(eco.id, user.id)
+
+      const notifications = await testDb.db
+        .select()
+        .from(upstreamChanges)
+        .where(eq(upstreamChanges.targetDesignId, mbom.id))
+
+      expect(notifications.length).toBe(1)
+      expect(notifications[0]!.sourceDesignId).toBe(designId)
+      expect(notifications[0]!.sourceEcoId).toBe(eco.id)
+      expect(notifications[0]!.status).toBe('pending')
+
+      // The payload must describe the change well enough to review it.
+      const changed = notifications[0]!.changedItems
+      expect(changed.length).toBe(1)
+      expect(changed[0]!.masterId).toBe(part.masterId)
+      expect(changed[0]!.itemNumber).toBe(part.itemNumber)
+      expect(changed[0]!.changeType).toBe('modified')
+      expect(changed[0]!.previousRevision).toBe('A')
+      expect(changed[0]!.newRevision).toBe('B')
+    })
+
+    it('does not notify when the design has no derived MBOMs', async () => {
+      const part = await createPart('upstream-none', 'Released')
+      const mainBranch = await BranchService.getMainBranch(designId)
+
+      await testDb.db.insert(branchItems).values({
+        branchId: mainBranch!.id,
+        itemMasterId: part.masterId!,
+        currentItemId: part.id,
+        baseItemId: part.id,
+        changeType: null,
+      })
+
+      const eco = await createChangeOrder()
+      const { branch } = await BranchService.getOrCreateEcoBranch(
+        designId,
+        eco.id,
+        user.id,
+      )
+
+      const workingCopy = takeFirst(
+        await testDb.db
+          .insert(items)
+          .values({
+            itemNumber: part.itemNumber,
+            itemType: 'Part',
+            revision: '-',
+            name: 'Branch Working Copy',
+            state: 'Draft',
+            masterId: part.masterId,
+            designId: part.designId,
+            isCurrent: false,
+            createdBy: user.id,
+            modifiedBy: user.id,
+          })
+          .returning(),
+      )
+
+      await testDb.db.insert(branchItems).values({
+        branchId: branch.id,
+        itemMasterId: part.masterId!,
+        currentItemId: workingCopy.id,
+        baseItemId: part.id,
+        changeType: 'modified',
+      })
+
+      await testDb.db.insert(changeOrderDesigns).values({
+        changeOrderId: eco.id,
+        designId: designId,
+        branchId: branch.id,
+        mergeStatus: 'pending',
+        itemsAffected: 1,
+      })
+
+      await approveEco(eco.id)
+      await ChangeOrderMergeService.merge(eco.id, user.id)
+
+      const notifications = await testDb.db
+        .select()
+        .from(upstreamChanges)
+        .where(eq(upstreamChanges.sourceDesignId, designId))
+
+      expect(notifications.length).toBe(0)
     })
   })
 

--- a/src/lib/services/ChangeOrderMergeService.ts
+++ b/src/lib/services/ChangeOrderMergeService.ts
@@ -19,8 +19,9 @@ import { CommitService } from './CommitService'
 import { CrossDesignReferenceService } from './CrossDesignReferenceService'
 import { DesignService } from './DesignService'
 import { LifecycleService } from './LifecycleService'
+import { MbomService } from './MbomService'
 import { RevisionService } from './RevisionService'
-import type { commits } from '../db/schema'
+import type { UpstreamChangeItem, commits } from '../db/schema'
 import type { PromoteActionMapping, RevisionScheme } from '../types/lifecycle'
 import type { ChangeOrder } from '../items/types/change-order'
 import { serviceLogger } from '@/lib/logging/logger'
@@ -36,6 +37,8 @@ export interface MergeResult {
   itemsMerged: number
   itemsAdded: number
   itemsDeleted: number
+  /** What this merge changed, as notified to MBOMs derived from the design. */
+  changedItems: Array<UpstreamChangeItem>
 }
 
 export interface ChangeOrderMergeResult {
@@ -205,6 +208,34 @@ export class ChangeOrderMergeService {
           designName: design?.name || 'Unknown',
           mergeResult,
         })
+
+        // Tell any Manufacturing designs derived from this design that their
+        // source moved. This is the only point that knows an engineering
+        // change actually released, so it is where the notification belongs;
+        // MBOM owners then accept or defer each change on their own schedule.
+        if (mergeResult.changedItems.length > 0) {
+          try {
+            const notified = await MbomService.notifyDerivedMboms(
+              ecoDesign.designId,
+              mergeResult.mergeCommit.id,
+              changeOrderId,
+              mergeResult.changedItems,
+            )
+            if (notified > 0) {
+              serviceLogger.info(
+                { designId: ecoDesign.designId, notified, changeOrderId },
+                'Notified derived MBOMs of upstream change',
+              )
+            }
+          } catch (error) {
+            // A derived-MBOM notification must never block the release it
+            // describes — the change is already merged and valid.
+            serviceLogger.warn(
+              { err: error, designId: ecoDesign.designId, changeOrderId },
+              'Failed to notify derived MBOMs of upstream change',
+            )
+          }
+        }
 
         results.totalRevisionsAssigned += Object.keys(
           mergeResult.revisionsAssigned,
@@ -1371,12 +1402,48 @@ export class ChangeOrderMergeService {
     // 8. Archive ECO branch
     await BranchService.archiveBranch(branchId)
 
+    // 9. Describe what this merge changed, for MBOMs derived from this design.
+    // Resolved here because this is the only scope that still knows both the
+    // released item and the revision it superseded.
+    const upstreamItems: Array<UpstreamChangeItem> = []
+    for (const change of itemChanges) {
+      const released = await db
+        .select()
+        .from(items)
+        .where(eq(items.id, change.itemId))
+        .limit(1)
+        .then((r) => r.at(0))
+      if (!released) continue
+
+      let previousRevision = ''
+      if (change.previousItemId) {
+        const previous = await db
+          .select({ revision: items.revision })
+          .from(items)
+          .where(eq(items.id, change.previousItemId))
+          .limit(1)
+          .then((r) => r.at(0))
+        previousRevision = previous?.revision ?? ''
+      }
+
+      upstreamItems.push({
+        masterId: change.itemMasterId,
+        itemNumber: released.itemNumber,
+        name: released.name,
+        itemType: released.itemType,
+        previousRevision,
+        newRevision: released.revision,
+        changeType: change.changeType,
+      })
+    }
+
     return {
       mergeCommit,
       revisionsAssigned,
       itemsMerged,
       itemsAdded,
       itemsDeleted,
+      changedItems: upstreamItems,
     }
   }
 


### PR DESCRIPTION
## What

`MbomService.notifyDerivedMboms` is the only writer of `upstream_changes`, and **nothing in the codebase called it**. So the table was never populated, `GET /mbom/:id/upstream-changes` could only ever return empty, and `reviewUpstreamChange` had nothing to review — the read and review halves of the MBOM upstream-review feature were implemented but unreachable.

This calls it from the **branch-merge path**, the only point that knows an engineering change actually released. `mergeBranchToMain` already tracked per-item changes for the merge commit; it now also resolves them into the `UpstreamChangeItem` shape the notification expects (it's the only scope that still knows both the released item and the revision it superseded) and returns them on `MergeResult`.

A notification failure is **logged, never thrown**: the change it describes is already merged and valid, so it must not fail the release.

## Notes for review

- Rebased from the original downstream-fork commit onto current `main`; the import and test-fixture conflicts were resolved to the codebase's current idioms (`takeFirst()`, `[0]!`).
- **Stacked on #50** — same as the sibling BOM PR; targets that branch so CI stays green, and will retarget to `main` once #50 merges.
- Overlaps `ChangeOrderMergeService.ts` with the BOM PR; whichever lands second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pz4JFs25qTFzzUdNyonhzE
