### PR TITLE
Use the shared DataGrid for the Tools list instead of a bespoke table

### DIFF
--- a/src/components/tools/ToolTable.tsx
+++ b/src/components/tools/ToolTable.tsx
@@ -1,29 +1,61 @@
-import type { KnownToolSubtype } from '@/lib/items/types/tool'
-import { Badge } from '@/components/ui'
+import { Link } from '@tanstack/react-router'
+import { useCallback } from 'react'
+import { Edit, Eye, MoreVertical, Trash2 } from 'lucide-react'
+import type { KnownToolSubtype, Tool } from '@/lib/items/types/tool'
+import type {
+  ColumnFiltersState,
+  DataGridColumn,
+  PaginationState,
+  Row,
+  SortingState,
+} from '@/components/ui'
+import { Badge, Button, DataGrid } from '@/components/ui'
 import { TOOL_SUBTYPES } from '@/lib/items/types/tool'
-
-interface ToolRow {
-  id?: string
-  itemNumber?: string
-  name?: string
-  toolType?: string
-  toolSubtype?: string
-  manufacturer?: string
-  model?: string
-  toolStatus?: string
-  location?: string
-}
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/DropdownMenu'
+import {
+  ContextMenuItem,
+  ContextMenuSeparator,
+} from '@/components/ui/ContextMenu'
 
 interface ToolTableProps {
-  items: Array<ToolRow>
-  onSelect?: (item: ToolRow) => void
+  items: Array<Tool>
+  onEdit?: (tool: Tool) => void
+  onDelete?: (tool: Tool) => void
+  // Initial state from URL (uncontrolled - just sets starting values)
+  defaultSorting?: SortingState
+  defaultColumnFilters?: ColumnFiltersState
+  defaultGlobalFilter?: string
+  // Server-side pagination
+  serverSidePagination?: boolean
+  totalRows?: number
+  onPageChange?: (page: number, pageSize: number) => void
+  isLoading?: boolean
+  // Server-side operations (controlled state)
+  serverSideOperations?: boolean
+  sorting?: SortingState
+  onSortingChange?: (sorting: SortingState) => void
+  columnFilters?: ColumnFiltersState
+  onColumnFiltersChange?: (filters: ColumnFiltersState) => void
+  globalFilter?: string
+  onGlobalFilterChange?: (filter: string) => void
+  pagination?: PaginationState
+  onPaginationChange?: (pagination: PaginationState) => void
 }
 
