### PR TITLE
Fix item-number auto-assignment, unify wording, surface the scheme

### DIFF
--- a/src/components/change-orders/ChangeOrderForm.tsx
+++ b/src/components/change-orders/ChangeOrderForm.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import type { ChangeOrder } from '@/lib/items/types/change-order'
 import { changeOrderSchema } from '@/lib/items/types/change-order'
 import { AttributesEditor } from '@/components/items/AttributesEditor'
+import { getItemNumberHelpText } from '@/lib/items/numbering/format'
 import { zodValidator } from '@/lib/form-validation'
 import {
   Button,
@@ -85,7 +86,7 @@ export function ChangeOrderForm({
         {/* Item Number - Always auto-generated for Change Orders */}
         <FormField
           label="Change Order Number"
-          helpText="Will be auto-generated (e.g., ECO-000001)"
+          helpText={getItemNumberHelpText('ChangeOrder')}
         >
           <div className="flex items-center h-10 px-3 rounded-md border border-input bg-muted text-muted-foreground">
             Auto-generated on creation

--- a/src/components/documents/DocumentForm.tsx
+++ b/src/components/documents/DocumentForm.tsx
@@ -9,6 +9,7 @@ import { DesignSelector } from '@/components/versioning/DesignSelector'
 import { DesignPhaseIndicator } from '@/components/versioning/DesignPhaseIndicator'
 import { BranchSelector } from '@/components/versioning/BranchSelector'
 import { AttributesEditor } from '@/components/items/AttributesEditor'
+import { ItemNumberField } from '@/components/items/ItemNumberField'
 import { apiFetch } from '@/lib/api/client'
 import { zodValidator } from '@/lib/form-validation'
 import { Button, FormField, Input, Textarea } from '@/components/ui'
@@ -195,21 +196,15 @@ export function DocumentForm({
         {/* Item Number */}
         <form.Field name="itemNumber">
           {(field) => (
-            <FormField
-              label="Item Number"
+            <ItemNumberField
+              itemType="Document"
+              name={field.name}
+              value={field.state.value}
+              onChange={field.handleChange}
+              onBlur={field.handleBlur}
               error={field.state.meta.errors[0]}
-              helpText="Leave blank to auto-generate (e.g., DOC-000001)"
-            >
-              <Input
-                name={field.name}
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                onBlur={field.handleBlur}
-                placeholder="Auto-generated if blank"
-                error={!!field.state.meta.errors.length}
-                data-testid="document-item-number"
-              />
-            </FormField>
+              data-testid="document-item-number"
+            />
           )}
         </form.Field>
 

--- a/src/components/issues/IssueForm.tsx
+++ b/src/components/issues/IssueForm.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import type { Issue } from '@/lib/items/types/issue'
 import { issueSchema } from '@/lib/items/types/issue'
 import { AttributesEditor } from '@/components/items/AttributesEditor'
+import { ItemNumberField } from '@/components/items/ItemNumberField'
 import { zodValidator } from '@/lib/form-validation'
 import {
   Button,
@@ -75,20 +76,15 @@ export function IssueForm({
         {/* Item Number */}
         <form.Field name="itemNumber">
           {(field) => (
-            <FormField
+            <ItemNumberField
+              itemType="Issue"
               label="Issue Number"
+              name={field.name}
+              value={field.state.value}
+              onChange={field.handleChange}
+              onBlur={field.handleBlur}
               error={field.state.meta.errors[0]}
-              helpText="Leave blank to auto-generate (e.g., ISS-000001)"
-            >
-              <Input
-                name={field.name}
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                onBlur={field.handleBlur}
-                placeholder="Auto-generated if blank"
-                error={!!field.state.meta.errors.length}
-              />
-            </FormField>
+            />
           )}
         </form.Field>
 

--- a/src/components/items/ItemNumberField.tsx
+++ b/src/components/items/ItemNumberField.tsx
@@ -1,0 +1,61 @@
+import { FormField, Input } from '@/components/ui'
+import {
+  ITEM_NUMBER_PLACEHOLDER,
+  getItemNumberHelpText,
+} from '@/lib/items/numbering/format'
+
+interface ItemNumberFieldProps {
+  /** Item type key (e.g. 'Part') — drives the format example in the help text. */
+  itemType: string
+  value: string
+  onChange: (value: string) => void
+  onBlur?: () => void
+  error?: string
+  /** Field label. Defaults to "Item Number". */
+  label?: string
+  name?: string
+  disabled?: boolean
+  className?: string
+  'data-testid'?: string
+}
+
+/**
+ * Shared item-number input for create/edit forms.
+ *
+ * Centralizes the placeholder and help-text wording so every item type says the
+ * same thing, and surfaces the type's auto-generated format (e.g. `PN-000001`).
+ * Leaving the field blank is always valid — the server auto-generates the
+ * number (see `baseItemSchema.itemNumber`).
+ */
+export function ItemNumberField({
+  itemType,
+  value,
+  onChange,
+  onBlur,
+  error,
+  label = 'Item Number',
+  name,
+  disabled,
+  className,
+  'data-testid': testId,
+}: ItemNumberFieldProps) {
+  return (
+    <FormField
+      label={label}
+      error={error}
+      helpText={getItemNumberHelpText(itemType)}
+      className={className}
+    >
+      <Input
+        name={name}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={onBlur}
+        placeholder={ITEM_NUMBER_PLACEHOLDER}
+        error={!!error}
+        disabled={disabled}
+        data-testid={testId}
+      />
+    </FormField>
+  )
+}

--- a/src/components/parts/PartForm.tsx
+++ b/src/components/parts/PartForm.tsx
@@ -9,6 +9,7 @@ import { DesignSelector } from '@/components/versioning/DesignSelector'
 import { DesignPhaseIndicator } from '@/components/versioning/DesignPhaseIndicator'
 import { BranchSelector } from '@/components/versioning/BranchSelector'
 import { AttributesEditor } from '@/components/items/AttributesEditor'
+import { ItemNumberField } from '@/components/items/ItemNumberField'
 import { apiFetch } from '@/lib/api/client'
 import { zodValidator } from '@/lib/form-validation'
 import {
@@ -213,21 +214,15 @@ export function PartForm({
         {/* Item Number */}
         <form.Field name="itemNumber">
           {(field) => (
-            <FormField
-              label="Item Number"
+            <ItemNumberField
+              itemType="Part"
+              name={field.name}
+              value={field.state.value}
+              onChange={field.handleChange}
+              onBlur={field.handleBlur}
               error={field.state.meta.errors[0]}
-              helpText="Leave blank to auto-generate (e.g., PN-000001)"
-            >
-              <Input
-                name={field.name}
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                onBlur={field.handleBlur}
-                placeholder="Auto-generated if blank"
-                error={!!field.state.meta.errors.length}
-                data-testid="part-item-number"
-              />
-            </FormField>
+              data-testid="part-item-number"
+            />
           )}
         </form.Field>
 

--- a/src/components/requirements/RequirementForm.tsx
+++ b/src/components/requirements/RequirementForm.tsx
@@ -9,6 +9,7 @@ import { DesignSelector } from '@/components/versioning/DesignSelector'
 import { DesignPhaseIndicator } from '@/components/versioning/DesignPhaseIndicator'
 import { BranchSelector } from '@/components/versioning/BranchSelector'
 import { AttributesEditor } from '@/components/items/AttributesEditor'
+import { ItemNumberField } from '@/components/items/ItemNumberField'
 import { apiFetch } from '@/lib/api/client'
 import { zodValidator } from '@/lib/form-validation'
 import {
@@ -218,21 +219,15 @@ export function RequirementForm({
         {/* Item Number */}
         <form.Field name="itemNumber">
           {(field) => (
-            <FormField
-              label="Item Number"
+            <ItemNumberField
+              itemType="Requirement"
+              name={field.name}
+              value={field.state.value}
+              onChange={field.handleChange}
+              onBlur={field.handleBlur}
               error={field.state.meta.errors[0]}
-              helpText="Leave blank to auto-generate (e.g., REQ-000001)"
-            >
-              <Input
-                name={field.name}
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                onBlur={field.handleBlur}
-                placeholder="Auto-generated if blank"
-                error={!!field.state.meta.errors.length}
-                data-testid="requirement-item-number"
-              />
-            </FormField>
+              data-testid="requirement-item-number"
+            />
           )}
         </form.Field>
 

--- a/src/components/tasks/TaskForm.tsx
+++ b/src/components/tasks/TaskForm.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import type { Task } from '@/lib/items/types/task'
 import { taskSchema } from '@/lib/items/types/task'
 import { AttributesEditor } from '@/components/items/AttributesEditor'
+import { ItemNumberField } from '@/components/items/ItemNumberField'
 import { zodValidator } from '@/lib/form-validation'
 import {
   Button,
@@ -75,20 +76,15 @@ export function TaskForm({
         {/* Item Number */}
         <form.Field name="itemNumber">
           {(field) => (
-            <FormField
+            <ItemNumberField
+              itemType="Task"
               label="Task Number"
+              name={field.name}
+              value={field.state.value}
+              onChange={field.handleChange}
+              onBlur={field.handleBlur}
               error={field.state.meta.errors[0]}
-              helpText="Leave blank to auto-generate (e.g., TSK-000001)"
-            >
-              <Input
-                name={field.name}
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                onBlur={field.handleBlur}
-                placeholder="Auto-generated if blank"
-                error={!!field.state.meta.errors.length}
-              />
-            </FormField>
+            />
           )}
         </form.Field>
 

--- a/src/components/tests/TestCaseForm.tsx
+++ b/src/components/tests/TestCaseForm.tsx
@@ -10,6 +10,7 @@ import { DesignSelector } from '@/components/versioning/DesignSelector'
 import { DesignPhaseIndicator } from '@/components/versioning/DesignPhaseIndicator'
 import { BranchSelector } from '@/components/versioning/BranchSelector'
 import { AttributesEditor } from '@/components/items/AttributesEditor'
+import { ItemNumberField } from '@/components/items/ItemNumberField'
 import { apiFetch } from '@/lib/api/client'
 import { zodValidator } from '@/lib/form-validation'
 import {
@@ -284,21 +285,15 @@ export function TestCaseForm({
         {/* Item Number */}
         <form.Field name="itemNumber">
           {(field) => (
-            <FormField
-              label="Item Number"
+            <ItemNumberField
+              itemType="TestCase"
+              name={field.name}
+              value={field.state.value}
+              onChange={field.handleChange}
+              onBlur={field.handleBlur}
               error={field.state.meta.errors[0]}
-              helpText="Leave blank to auto-generate (e.g., TC-000001)"
-            >
-              <Input
-                name={field.name}
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                onBlur={field.handleBlur}
-                placeholder="Auto-generated if blank"
-                error={!!field.state.meta.errors.length}
-                data-testid="test-case-item-number"
-              />
-            </FormField>
+              data-testid="test-case-item-number"
+            />
           )}
         </form.Field>
 

--- a/src/components/tests/TestPlanForm.tsx
+++ b/src/components/tests/TestPlanForm.tsx
@@ -9,6 +9,7 @@ import { DesignSelector } from '@/components/versioning/DesignSelector'
 import { DesignPhaseIndicator } from '@/components/versioning/DesignPhaseIndicator'
 import { BranchSelector } from '@/components/versioning/BranchSelector'
 import { AttributesEditor } from '@/components/items/AttributesEditor'
+import { ItemNumberField } from '@/components/items/ItemNumberField'
 import { apiFetch } from '@/lib/api/client'
 import { zodValidator } from '@/lib/form-validation'
 import {
@@ -192,21 +193,15 @@ export function TestPlanForm({
         {/* Item Number */}
         <form.Field name="itemNumber">
           {(field) => (
-            <FormField
-              label="Item Number"
+            <ItemNumberField
+              itemType="TestPlan"
+              name={field.name}
+              value={field.state.value}
+              onChange={field.handleChange}
+              onBlur={field.handleBlur}
               error={field.state.meta.errors[0]}
-              helpText="Leave blank to auto-generate (e.g., TP-000001)"
-            >
-              <Input
-                name={field.name}
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                onBlur={field.handleBlur}
-                placeholder="Auto-generated if blank"
-                error={!!field.state.meta.errors.length}
-                data-testid="test-plan-item-number"
-              />
-            </FormField>
+              data-testid="test-plan-item-number"
+            />
           )}
         </form.Field>
 

--- a/src/components/tools/ToolDetail.tsx
+++ b/src/components/tools/ToolDetail.tsx
@@ -12,6 +12,7 @@ import { UrlDropOverlay } from '@/components/items/UrlDropOverlay'
 import { useUrlDropEnrichment } from '@/components/items/useUrlDropEnrichment'
 import { useErrorHandler } from '@/lib/hooks/useErrorHandler'
 import { ItemHistoryTab } from '@/components/items/ItemHistoryTab'
+import { ITEM_NUMBER_PLACEHOLDER } from '@/lib/items/numbering/format'
 import {
   Badge,
   Button,
@@ -375,7 +376,7 @@ export function ToolDetail({
                         }
                         onChange={(v) => updateField('itemNumber', v)}
                         isEditing={isEditing && isCreateMode}
-                        placeholder="Auto-assigned"
+                        placeholder={ITEM_NUMBER_PLACEHOLDER}
                       />
                       <ViewEditText
                         label="Name"

--- a/src/components/work-instructions/WorkInstructionForm.tsx
+++ b/src/components/work-instructions/WorkInstructionForm.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
   Textarea,
 } from '@/components/ui'
+import { ItemNumberField } from '@/components/items/ItemNumberField'
 
 interface WorkInstructionFormProps {
   workInstruction?: Partial<WorkInstruction>
@@ -70,20 +71,15 @@ export function WorkInstructionForm({
         {/* Item Number */}
         <form.Field name="itemNumber">
           {(field) => (
-            <FormField
+            <ItemNumberField
+              itemType="WorkInstruction"
               label="Work Instruction Number"
+              name={field.name}
+              value={field.state.value}
+              onChange={field.handleChange}
+              onBlur={field.handleBlur}
               error={field.state.meta.errors[0]}
-              helpText="Leave blank to auto-generate (e.g., WI-000001)"
-            >
-              <Input
-                name={field.name}
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                onBlur={field.handleBlur}
-                placeholder="Auto-generated if blank"
-                error={!!field.state.meta.errors.length}
-              />
-            </FormField>
+            />
           )}
         </form.Field>
 

--- a/src/lib/items/numbering/format.ts
+++ b/src/lib/items/numbering/format.ts
@@ -1,0 +1,147 @@
+/**
+ * Client-safe helpers for *displaying* numbering schemes.
+ *
+ * This module intentionally imports only the pure scheme data (`./schemes`)
+ * and types — never `NumberingService` (which pulls in the database). That
+ * keeps it importable from React components and the admin UI without dragging
+ * server-only code into the client bundle. Do NOT import from `./index` here.
+ *
+ * Everything here is side-effect free: it renders *example* numbers without
+ * touching the sequence counters, so it is safe to call anywhere.
+ */
+import { familyNumberingConfig, numberingSchemes } from './schemes'
+import type { NumberSegment, SequenceScope } from './types'
+
+/** Placeholder shown in every item-number input when the field is left blank. */
+export const ITEM_NUMBER_PLACEHOLDER = 'Auto-generated if blank'
+
+/**
+ * Render a single segment as a representative example, WITHOUT consuming a
+ * sequence value. Sequence segments render as their zero-padded starting value;
+ * dynamic segments (design code, fields, dates) render as short placeholder
+ * tokens so the shape of the number is still clear.
+ */
+function renderSegmentExample(segment: NumberSegment): string {
+  switch (segment.type) {
+    case 'literal':
+      return segment.value
+    case 'sequence':
+      return String(segment.startAt ?? 1).padStart(segment.padding ?? 6, '0')
+    case 'design-code':
+      return '{design}'
+    case 'field':
+      return `{${segment.field}}`
+    case 'lookup':
+      return segment.default ?? Object.values(segment.map)[0] ?? '{code}'
+    case 'date':
+      return segment.format
+    case 'family-sequence':
+      return String(1).padStart(segment.padding ?? 3, '0')
+  }
+}
+
+/**
+ * A representative example of the number an item type will be assigned,
+ * e.g. `PN-000001`. Returns `null` if the type has no numbering scheme.
+ */
+export function formatSchemeExample(itemType: string): string | null {
+  const scheme = numberingSchemes[itemType]
+  if (!scheme) return null
+  const separator = scheme.separator ?? '-'
+  return scheme.segments.map(renderSegmentExample).join(separator)
+}
+
+/** Whether an item type permits manually-entered numbers. */
+export function allowsManualEntry(itemType: string): boolean {
+  return numberingSchemes[itemType]?.allowManualEntry ?? false
+}
+
+/**
+ * The standardized help text for an item-number field. Used by
+ * `ItemNumberField` so every item form says the same thing.
+ */
+export function getItemNumberHelpText(itemType: string): string {
+  const example = formatSchemeExample(itemType)
+  const suffix = example ? ` (e.g., ${example})` : ''
+  return allowsManualEntry(itemType)
+    ? `Leave blank to auto-generate${suffix}`
+    : `Auto-generated on creation${suffix}`
+}
+
+/** Human-readable description of when a sequence counter resets. */
+function describeSequenceScope(scope: SequenceScope | undefined): string {
+  switch (scope) {
+    case 'design':
+      return 'restarts per design'
+    case 'prefix':
+      return 'restarts per prefix'
+    case 'yearly':
+      return 'restarts each year'
+    default:
+      return 'never restarts (global)'
+  }
+}
+
+/** Human-readable description of a single segment, for the admin display. */
+function describeSegment(segment: NumberSegment): string {
+  switch (segment.type) {
+    case 'literal':
+      return `Fixed text "${segment.value}"`
+    case 'sequence': {
+      const digits = segment.padding ?? 6
+      const start = segment.startAt ?? 1
+      return `Sequence — ${digits}-digit number starting at ${start}, ${describeSequenceScope(segment.scope)}`
+    }
+    case 'design-code':
+      return 'Design code'
+    case 'field':
+      return `Value of the "${segment.field}" field${segment.transform ? ` (${segment.transform})` : ''}`
+    case 'lookup':
+      return `Code looked up from the "${segment.field}" field`
+    case 'date':
+      return `Date (${segment.format})`
+    case 'family-sequence':
+      return `Family variant — ${segment.padding ?? 3}-digit number`
+  }
+}
+
+export interface NumberingInfo {
+  itemType: string
+  /** e.g. `PN-000001`, or `null` if no scheme is defined. */
+  example: string | null
+  separator: string
+  allowManualEntry: boolean
+  familyVariants: { enabled: boolean; example: string | null }
+  segments: Array<{ type: NumberSegment['type']; description: string }>
+}
+
+/**
+ * Full read-only description of an item type's numbering scheme, for the admin
+ * item-type page. Returns `null` if the type has no scheme defined in code.
+ */
+export function getNumberingInfo(itemType: string): NumberingInfo | null {
+  const scheme = numberingSchemes[itemType]
+  if (!scheme) return null
+
+  const separator = scheme.separator ?? '-'
+  const example = formatSchemeExample(itemType)
+
+  const family = familyNumberingConfig[itemType]
+  const familyEnabled = family?.enabled ?? false
+  const familyExample =
+    familyEnabled && example
+      ? `${example}${family?.separator ?? '-'}${String(1).padStart(family?.padding ?? 3, '0')}`
+      : null
+
+  return {
+    itemType,
+    example,
+    separator,
+    allowManualEntry: scheme.allowManualEntry ?? false,
+    familyVariants: { enabled: familyEnabled, example: familyExample },
+    segments: scheme.segments.map((s) => ({
+      type: s.type,
+      description: describeSegment(s),
+    })),
+  }
+}

--- a/src/lib/items/types/base.ts
+++ b/src/lib/items/types/base.ts
@@ -48,7 +48,15 @@ export const baseItemSchema = z.object({
   id: z.string().uuid().optional(),
   masterId: z.string().uuid().optional(),
   designId: z.string().uuid().optional(), // Nullable at DB level. Part, Document, Requirement override to required. Task and Issue leave optional/omitted.
-  itemNumber: z.string().min(1).max(100).optional(), // Optional - auto-generated if not provided
+  // Optional - auto-generated if not provided. A blank/whitespace-only string
+  // (what an untouched form field submits) is coerced to `undefined` so the
+  // service auto-generates instead of failing `.min(1)` validation. This makes
+  // "leave blank to auto-generate" work uniformly for every item type, on both
+  // the client (zodValidator) and the server (schema.parse).
+  itemNumber: z.preprocess(
+    (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+    z.string().min(1).max(100).optional(),
+  ),
   revision: z.string().min(1).max(10),
   itemType: z.string().min(1).max(50),
   name: z.string().max(500).optional(),

--- a/src/routes/admin/item-types/$itemType.tsx
+++ b/src/routes/admin/item-types/$itemType.tsx
@@ -25,6 +25,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui'
+import { getNumberingInfo } from '@/lib/items/numbering/format'
 
 export const Route = createFileRoute('/admin/item-types/$itemType')({
   component: ItemTypeConfigEditPage,
@@ -86,6 +87,9 @@ const CHANGE_ORDER_TYPES = ['ECO', 'ECN', 'Deviation', 'MCO', 'XCO'] as const
 
 function ItemTypeConfigEditPage() {
   const { itemType } = Route.useParams()
+
+  // Read-only view of the code-defined numbering scheme for this item type.
+  const numbering = getNumberingInfo(itemType)
 
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
@@ -451,6 +455,66 @@ function ItemTypeConfigEditPage() {
               {codeConfig && <span>Code default: {codeConfig.icon}</span>}
             </p>
           </div>
+        </CardContent>
+      </Card>
+
+      {/* Numbering Scheme (read-only) */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Item Numbering</CardTitle>
+          <CardDescription>
+            How item numbers are generated for this type. Defined in code (
+            <code className="text-xs">src/lib/items/numbering/schemes.ts</code>
+            ).
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {numbering ? (
+            <>
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="text-sm text-slate-600 dark:text-slate-400">
+                  Example
+                </span>
+                <code className="text-base font-mono bg-slate-100 dark:bg-slate-800 px-3 py-1 rounded">
+                  {numbering.example ?? '—'}
+                </code>
+                <Badge variant="secondary">
+                  {numbering.allowManualEntry
+                    ? 'Manual entry allowed'
+                    : 'Always auto-generated'}
+                </Badge>
+                {numbering.familyVariants.enabled && (
+                  <Badge variant="secondary">
+                    Family variants (e.g. {numbering.familyVariants.example})
+                  </Badge>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label>Pattern</Label>
+                <ol className="space-y-1.5">
+                  {numbering.segments.map((seg, i) => (
+                    <li
+                      key={i}
+                      className="flex items-start gap-2 text-sm text-slate-700 dark:text-slate-300"
+                    >
+                      <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-slate-200 text-xs dark:bg-slate-700">
+                        {i + 1}
+                      </span>
+                      <span>{seg.description}</span>
+                    </li>
+                  ))}
+                </ol>
+                <p className="text-xs text-slate-500">
+                  Segments are joined with{' '}
+                  <code className="text-xs">"{numbering.separator}"</code>.
+                </p>
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              No numbering scheme is defined for this item type.
+            </p>
+          )}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary

Leaving the item-number field blank now works for **every** item type — previously only Work Instructions could be created without typing a number. Also unifies the "auto-assigned" messaging across forms and surfaces the numbering scheme read-only in the admin UI.

## Why

Three related issues:

1. **Inconsistent wording** — the item-number field said different things in different places ("Auto-generated if blank" on most forms, "Auto-assigned" on Tools, "Auto-generated on creation" on Change Orders).
2. **Blank submit was blocked** — you couldn't create a Tool, Part, etc. without entering a number, even though the field is supposed to auto-generate. Work Instructions were the only type that worked.
3. **No way to see the scheme** — the auto-number format lived only in code with no UI to view it.

## What changed

### #2 — Blank item numbers now auto-generate (the bug)

Root cause: `baseItemSchema.itemNumber` was `z.string().min(1).max(100).optional()`. An untouched form field submits `""` (empty string), which is *not* `undefined`, so `.min(1)` rejected it:

- **Client**: forms using `zodValidator(schema)` (Part, Document, Requirement, Task, Issue, Test Plan, Test Case) failed validation on submit.
- **Server**: Tools are created via `ToolDetail`, which posted `""` straight to `POST /api/v1/items`, so `ItemService.create` → `schema.parse()` threw.

Work Instructions dodged it only because `WorkInstructionForm` converted `itemNumber: value.itemNumber || undefined` before validating.

Fixed at the source — `baseItemSchema.itemNumber` now coerces blank/whitespace to `undefined`, so `ItemService.create` auto-generates. This resolves **both** the client and server paths for **all** item types in one place. Non-empty values are still validated (`.min(1).max(100)`) and preserved.

### #1 — Consistent wording

New shared [`ItemNumberField`](src/components/items/ItemNumberField.tsx) drives the item-number input in all eight form-based types so the copy can't drift:

- Placeholder everywhere: **"Auto-generated if blank"**
- Help text: **"Leave blank to auto-generate (e.g., PN-000001)"** — the example comes from each type's actual scheme
- Always-auto types (Change Orders): **"Auto-generated on creation (e.g., ECO-000001)"**

Tool's inline view/edit widget has no help-text slot, so it gets the standardized placeholder; its format example shows on the admin page instead.

### #3 — Display the scheme (read-only)

- New client-safe [`numbering/format.ts`](src/lib/items/numbering/format.ts) renders scheme examples **without consuming a sequence counter**. It imports only the pure `schemes` data (never `NumberingService`), so no DB code leaks into the client bundle.
- The admin item-type page ([`$itemType.tsx`](src/routes/admin/item-types/$itemType.tsx)) gains a read-only **"Item Numbering"** card: format example, plain-English segment breakdown, manual-entry / family-variant flags, and a pointer to `schemes.ts`. Schemes remain code-defined (matches the code-first philosophy).

## Testing

- `npm run typecheck` — clean for all touched files (only the pre-existing `routeTree.gen.ts` `createFileRoute` noise remains, which is expected outside a build per CLAUDE.md).
- `npm run lint` (`--max-warnings 0`) — clean on every touched file.
- Verified the schema fix directly against the real `partSchema`/`toolSchema`: blank/whitespace → `undefined` (auto-generates), real values preserved.
- No new tests: the change is a schema coercion, which the repo's three-gate testing philosophy explicitly excludes, and no existing test passed an empty-string `itemNumber`.

## Reviewer notes

- The fix is intentionally at `baseItemSchema` (one place) rather than per-form, so it covers types the report didn't mention.
- This is **display-only** for the numbering scheme. An editable per-type editor (persisted as a runtime override like the existing label/permission overrides) would be a natural follow-up; the display helper and admin card are the foundation for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