-const STATUS_COLORS: Record<string, string> = {
-  available: 'bg-green-500/10 text-green-400 border-green-500/20',
-  in_use: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
-  maintenance: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
-  retired: 'bg-red-500/10 text-red-400 border-red-500/20',
+const statusVariant: Record<
+  string,
+  'default' | 'secondary' | 'success' | 'warning' | 'destructive'
+> = {
+  available: 'success',
+  in_use: 'default',
+  maintenance: 'warning',
+  retired: 'destructive',
 }
 
 function subtypeLabel(subtype?: string): string {
@@ -34,59 +66,247 @@ function subtypeLabel(subtype?: string): string {
   return known?.label ?? subtype
 }
 
-export function ToolTable({ items, onSelect }: ToolTableProps) {
-  return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-zinc-800 text-left text-xs text-zinc-500">
-            <th className="px-3 py-2">Item Number</th>
-            <th className="px-3 py-2">Name</th>
-            <th className="px-3 py-2">Subtype</th>
-            <th className="px-3 py-2">Manufacturer</th>
-            <th className="px-3 py-2">Model</th>
-            <th className="px-3 py-2">Status</th>
-            <th className="px-3 py-2">Location</th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((item) => (
-            <tr
-              key={item.id}
-              className="cursor-pointer border-b border-zinc-800/50 hover:bg-zinc-800/30"
-              onClick={() => onSelect?.(item)}
-            >
-              <td className="px-3 py-2 font-mono text-xs text-cyan-400">
-                {item.itemNumber}
-              </td>
-              <td className="px-3 py-2">{item.name}</td>
-              <td className="px-3 py-2 text-zinc-400">
-                {subtypeLabel(item.toolSubtype)}
-              </td>
-              <td className="px-3 py-2 text-zinc-400">{item.manufacturer}</td>
-              <td className="px-3 py-2 text-zinc-400">{item.model}</td>
-              <td className="px-3 py-2">
-                {item.toolStatus && (
-                  <Badge
-                    variant="outline"
-                    className={STATUS_COLORS[item.toolStatus] ?? ''}
-                  >
-                    {item.toolStatus}
-                  </Badge>
-                )}
-              </td>
-              <td className="px-3 py-2 text-zinc-500">{item.location}</td>
-            </tr>
-          ))}
-          {items.length === 0 && (
-            <tr>
-              <td colSpan={7} className="px-3 py-8 text-center text-zinc-500">
-                No tools found
-              </td>
-            </tr>
+export function ToolTable({
+  items,
+  onEdit,
+  onDelete,
+  defaultSorting,
+  defaultColumnFilters,
+  defaultGlobalFilter,
+  serverSidePagination,
+  totalRows,
+  onPageChange,
+  isLoading,
+  serverSideOperations,
+  sorting,
+  onSortingChange,
+  columnFilters,
+  onColumnFiltersChange,
+  globalFilter,
+  onGlobalFilterChange,
+  pagination,
+  onPaginationChange,
+}: ToolTableProps) {
+  const columns: Array<DataGridColumn<Tool>> = [
+    {
+      id: 'itemNumber',
+      header: 'Item Number',
+      accessorKey: 'itemNumber',
+      enableFiltering: true,
+      filterType: 'text',
+      filterPlaceholder: 'Filter...',
+      cell: ({ row }) =>
+        row.original.id ? (
+          <Link
+            to="/tools/$id"
+            params={{ id: row.original.id }}
+            className="font-mono text-sm text-sky-600 hover:text-sky-800 hover:underline dark:text-sky-400 dark:hover:text-sky-300"
+          >
+            {row.original.itemNumber}
+          </Link>
+        ) : (
+          <span className="font-mono text-sm">{row.original.itemNumber}</span>
+        ),
+    },
+    {
+      id: 'name',
+      header: 'Name',
+      accessorKey: 'name',
+      enableFiltering: true,
+      filterType: 'text',
+      filterPlaceholder: 'Filter...',
+      cell: ({ getValue }) => (getValue() as string) || '-',
+    },
+    {
+      id: 'toolType',
+      header: 'Type',
+      accessorKey: 'toolType',
+      enableFiltering: true,
+      filterType: 'multiSelect',
+      filterOptions: [
+        { label: 'Manufacturing', value: 'manufacturing' },
+        { label: 'Quality', value: 'quality' },
+        { label: 'Utility', value: 'utility' },
+      ],
+      cell: ({ getValue }) => {
+        const value = getValue() as string | undefined
+        if (!value) return '-'
+        return <span className="capitalize">{value}</span>
+      },
+    },
+    {
+      id: 'toolSubtype',
+      header: 'Subtype',
+      accessorKey: 'toolSubtype',
+      enableFiltering: false,
+      cell: ({ getValue }) => (
+        <span className="text-slate-500 dark:text-slate-400">
+          {subtypeLabel(getValue() as string | undefined)}
+        </span>
+      ),
+    },
+    {
+      id: 'manufacturer',
+      header: 'Manufacturer',
+      accessorKey: 'manufacturer',
+      enableFiltering: true,
+      filterType: 'text',
+      filterPlaceholder: 'Filter...',
+      cell: ({ getValue }) => (getValue() as string) || '-',
+    },
+    {
+      id: 'model',
+      header: 'Model',
+      accessorKey: 'model',
+      enableFiltering: true,
+      filterType: 'text',
+      filterPlaceholder: 'Filter...',
+      cell: ({ getValue }) => (getValue() as string) || '-',
+    },
+    {
+      id: 'toolStatus',
+      header: 'Status',
+      accessorKey: 'toolStatus',
+      enableFiltering: true,
+      filterType: 'multiSelect',
+      filterOptions: [
+        { label: 'Available', value: 'available' },
+        { label: 'In Use', value: 'in_use' },
+        { label: 'Maintenance', value: 'maintenance' },
+        { label: 'Retired', value: 'retired' },
+      ],
+      cell: ({ getValue }) => {
+        const value = getValue() as string | undefined
+        if (!value) return '-'
+        return (
+          <Badge variant={statusVariant[value] ?? 'secondary'}>
+            {value.replace('_', ' ')}
+          </Badge>
+        )
+      },
+    },
+    {
+      id: 'location',
+      header: 'Location',
+      accessorKey: 'location',
+      enableFiltering: true,
+      filterType: 'text',
+      filterPlaceholder: 'Filter...',
+      cell: ({ getValue }) => (getValue() as string) || '-',
+    },
+  ]
+
+  const renderRowActions = (row: Row<Tool>) => {
+    const tool = row.original
+    const hasActions = tool.id || onEdit || onDelete
+    if (!hasActions) return null
+
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button size="icon" variant="ghost" className="h-8 w-8">
+            <MoreVertical className="h-4 w-4" />
+            <span className="sr-only">Open menu</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {tool.id && (
+            <DropdownMenuItem asChild>
+              <Link to="/tools/$id" params={{ id: tool.id }}>
+                <Eye className="mr-2 h-4 w-4" />
+                View details
+              </Link>
+            </DropdownMenuItem>
           )}
-        </tbody>
-      </table>
-    </div>
+          {onEdit && (
+            <DropdownMenuItem onClick={() => onEdit(tool)}>
+              <Edit className="mr-2 h-4 w-4" />
+              Edit
+            </DropdownMenuItem>
+          )}
+          {onDelete && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => onDelete(tool)}
+                className="text-red-600 focus:text-red-600"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+  }
+
+  const renderContextMenuItems = useCallback(
+    (row: Row<Tool>) => {
+      const tool = row.original
+      const hasActions = onEdit || onDelete
+      if (!hasActions) return null
+
+      return (
+        <>
+          {onEdit && (
+            <ContextMenuItem onClick={() => onEdit(tool)}>
+              <Edit className="mr-2 h-4 w-4" />
+              Edit
+            </ContextMenuItem>
+          )}
+          {onDelete && (
+            <>
+              <ContextMenuSeparator />
+              <ContextMenuItem
+                onClick={() => onDelete(tool)}
+                className="text-red-600 focus:text-red-600"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
+              </ContextMenuItem>
+            </>
+          )}
+        </>
+      )
+    },
+    [onEdit, onDelete],
+  )
+
+  const getRowUrl = useCallback((row: Tool) => {
+    return row.id ? `/tools/${row.id}` : ''
+  }, [])
+
+  return (
+    <DataGrid
+      data={items}
+      columns={columns}
+      getRowId={(row) => row.id ?? row.itemNumber ?? ''}
+      enableRowActions={true}
+      renderRowActions={renderRowActions}
+      enableContextMenu
+      getRowUrl={getRowUrl}
+      renderContextMenuItems={renderContextMenuItems}
+      defaultSorting={defaultSorting}
+      defaultColumnFilters={defaultColumnFilters}
+      defaultGlobalFilter={defaultGlobalFilter}
+      emptyMessage="No tools found"
+      emptyDescription="Create your first tool to get started"
+      exportFilename="tools"
+      serverSidePagination={serverSidePagination}
+      totalRows={totalRows}
+      onPageChange={onPageChange}
+      isLoading={isLoading}
+      // Server-side operations (controlled state)
+      serverSideOperations={serverSideOperations}
+      sorting={sorting}
+      onSortingChange={onSortingChange}
+      columnFilters={columnFilters}
+      onColumnFiltersChange={onColumnFiltersChange}
+      globalFilter={globalFilter}
+      onGlobalFilterChange={onGlobalFilterChange}
+      pagination={pagination}
+      onPaginationChange={onPaginationChange}
+    />
   )
 }

--- a/src/routes/tools/index.tsx
+++ b/src/routes/tools/index.tsx
@@ -1,9 +1,16 @@
-import { Link, createFileRoute, useNavigate } from '@tanstack/react-router'
+import {
+  Link,
+  createFileRoute,
+  useNavigate,
+  useRouter,
+} from '@tanstack/react-router'
 import { useEffect, useState } from 'react'
 import { Plus } from 'lucide-react'
+import { z } from 'zod'
 import type { Tool } from '@/lib/items/types/tool'
 import { PageContainer } from '@/components/layout'
 import { ToolTable } from '@/components/tools/ToolTable'
+import { useServerDataGrid } from '@/lib/hooks/useServerDataGrid'
 import {
   Button,
   Card,
@@ -12,6 +19,8 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui'
+import { useAlertDialog } from '@/lib/hooks/useAlertDialog'
+import { useErrorHandler } from '@/lib/hooks/useErrorHandler'
 import { apiFetch } from '@/lib/api/client'
 
 interface ToolStateCounts {
@@ -21,66 +30,121 @@ interface ToolStateCounts {
   retired: number
 }
 
+// Search schema for URL validation (drives useServerDataGrid state sync)
+const toolsSearchSchema = z.object({
+  search: z.coerce.string().optional(),
+  sortBy: z.string().optional(),
+  sortOrder: z.enum(['asc', 'desc']).optional(),
+  page: z.coerce.number().int().positive().optional(),
+  pageSize: z.coerce.number().int().positive().optional(),
+  filter_toolType: z.coerce.string().optional(),
+  filter_toolStatus: z.coerce.string().optional(),
+})
+
 export const Route = createFileRoute('/tools/')({
+  validateSearch: toolsSearchSchema,
   component: ToolsListPage,
   loader: async () => {
     try {
+      // Fetch per-lifecycle-state counts in a single request
       const params = new URLSearchParams({
         itemType: 'Tool',
-        limit: '50',
-        offset: '0',
+        limit: '1',
+        includeCounts: 'true',
+        countStates: 'Draft,Active,Maintenance,Retired',
       })
       const result = await apiFetch<{
-        data: { items: Array<Tool>; total: number }
+        data: { total: number; counts?: Record<string, number> }
       }>(`/api/v1/items?${params}`)
+      const counts = result.data.counts ?? {}
       return {
-        tools: result.data.items,
-        total: result.data.total,
         counts: {
-          draft: 0,
-          active: 0,
-          maintenance: 0,
-          retired: 0,
+          draft: counts.Draft ?? 0,
+          active: counts.Active ?? 0,
+          maintenance: counts.Maintenance ?? 0,
+          retired: counts.Retired ?? 0,
         },
       }
     } catch (error) {
-      console.error('Error loading tools:', error)
+      console.error('Error loading tool counts:', error)
       return {
-        tools: [] as Array<Tool>,
-        total: 0,
-        counts: {
-          draft: 0,
-          active: 0,
-          maintenance: 0,
-          retired: 0,
-        },
+        counts: { draft: 0, active: 0, maintenance: 0, retired: 0 },
       }
     }
   },
 })
 
 function ToolsListPage() {
+  const router = useRouter()
   const navigate = useNavigate()
-  const {
-    tools: initialTools,
-    total: initialTotal,
-    counts: initialCounts,
-  } = Route.useLoaderData()
+  const { confirm } = useAlertDialog()
+  const { handleError, showSuccess } = useErrorHandler()
+  const { counts: initialCounts } = Route.useLoaderData()
 
-  const [tools, setTools] = useState<Array<Tool>>(initialTools)
-  const [total, setTotal] = useState(initialTotal)
+  // State for counts (loaded separately to avoid re-fetching on every filter change)
   const [counts, setCounts] = useState<ToolStateCounts>(initialCounts)
 
-  useEffect(() => {
-    setTools(initialTools)
-    setTotal(initialTotal)
-    setCounts(initialCounts)
-  }, [initialTools, initialTotal, initialCounts])
+  // Server-side DataGrid with URL state sync
+  const {
+    items: tools,
+    total,
+    dataGridProps,
+    refetch,
+  } = useServerDataGrid<Tool>({
+    queryKey: ['tools'],
+    fetchFn: async (params) => {
+      const qp = new URLSearchParams({ itemType: 'Tool' })
+      qp.set('limit', String(params.pageSize))
+      qp.set('offset', String((params.page - 1) * params.pageSize))
+      if (params.globalSearch) qp.set('search', params.globalSearch)
+      if (params.sortField) qp.set('sortField', params.sortField)
+      if (params.sortDirection) qp.set('sortDirection', params.sortDirection)
+      if (params.columnFilters)
+        qp.set('columnFilters', JSON.stringify(params.columnFilters))
 
-  const handleEditTool = (tool: { id?: string }) => {
+      const result = await apiFetch<{
+        data: { items: Array<Tool>; total: number }
+      }>(`/api/v1/items?${qp}`)
+      return { items: result.data.items, total: result.data.total }
+    },
+  })
+
+  // Sync counts with loader data when it changes
+  useEffect(() => {
+    setCounts(initialCounts)
+  }, [initialCounts])
+
+  const handleEditTool = (tool: Tool) => {
     if (tool.id) {
       navigate({ to: '/tools/$id', params: { id: tool.id } })
     }
+  }
+
+  const handleDeleteTool = (tool: Tool) => {
+    if (!tool.id) return
+
+    confirm({
+      title: 'Delete Tool',
+      description: `Are you sure you want to delete ${tool.itemNumber}? This action cannot be undone.`,
+      actionLabel: 'Delete',
+      cancelLabel: 'Cancel',
+      variant: 'destructive',
+      onConfirm: async () => {
+        try {
+          await apiFetch(`/api/v1/tools/${tool.id}`, {
+            method: 'DELETE',
+          })
+
+          showSuccess('Tool deleted', `${tool.itemNumber} has been deleted`)
+
+          // Refetch data to get fresh data from server
+          refetch()
+          router.invalidate()
+        } catch (error) {
+          handleError(error, { title: 'Failed to delete tool' })
+        }
+      },
+    })
   }
 
   return (
@@ -146,7 +210,25 @@ function ToolsListPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <ToolTable items={tools} onSelect={handleEditTool} />
+          <ToolTable
+            items={tools}
+            onEdit={handleEditTool}
+            onDelete={handleDeleteTool}
+            // Server-side operations with URL state sync
+            serverSidePagination={dataGridProps.serverSidePagination}
+            serverSideOperations={dataGridProps.serverSideOperations}
+            totalRows={dataGridProps.totalRows}
+            isLoading={dataGridProps.isLoading}
+            sorting={dataGridProps.sorting}
+            onSortingChange={dataGridProps.onSortingChange}
+            columnFilters={dataGridProps.columnFilters}
+            onColumnFiltersChange={dataGridProps.onColumnFiltersChange}
+            globalFilter={dataGridProps.globalFilter}
+            onGlobalFilterChange={dataGridProps.onGlobalFilterChange}
+            pagination={dataGridProps.pagination}
+            onPaginationChange={dataGridProps.onPaginationChange}
+            onPageChange={dataGridProps.onPageChange}
+          />
         </CardContent>
       </Card>
     </PageContainer>


### PR DESCRIPTION
## What & why

The Tools itemtype was the **only** one of ~20 that didn't use the shared search-grid stack. Instead of the `DataGrid` + `useServerDataGrid` components that every other list (Parts, Issues, Documents, Requirements, Tasks, …) routes through, the Tools list hand-rolled a bare `<table>` with a static 50-row loader — no sorting, no column filters, no global search, no pagination, no row actions, and stat cards hardcoded to `0`. That bespoke divergence was the wasted code this PR removes.

## Changes

- **`src/components/tools/ToolTable.tsx`** — rewritten from a raw `<table>` into a thin `DataGrid` column-config wrapper, structurally identical to `PartTable`/`IssueTable`. Columns: item number (link), name, type (multiSelect filter), subtype, manufacturer, model, status (multiSelect filter + badge), location. Inherits sorting, per-column filters, global search, CSV export, row actions (view / edit / delete), context menu, and "open in new tab" from the shared component.
- **`src/routes/tools/index.tsx`** — swapped the static loader for `useServerDataGrid`, wiring server-side pagination/sort/filter/search through the same `/api/v1/items` params every other route uses. Stat cards now show **real** lifecycle-state counts (`Draft`/`Active`/`Maintenance`/`Retired`) via a single `includeCounts`/`countStates` request instead of hardcoded zeros. Rows gain edit + delete-with-confirm.

No server changes: the Tools route uses the no-`designId` path of `/api/v1/items`, which already supports `search`, `sortField`/`sortDirection`, `columnFilters`, and count aggregation.

## Reviewer notes

- The registry entry in `registerItemTypes.tsx` types `table` as `any` and registers `ToolTable` right beside `PartTable`; the new prop shape now matches `PartTable`, so it's strictly more consistent. That registry `table` is never rendered generically — the only live consumer is `routes/tools/index.tsx`.
- Whether `ItemService.search`'s `columnFilters` actually filters on the tool-specific `toolType`/`toolStatus` columns (which live in the `tools` table, not `items`) is a shared question with Parts, which filters its `parts`-table columns the same way. If it turns out to be a server-side no-op for both, that's a pre-existing limitation to address separately — Tools is no worse off.
- No tests added: UI-wiring refactor with no data-integrity, security, or complex-algorithm gate under the repo's three-gate rule.

**Verification:** typecheck clean on both files, `eslint --max-warnings 0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
