### PR TITLE
Software Phase 2: in-app source editing, per-file history, and conflict sharpening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ Comprehensive documentation lives in-repo at [`./docs/`](./docs/README.md).
 
 **Item types**: Part, Document, ChangeOrder, Requirement, Task, WorkInstruction, Issue, Tool, Software. All extend `BaseItem` and register via `ItemTypeRegistry`.
 
-**Software items**: firmware/software configuration items with a content-addressed source store (`software_blobs` + immutable `software_manifests`). The `software.manifestId` pointer rides the item version, so branch isolation and time travel work with no special cases. `SoftwareSourceService` handles imports (files/zip) and tree/file/diff reads. See `docs/proposals/software-management.md`.
+**Software items**: firmware/software configuration items with a content-addressed source store (`software_blobs` + immutable `software_manifests`). The `software.manifestId` pointer rides the item version, so branch isolation and time travel work with no special cases. `SoftwareSourceService` handles imports (files/zip), tree/file/diff reads, and checkout-gated draft editing (`draftManifestId` accumulates edits; an explicit commit promotes the draft and records per-file `source`-category field changes). Software manifest conflicts are sharpened to per-file granularity in `ConflictDetectionService`. See `docs/proposals/software-management.md`.
 
 **Part types**: Parts have a `partType` field: `Manufacture`, `Purchase`, `Phantom` (logical grouping), or `Software`.
 

--- a/docs/api/openapi.v1.json
+++ b/docs/api/openapi.v1.json
@@ -75989,6 +75989,601 @@
         ]
       }
     },
+    "/api/v1/software/{id}/blob/{hash}": {
+      "get": {
+        "operationId": "getApiV1SoftwareByIdBlobByHash",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "hash",
+            "required": true,
+            "schema": {
+              "pattern": "^[a-f0-9]{64}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Server error"
+          }
+        },
+        "summary": "Get source blob content by hash",
+        "tags": [
+          "Software"
+        ]
+      }
+    },
+    "/api/v1/software/{id}/commit": {
+      "post": {
+        "operationId": "postApiV1SoftwareByIdCommit",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "vendor": "zod"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Server error"
+          }
+        },
+        "summary": "Commit the draft source tree",
+        "tags": [
+          "Software"
+        ]
+      }
+    },
     "/api/v1/software/{id}/diff": {
       "get": {
         "operationId": "getApiV1SoftwareByIdDiff",
@@ -76287,7 +76882,590 @@
         ]
       }
     },
+    "/api/v1/software/{id}/draft/discard": {
+      "post": {
+        "operationId": "postApiV1SoftwareByIdDraftDiscard",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Server error"
+          }
+        },
+        "summary": "Discard the draft source tree",
+        "tags": [
+          "Software"
+        ]
+      }
+    },
     "/api/v1/software/{id}/file": {
+      "delete": {
+        "operationId": "deleteApiV1SoftwareByIdFile",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Server error"
+          }
+        },
+        "summary": "Delete a source file from the draft tree",
+        "tags": [
+          "Software"
+        ]
+      },
       "get": {
         "operationId": "getApiV1SoftwareByIdFile",
         "parameters": [
@@ -76609,6 +77787,600 @@
           }
         },
         "summary": "Get a source file from a software item",
+        "tags": [
+          "Software"
+        ]
+      },
+      "put": {
+        "operationId": "putApiV1SoftwareByIdFile",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "vendor": "zod"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Server error"
+          }
+        },
+        "summary": "Save a source file to the draft tree",
+        "tags": [
+          "Software"
+        ]
+      }
+    },
+    "/api/v1/software/{id}/file/rename": {
+      "post": {
+        "operationId": "postApiV1SoftwareByIdFileRename",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "vendor": "zod"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Server error"
+          }
+        },
+        "summary": "Rename a source file in the draft tree",
         "tags": [
           "Software"
         ]
@@ -76945,6 +78717,18 @@
               "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "draft",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -76955,6 +78739,16 @@
                   "properties": {
                     "data": {
                       "properties": {
+                        "draftManifestId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "entries": {
                           "items": {
                             "properties": {
@@ -76980,6 +78774,9 @@
                         "fileCount": {
                           "type": "number"
                         },
+                        "isDraft": {
+                          "type": "boolean"
+                        },
                         "itemId": {
                           "type": "string"
                         },
@@ -77004,6 +78801,8 @@
                         "itemId",
                         "revision",
                         "manifestId",
+                        "draftManifestId",
+                        "isDraft",
                         "fileCount",
                         "totalSize",
                         "entries"
@@ -77287,6 +79086,294 @@
           }
         },
         "summary": "Get the source tree of a software item",
+        "tags": [
+          "Software"
+        ]
+      }
+    },
+    "/api/v1/software/{id}/versions": {
+      "get": {
+        "operationId": "getApiV1SoftwareByIdVersions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Permission denied"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "fieldErrors": {
+                          "additionalProperties": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "timestamp"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Server error"
+          }
+        },
+        "summary": "List all versions of a software item",
         "tags": [
           "Software"
         ]

--- a/docs/proposals/software-management.md
+++ b/docs/proposals/software-management.md
@@ -1,6 +1,6 @@
 # Proposal: Software as a First-Class Item Type
 
-**Status**: Phase 1 implemented (Software item type, content-addressed source store, import + read-only viewer). Phases 2-4 (in-app editing, per-file conflicts, external repos) not yet started.
+**Status**: Phases 1-2 implemented. Phase 1: Software item type, content-addressed source store, import + read-only viewer. Phase 2: checkout-gated in-app editing with draft manifests, per-file `source` history rows, revision/line diff views, per-file conflict sharpening, build-artifact slot. Phases 3-4 (external repos, drift alerts) not yet started.
 **Scope**: Firmware/embedded software management inside Cascadia — in-app code viewing and editing, full participation in the Design/Part/Document versioning model, and integration with external repositories (GitHub, Bitbucket, GitLab).
 
 ---

--- a/drizzle/0005_steady_rhodey.sql
+++ b/drizzle/0005_steady_rhodey.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "software" ADD COLUMN "draft_manifest_id" uuid;--> statement-breakpoint
+ALTER TABLE "software" ADD CONSTRAINT "software_draft_manifest_id_software_manifests_id_fk" FOREIGN KEY ("draft_manifest_id") REFERENCES "public"."software_manifests"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,11050 @@
+{
+  "id": "0c754a2f-5d0b-48b2-960d-20e1ed76c4bd",
+  "prevId": "97f592c3-af5c-4ccc-95dc-6159db28025c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_events": {
+      "name": "auth_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_events_user_id_users_id_fk": {
+          "name": "auth_events_user_id_users_id_fk",
+          "tableFrom": "auth_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'local'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program_members": {
+      "name": "program_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'engineer'"
+        },
+        "can_create_eco": {
+          "name": "can_create_eco",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "can_approve_eco": {
+          "name": "can_approve_eco",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "can_manage_products": {
+          "name": "can_manage_products",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_program_member_user": {
+          "name": "idx_program_member_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "program_members_program_id_programs_id_fk": {
+          "name": "program_members_program_id_programs_id_fk",
+          "tableFrom": "program_members",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_members_user_id_users_id_fk": {
+          "name": "program_members_user_id_users_id_fk",
+          "tableFrom": "program_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_members_invited_by_users_id_fk": {
+          "name": "program_members_invited_by_users_id_fk",
+          "tableFrom": "program_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "program_members_unique": {
+          "name": "program_members_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "program_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_number": {
+          "name": "contract_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer": {
+          "name": "customer",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_end_date": {
+          "name": "target_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_program_status": {
+          "name": "idx_program_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_program_attributes": {
+          "name": "idx_program_attributes",
+          "columns": [
+            {
+              "expression": "attributes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "programs_created_by_users_id_fk": {
+          "name": "programs_created_by_users_id_fk",
+          "tableFrom": "programs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "programs_updated_by_users_id_fk": {
+          "name": "programs_updated_by_users_id_fk",
+          "tableFrom": "programs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "programs_code_unique": {
+          "name": "programs_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.designs": {
+      "name": "designs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "design_type": {
+          "name": "design_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Engineering'"
+        },
+        "parent_design_id": {
+          "name": "parent_design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clone_source_design_id": {
+          "name": "clone_source_design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_design_id": {
+          "name": "source_design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_tag_id": {
+          "name": "source_tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_commit_id": {
+          "name": "source_commit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planned_quantity": {
+          "name": "planned_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch_id": {
+          "name": "default_branch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "sysml_project_id": {
+          "name": "sysml_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_design_program": {
+          "name": "idx_design_program",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_design_type": {
+          "name": "idx_design_type",
+          "columns": [
+            {
+              "expression": "design_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_design_parent": {
+          "name": "idx_design_parent",
+          "columns": [
+            {
+              "expression": "parent_design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_design_clone_source": {
+          "name": "idx_design_clone_source",
+          "columns": [
+            {
+              "expression": "clone_source_design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_design_source": {
+          "name": "idx_design_source",
+          "columns": [
+            {
+              "expression": "source_design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_design_attributes": {
+          "name": "idx_design_attributes",
+          "columns": [
+            {
+              "expression": "attributes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "designs_program_id_programs_id_fk": {
+          "name": "designs_program_id_programs_id_fk",
+          "tableFrom": "designs",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "designs_created_by_users_id_fk": {
+          "name": "designs_created_by_users_id_fk",
+          "tableFrom": "designs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "designs_updated_by_users_id_fk": {
+          "name": "designs_updated_by_users_id_fk",
+          "tableFrom": "designs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "designs_code_unique": {
+          "name": "designs_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.branch_items": {
+      "name": "branch_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_master_id": {
+          "name": "item_master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_item_id": {
+          "name": "current_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_item_id": {
+          "name": "base_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_out_by": {
+          "name": "checked_out_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_out_at": {
+          "name": "checked_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_branch_items_branch": {
+          "name": "idx_branch_items_branch",
+          "columns": [
+            {
+              "expression": "branch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_branch_items_master": {
+          "name": "idx_branch_items_master",
+          "columns": [
+            {
+              "expression": "item_master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_branch_items_checkout": {
+          "name": "idx_branch_items_checkout",
+          "columns": [
+            {
+              "expression": "checked_out_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "branch_items_branch_id_branches_id_fk": {
+          "name": "branch_items_branch_id_branches_id_fk",
+          "tableFrom": "branch_items",
+          "tableTo": "branches",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "branch_items_checked_out_by_users_id_fk": {
+          "name": "branch_items_checked_out_by_users_id_fk",
+          "tableFrom": "branch_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "checked_out_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "branch_items_unique": {
+          "name": "branch_items_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "branch_id",
+            "item_master_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.branches": {
+      "name": "branches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_type": {
+          "name": "branch_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_commit_id": {
+          "name": "head_commit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_commit_id": {
+          "name": "base_commit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_order_item_id": {
+          "name": "change_order_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_tag_id": {
+          "name": "source_tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_branch_design": {
+          "name": "idx_branch_design",
+          "columns": [
+            {
+              "expression": "design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_branch_eco": {
+          "name": "idx_branch_eco",
+          "columns": [
+            {
+              "expression": "change_order_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_branch_owner": {
+          "name": "idx_branch_owner",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_branch_type": {
+          "name": "idx_branch_type",
+          "columns": [
+            {
+              "expression": "branch_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "branches_design_id_designs_id_fk": {
+          "name": "branches_design_id_designs_id_fk",
+          "tableFrom": "branches",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "branches_owner_id_users_id_fk": {
+          "name": "branches_owner_id_users_id_fk",
+          "tableFrom": "branches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "branches_created_by_users_id_fk": {
+          "name": "branches_created_by_users_id_fk",
+          "tableFrom": "branches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "branches_design_name_unique": {
+          "name": "branches_design_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "design_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.commits": {
+      "name": "commits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_parent_id": {
+          "name": "merge_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_changed": {
+          "name": "items_changed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "items_added": {
+          "name": "items_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "items_deleted": {
+          "name": "items_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "change_order_item_id": {
+          "name": "change_order_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revisions_assigned": {
+          "name": "revisions_assigned",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_commit_design": {
+          "name": "idx_commit_design",
+          "columns": [
+            {
+              "expression": "design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_commit_branch": {
+          "name": "idx_commit_branch",
+          "columns": [
+            {
+              "expression": "branch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_commit_parent": {
+          "name": "idx_commit_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_commit_date": {
+          "name": "idx_commit_date",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commits_design_id_designs_id_fk": {
+          "name": "commits_design_id_designs_id_fk",
+          "tableFrom": "commits",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commits_created_by_users_id_fk": {
+          "name": "commits_created_by_users_id_fk",
+          "tableFrom": "commits",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conflict_reviews": {
+      "name": "conflict_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "change_order_id": {
+          "name": "change_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_master_id": {
+          "name": "item_master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflict_type": {
+          "name": "conflict_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "their_eco_id": {
+          "name": "their_eco_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_signature": {
+          "name": "conflict_signature",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_conflict_reviews_change_order": {
+          "name": "idx_conflict_reviews_change_order",
+          "columns": [
+            {
+              "expression": "change_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conflict_reviews_item": {
+          "name": "idx_conflict_reviews_item",
+          "columns": [
+            {
+              "expression": "item_master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conflict_reviews_reviewer": {
+          "name": "idx_conflict_reviews_reviewer",
+          "columns": [
+            {
+              "expression": "reviewed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conflict_reviews_reviewed_by_users_id_fk": {
+          "name": "conflict_reviews_reviewed_by_users_id_fk",
+          "tableFrom": "conflict_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conflict_reviews_unique": {
+          "name": "conflict_reviews_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "change_order_id",
+            "item_master_id",
+            "conflict_type",
+            "their_eco_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_field_changes": {
+      "name": "item_field_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_version_id": {
+          "name": "item_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_category": {
+          "name": "field_category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'core'"
+        }
+      },
+      "indexes": {
+        "idx_field_changes_version": {
+          "name": "idx_field_changes_version",
+          "columns": [
+            {
+              "expression": "item_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_field_changes_field": {
+          "name": "idx_field_changes_field",
+          "columns": [
+            {
+              "expression": "field_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "item_field_changes_item_version_id_item_versions_id_fk": {
+          "name": "item_field_changes_item_version_id_item_versions_id_fk",
+          "tableFrom": "item_field_changes",
+          "tableTo": "item_versions",
+          "columnsFrom": [
+            "item_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_versions": {
+      "name": "item_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_item_id": {
+          "name": "previous_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_item_versions_commit": {
+          "name": "idx_item_versions_commit",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_item_versions_item": {
+          "name": "idx_item_versions_item",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "item_versions_commit_id_commits_id_fk": {
+          "name": "item_versions_commit_id_commits_id_fk",
+          "tableFrom": "item_versions",
+          "tableTo": "commits",
+          "columnsFrom": [
+            "commit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item_versions_unique": {
+          "name": "item_versions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "commit_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_type": {
+          "name": "tag_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'baseline'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tag_design": {
+          "name": "idx_tag_design",
+          "columns": [
+            {
+              "expression": "design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tag_commit": {
+          "name": "idx_tag_commit",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_design_id_designs_id_fk": {
+          "name": "tags_design_id_designs_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tags_commit_id_commits_id_fk": {
+          "name": "tags_commit_id_commits_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "commits",
+          "columnsFrom": [
+            "commit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tags_created_by_users_id_fk": {
+          "name": "tags_created_by_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_design_name_unique": {
+          "name": "tags_design_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "design_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change_order_affected_items": {
+      "name": "change_order_affected_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "change_order_id": {
+          "name": "change_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affected_item_id": {
+          "name": "affected_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affected_item_master_id": {
+          "name": "affected_item_master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_action": {
+          "name": "change_action",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_state": {
+          "name": "current_state",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_revision": {
+          "name": "current_revision",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_state": {
+          "name": "target_state",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_revision": {
+          "name": "target_revision",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacement_item_id": {
+          "name": "replacement_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_item_data": {
+          "name": "new_item_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_item_type": {
+          "name": "new_item_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_description": {
+          "name": "change_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_directly_affected": {
+          "name": "is_directly_affected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "working_copy_id": {
+          "name": "working_copy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_change_order": {
+          "name": "idx_change_order",
+          "columns": [
+            {
+              "expression": "change_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_affected_item": {
+          "name": "idx_affected_item",
+          "columns": [
+            {
+              "expression": "affected_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_working_copy": {
+          "name": "idx_working_copy",
+          "columns": [
+            {
+              "expression": "working_copy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_order_affected_items_change_order_id_change_orders_item_id_fk": {
+          "name": "change_order_affected_items_change_order_id_change_orders_item_id_fk",
+          "tableFrom": "change_order_affected_items",
+          "tableTo": "change_orders",
+          "columnsFrom": [
+            "change_order_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_order_affected_items_affected_item_id_items_id_fk": {
+          "name": "change_order_affected_items_affected_item_id_items_id_fk",
+          "tableFrom": "change_order_affected_items",
+          "tableTo": "items",
+          "columnsFrom": [
+            "affected_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_order_affected_items_replacement_item_id_items_id_fk": {
+          "name": "change_order_affected_items_replacement_item_id_items_id_fk",
+          "tableFrom": "change_order_affected_items",
+          "tableTo": "items",
+          "columnsFrom": [
+            "replacement_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "change_order_affected_items_working_copy_id_items_id_fk": {
+          "name": "change_order_affected_items_working_copy_id_items_id_fk",
+          "tableFrom": "change_order_affected_items",
+          "tableTo": "items",
+          "columnsFrom": [
+            "working_copy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "change_order_affected_items_created_by_users_id_fk": {
+          "name": "change_order_affected_items_created_by_users_id_fk",
+          "tableFrom": "change_order_affected_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change_order_designs": {
+      "name": "change_order_designs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "change_order_id": {
+          "name": "change_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_status": {
+          "name": "merge_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_commit_id": {
+          "name": "merge_commit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "items_affected": {
+          "name": "items_affected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cod_change_order": {
+          "name": "idx_cod_change_order",
+          "columns": [
+            {
+              "expression": "change_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cod_design": {
+          "name": "idx_cod_design",
+          "columns": [
+            {
+              "expression": "design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cod_branch": {
+          "name": "idx_cod_branch",
+          "columns": [
+            {
+              "expression": "branch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_order_designs_change_order_id_items_id_fk": {
+          "name": "change_order_designs_change_order_id_items_id_fk",
+          "tableFrom": "change_order_designs",
+          "tableTo": "items",
+          "columnsFrom": [
+            "change_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_order_designs_design_id_designs_id_fk": {
+          "name": "change_order_designs_design_id_designs_id_fk",
+          "tableFrom": "change_order_designs",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_order_designs_branch_id_branches_id_fk": {
+          "name": "change_order_designs_branch_id_branches_id_fk",
+          "tableFrom": "change_order_designs",
+          "tableTo": "branches",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "change_order_designs_merge_commit_id_commits_id_fk": {
+          "name": "change_order_designs_merge_commit_id_commits_id_fk",
+          "tableFrom": "change_order_designs",
+          "tableTo": "commits",
+          "columnsFrom": [
+            "merge_commit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "change_order_designs_unique": {
+          "name": "change_order_designs_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "change_order_id",
+            "design_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change_order_impact_reports": {
+      "name": "change_order_impact_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "change_order_id": {
+          "name": "change_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "total_impacted_items": {
+          "name": "total_impacted_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_bom_depth": {
+          "name": "max_bom_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_data": {
+          "name": "report_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_duration_ms": {
+          "name": "generation_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "change_order_impact_reports_change_order_id_change_orders_item_id_fk": {
+          "name": "change_order_impact_reports_change_order_id_change_orders_item_id_fk",
+          "tableFrom": "change_order_impact_reports",
+          "tableTo": "change_orders",
+          "columnsFrom": [
+            "change_order_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "change_order_impact_reports_change_order_id_unique": {
+          "name": "change_order_impact_reports_change_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "change_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change_order_impacted_items": {
+      "name": "change_order_impacted_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "change_order_id": {
+          "name": "change_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impacted_item_id": {
+          "name": "impacted_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact_type": {
+          "name": "impact_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact_severity": {
+          "name": "impact_severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_co_impacted": {
+          "name": "idx_co_impacted",
+          "columns": [
+            {
+              "expression": "change_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_impacted_item": {
+          "name": "idx_impacted_item",
+          "columns": [
+            {
+              "expression": "impacted_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_order_impacted_items_change_order_id_change_orders_item_id_fk": {
+          "name": "change_order_impacted_items_change_order_id_change_orders_item_id_fk",
+          "tableFrom": "change_order_impacted_items",
+          "tableTo": "change_orders",
+          "columnsFrom": [
+            "change_order_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_order_impacted_items_impacted_item_id_items_id_fk": {
+          "name": "change_order_impacted_items_impacted_item_id_items_id_fk",
+          "tableFrom": "change_order_impacted_items",
+          "tableTo": "items",
+          "columnsFrom": [
+            "impacted_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change_order_risks": {
+      "name": "change_order_risks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "change_order_id": {
+          "name": "change_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affected_items": {
+          "name": "affected_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mitigation": {
+          "name": "mitigation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_acknowledgement": {
+          "name": "requires_acknowledgement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "acknowledged_by": {
+          "name": "acknowledged_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_co_risks": {
+          "name": "idx_co_risks",
+          "columns": [
+            {
+              "expression": "change_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_order_risks_change_order_id_change_orders_item_id_fk": {
+          "name": "change_order_risks_change_order_id_change_orders_item_id_fk",
+          "tableFrom": "change_order_risks",
+          "tableTo": "change_orders",
+          "columnsFrom": [
+            "change_order_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_order_risks_acknowledged_by_users_id_fk": {
+          "name": "change_order_risks_acknowledged_by_users_id_fk",
+          "tableFrom": "change_order_risks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "acknowledged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change_orders": {
+      "name": "change_orders",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'medium'"
+        },
+        "reason_for_change": {
+          "name": "reason_for_change",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impact_description": {
+          "name": "impact_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "implementation_date": {
+          "name": "implementation_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "implemented_at": {
+          "name": "implemented_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impact_assessment_status": {
+          "name": "impact_assessment_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_baseline": {
+          "name": "is_baseline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "baseline_name": {
+          "name": "baseline_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "change_orders_item_id_items_id_fk": {
+          "name": "change_orders_item_id_items_id_fk",
+          "tableFrom": "change_orders",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_orders_approved_by_users_id_fk": {
+          "name": "change_orders_approved_by_users_id_fk",
+          "tableFrom": "change_orders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "documents_item_id_items_id_fk": {
+          "name": "documents_item_id_items_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_affected_items": {
+      "name": "issue_affected_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_item_id": {
+          "name": "issue_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affected_item_id": {
+          "name": "affected_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issue_affected_items_issue": {
+          "name": "idx_issue_affected_items_issue",
+          "columns": [
+            {
+              "expression": "issue_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_affected_items_item": {
+          "name": "idx_issue_affected_items_item",
+          "columns": [
+            {
+              "expression": "affected_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_affected_items_issue_item_id_issues_item_id_fk": {
+          "name": "issue_affected_items_issue_item_id_issues_item_id_fk",
+          "tableFrom": "issue_affected_items",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_affected_items_affected_item_id_items_id_fk": {
+          "name": "issue_affected_items_affected_item_id_items_id_fk",
+          "tableFrom": "issue_affected_items",
+          "tableTo": "items",
+          "columnsFrom": [
+            "affected_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_issue_affected_item": {
+          "name": "uq_issue_affected_item",
+          "nullsNotDistinct": false,
+          "columns": [
+            "issue_item_id",
+            "affected_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_designs": {
+      "name": "issue_designs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_item_id": {
+          "name": "issue_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issue_designs_issue": {
+          "name": "idx_issue_designs_issue",
+          "columns": [
+            {
+              "expression": "issue_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_designs_design": {
+          "name": "idx_issue_designs_design",
+          "columns": [
+            {
+              "expression": "design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_designs_issue_item_id_issues_item_id_fk": {
+          "name": "issue_designs_issue_item_id_issues_item_id_fk",
+          "tableFrom": "issue_designs",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_item_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_designs_design_id_designs_id_fk": {
+          "name": "issue_designs_design_id_designs_id_fk",
+          "tableFrom": "issue_designs",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_issue_design": {
+          "name": "uq_issue_design",
+          "nullsNotDistinct": false,
+          "columns": [
+            "issue_item_id",
+            "design_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_by": {
+          "name": "reported_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_date": {
+          "name": "reported_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_issue_severity": {
+          "name": "idx_issue_severity",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_priority": {
+          "name": "idx_issue_priority",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_category": {
+          "name": "idx_issue_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_assigned": {
+          "name": "idx_issue_assigned",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_program": {
+          "name": "idx_issue_program",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_item_id_items_id_fk": {
+          "name": "issues_item_id_items_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issues_reported_by_users_id_fk": {
+          "name": "issues_reported_by_users_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reported_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_assigned_to_users_id_fk": {
+          "name": "issues_assigned_to_users_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_program_id_programs_id_fk": {
+          "name": "issues_program_id_programs_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_relationships": {
+      "name": "item_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship_type": {
+          "name": "relationship_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_designator": {
+          "name": "reference_designator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "find_number": {
+          "name": "find_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_composite": {
+          "name": "is_composite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_directed": {
+          "name": "is_directed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "multiplicity_lower": {
+          "name": "multiplicity_lower",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "multiplicity_upper": {
+          "name": "multiplicity_upper",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_attributes": {
+          "name": "usage_attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_by": {
+          "name": "modified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_design_id": {
+          "name": "source_design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_design_id": {
+          "name": "target_design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_domain": {
+          "name": "source_domain",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_domain": {
+          "name": "target_domain",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivation_method": {
+          "name": "derivation_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivation_notes": {
+          "name": "derivation_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_source": {
+          "name": "idx_source",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_target": {
+          "name": "idx_target",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_relationship_type": {
+          "name": "idx_relationship_type",
+          "columns": [
+            {
+              "expression": "relationship_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cross_design": {
+          "name": "idx_cross_design",
+          "columns": [
+            {
+              "expression": "source_design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "item_relationships_source_id_items_id_fk": {
+          "name": "item_relationships_source_id_items_id_fk",
+          "tableFrom": "item_relationships",
+          "tableTo": "items",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "item_relationships_target_id_items_id_fk": {
+          "name": "item_relationships_target_id_items_id_fk",
+          "tableFrom": "item_relationships",
+          "tableTo": "items",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "item_relationships_created_by_users_id_fk": {
+          "name": "item_relationships_created_by_users_id_fk",
+          "tableFrom": "item_relationships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "item_relationships_modified_by_users_id_fk": {
+          "name": "item_relationships_modified_by_users_id_fk",
+          "tableFrom": "item_relationships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "modified_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "item_relationships_source_design_id_designs_id_fk": {
+          "name": "item_relationships_source_design_id_designs_id_fk",
+          "tableFrom": "item_relationships",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "source_design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "item_relationships_target_design_id_designs_id_fk": {
+          "name": "item_relationships_target_design_id_designs_id_fk",
+          "tableFrom": "item_relationships",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "target_design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item_relationships_source_id_target_id_relationship_type_unique": {
+          "name": "item_relationships_source_id_target_id_relationship_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "target_id",
+            "relationship_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_number": {
+          "name": "item_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Draft'"
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_by": {
+          "name": "modified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_design_structure": {
+          "name": "in_design_structure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "metamodel": {
+          "name": "metamodel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cascadia'"
+        },
+        "sysml_type": {
+          "name": "sysml_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_of": {
+          "name": "usage_of",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_master_id": {
+          "name": "idx_master_id",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_item_type_state": {
+          "name": "idx_item_type_state",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_current": {
+          "name": "idx_current",
+          "columns": [
+            {
+              "expression": "is_current",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_item_design": {
+          "name": "idx_item_design",
+          "columns": [
+            {
+              "expression": "design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_item_commit": {
+          "name": "idx_item_commit",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_item_attributes": {
+          "name": "idx_item_attributes",
+          "columns": [
+            {
+              "expression": "attributes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_item_usage_of": {
+          "name": "idx_item_usage_of",
+          "columns": [
+            {
+              "expression": "usage_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_items_fts": {
+          "name": "idx_items_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', coalesce(\"item_number\", '') || ' ' || coalesce(\"name\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "items_created_by_users_id_fk": {
+          "name": "items_created_by_users_id_fk",
+          "tableFrom": "items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "items_modified_by_users_id_fk": {
+          "name": "items_modified_by_users_id_fk",
+          "tableFrom": "items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "modified_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "items_locked_by_users_id_fk": {
+          "name": "items_locked_by_users_id_fk",
+          "tableFrom": "items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "locked_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "items_design_id_designs_id_fk": {
+          "name": "items_design_id_designs_id_fk",
+          "tableFrom": "items",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "items_commit_id_commits_id_fk": {
+          "name": "items_commit_id_commits_id_fk",
+          "tableFrom": "items",
+          "tableTo": "commits",
+          "columnsFrom": [
+            "commit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "items_deleted_by_users_id_fk": {
+          "name": "items_deleted_by_users_id_fk",
+          "tableFrom": "items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "items_item_number_revision_design_id_item_type_unique": {
+          "name": "items_item_number_revision_design_id_item_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_number",
+            "revision",
+            "design_id",
+            "item_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parts": {
+      "name": "parts",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "part_type": {
+          "name": "part_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "material": {
+          "name": "material",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_time_days": {
+          "name": "lead_time_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity_on_hand": {
+          "name": "quantity_on_hand",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inventory_check": {
+          "name": "last_inventory_check",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parts_item_id_items_id_fk": {
+          "name": "parts_item_id_items_id_fk",
+          "tableFrom": "parts",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.requirements": {
+      "name": "requirements",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptance_criteria": {
+          "name": "acceptance_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_method": {
+          "name": "verification_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_design_id": {
+          "name": "allocated_design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_requirement_id": {
+          "name": "parent_requirement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_req_parent": {
+          "name": "idx_req_parent",
+          "columns": [
+            {
+              "expression": "parent_requirement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_req_allocated": {
+          "name": "idx_req_allocated",
+          "columns": [
+            {
+              "expression": "allocated_design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_req_verification_status": {
+          "name": "idx_req_verification_status",
+          "columns": [
+            {
+              "expression": "verification_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "requirements_item_id_items_id_fk": {
+          "name": "requirements_item_id_items_id_fk",
+          "tableFrom": "requirements",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "requirements_allocated_design_id_designs_id_fk": {
+          "name": "requirements_allocated_design_id_designs_id_fk",
+          "tableFrom": "requirements",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "allocated_design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "requirements_parent_requirement_id_items_id_fk": {
+          "name": "requirements_parent_requirement_id_items_id_fk",
+          "tableFrom": "requirements",
+          "tableTo": "items",
+          "columnsFrom": [
+            "parent_requirement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_task_id": {
+          "name": "parent_task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee": {
+          "name": "assignee",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_hours": {
+          "name": "estimated_hours",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_hours": {
+          "name": "actual_hours",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_task_program": {
+          "name": "idx_task_program",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_task_assignee": {
+          "name": "idx_task_assignee",
+          "columns": [
+            {
+              "expression": "assignee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_parent_task": {
+          "name": "idx_parent_task",
+          "columns": [
+            {
+              "expression": "parent_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_item_id_items_id_fk": {
+          "name": "tasks_item_id_items_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_program_id_programs_id_fk": {
+          "name": "tasks_program_id_programs_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_parent_task_id_items_id_fk": {
+          "name": "tasks_parent_task_id_items_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "items",
+          "columnsFrom": [
+            "parent_task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_users_id_fk": {
+          "name": "tasks_assignee_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_cases": {
+      "name": "test_cases",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_plan_id": {
+          "name": "test_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preconditions": {
+          "name": "preconditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_status": {
+          "name": "execution_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_executed_by": {
+          "name": "last_executed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_test_case_plan": {
+          "name": "idx_test_case_plan",
+          "columns": [
+            {
+              "expression": "test_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_execution_status": {
+          "name": "idx_test_execution_status",
+          "columns": [
+            {
+              "expression": "execution_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_cases_item_id_items_id_fk": {
+          "name": "test_cases_item_id_items_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_cases_test_plan_id_items_id_fk": {
+          "name": "test_cases_test_plan_id_items_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "items",
+          "columnsFrom": [
+            "test_plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_cases_last_executed_by_users_id_fk": {
+          "name": "test_cases_last_executed_by_users_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "last_executed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_executions": {
+      "name": "test_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executor_id": {
+          "name": "executor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_results": {
+          "name": "actual_results",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_test_exec_test_case": {
+          "name": "idx_test_exec_test_case",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_exec_date": {
+          "name": "idx_test_exec_date",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_executions_test_case_id_items_id_fk": {
+          "name": "test_executions_test_case_id_items_id_fk",
+          "tableFrom": "test_executions",
+          "tableTo": "items",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_executions_executor_id_users_id_fk": {
+          "name": "test_executions_executor_id_users_id_fk",
+          "tableFrom": "test_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "executor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_plans": {
+      "name": "test_plans",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_criteria": {
+          "name": "entry_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_criteria": {
+          "name": "exit_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_plans_item_id_items_id_fk": {
+          "name": "test_plans_item_id_items_id_fk",
+          "tableFrom": "test_plans",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tools": {
+      "name": "tools",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tool_type": {
+          "name": "tool_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_subtype": {
+          "name": "tool_subtype",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_status": {
+          "name": "tool_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'available'"
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tools_item_id_items_id_fk": {
+          "name": "tools_item_id_items_id_fk",
+          "tableFrom": "tools",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_instruction_change_alerts": {
+      "name": "work_instruction_change_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_instruction_id": {
+          "name": "work_instruction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_id": {
+          "name": "part_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eco_id": {
+          "name": "eco_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_fields": {
+          "name": "changed_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_values": {
+          "name": "previous_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "acknowledged_by": {
+          "name": "acknowledged_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wi_alert_wi": {
+          "name": "idx_wi_alert_wi",
+          "columns": [
+            {
+              "expression": "work_instruction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wi_alert_part": {
+          "name": "idx_wi_alert_part",
+          "columns": [
+            {
+              "expression": "part_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wi_alert_status": {
+          "name": "idx_wi_alert_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wi_alert_eco": {
+          "name": "idx_wi_alert_eco",
+          "columns": [
+            {
+              "expression": "eco_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_instruction_change_alerts_work_instruction_id_work_instructions_item_id_fk": {
+          "name": "work_instruction_change_alerts_work_instruction_id_work_instructions_item_id_fk",
+          "tableFrom": "work_instruction_change_alerts",
+          "tableTo": "work_instructions",
+          "columnsFrom": [
+            "work_instruction_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_instruction_change_alerts_part_id_items_id_fk": {
+          "name": "work_instruction_change_alerts_part_id_items_id_fk",
+          "tableFrom": "work_instruction_change_alerts",
+          "tableTo": "items",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_instruction_change_alerts_eco_id_items_id_fk": {
+          "name": "work_instruction_change_alerts_eco_id_items_id_fk",
+          "tableFrom": "work_instruction_change_alerts",
+          "tableTo": "items",
+          "columnsFrom": [
+            "eco_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "work_instruction_change_alerts_acknowledged_by_users_id_fk": {
+          "name": "work_instruction_change_alerts_acknowledged_by_users_id_fk",
+          "tableFrom": "work_instruction_change_alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "acknowledged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_instruction_operations": {
+      "name": "work_instruction_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_instruction_id": {
+          "name": "work_instruction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_time": {
+          "name": "estimated_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wi_operation_order": {
+          "name": "idx_wi_operation_order",
+          "columns": [
+            {
+              "expression": "work_instruction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_instruction_operations_work_instruction_id_work_instructions_item_id_fk": {
+          "name": "work_instruction_operations_work_instruction_id_work_instructions_item_id_fk",
+          "tableFrom": "work_instruction_operations",
+          "tableTo": "work_instructions",
+          "columnsFrom": [
+            "work_instruction_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_instruction_part_attachments": {
+      "name": "work_instruction_part_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_instruction_id": {
+          "name": "work_instruction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_id": {
+          "name": "part_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inherit_to_mbom": {
+          "name": "inherit_to_mbom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "inherited_from_id": {
+          "name": "inherited_from_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_wi_part_wi": {
+          "name": "idx_wi_part_wi",
+          "columns": [
+            {
+              "expression": "work_instruction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wi_part_part": {
+          "name": "idx_wi_part_part",
+          "columns": [
+            {
+              "expression": "part_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_instruction_part_attachments_work_instruction_id_work_instructions_item_id_fk": {
+          "name": "work_instruction_part_attachments_work_instruction_id_work_instructions_item_id_fk",
+          "tableFrom": "work_instruction_part_attachments",
+          "tableTo": "work_instructions",
+          "columnsFrom": [
+            "work_instruction_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_instruction_part_attachments_part_id_items_id_fk": {
+          "name": "work_instruction_part_attachments_part_id_items_id_fk",
+          "tableFrom": "work_instruction_part_attachments",
+          "tableTo": "items",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_instruction_part_attachments_created_by_users_id_fk": {
+          "name": "work_instruction_part_attachments_created_by_users_id_fk",
+          "tableFrom": "work_instruction_part_attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wi_part_attachment_unique": {
+          "name": "wi_part_attachment_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "work_instruction_id",
+            "part_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_instruction_steps": {
+      "name": "work_instruction_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_instruction_id": {
+          "name": "work_instruction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"blocks\":[]}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wi_step_order": {
+          "name": "idx_wi_step_order",
+          "columns": [
+            {
+              "expression": "work_instruction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wi_step_operation": {
+          "name": "idx_wi_step_operation",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_instruction_steps_work_instruction_id_work_instructions_item_id_fk": {
+          "name": "work_instruction_steps_work_instruction_id_work_instructions_item_id_fk",
+          "tableFrom": "work_instruction_steps",
+          "tableTo": "work_instructions",
+          "columnsFrom": [
+            "work_instruction_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_instruction_steps_operation_id_work_instruction_operations_id_fk": {
+          "name": "work_instruction_steps_operation_id_work_instruction_operations_id_fk",
+          "tableFrom": "work_instruction_steps",
+          "tableTo": "work_instruction_operations",
+          "columnsFrom": [
+            "operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_instructions": {
+      "name": "work_instructions",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_time": {
+          "name": "estimated_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safety_notes": {
+          "name": "safety_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_tools": {
+          "name": "required_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "work_instructions_item_id_items_id_fk": {
+          "name": "work_instructions_item_id_items_id_fk",
+          "tableFrom": "work_instructions",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.software": {
+      "name": "software",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_type": {
+          "name": "software_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_mode": {
+          "name": "source_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal'"
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_hardware": {
+          "name": "target_hardware",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolchain": {
+          "name": "toolchain",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_id": {
+          "name": "manifest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_manifest_id": {
+          "name": "draft_manifest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_artifact_file_id": {
+          "name": "build_artifact_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_software_manifest": {
+          "name": "idx_software_manifest",
+          "columns": [
+            {
+              "expression": "manifest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "software_item_id_items_id_fk": {
+          "name": "software_item_id_items_id_fk",
+          "tableFrom": "software",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "software_manifest_id_software_manifests_id_fk": {
+          "name": "software_manifest_id_software_manifests_id_fk",
+          "tableFrom": "software",
+          "tableTo": "software_manifests",
+          "columnsFrom": [
+            "manifest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "software_draft_manifest_id_software_manifests_id_fk": {
+          "name": "software_draft_manifest_id_software_manifests_id_fk",
+          "tableFrom": "software",
+          "tableTo": "software_manifests",
+          "columnsFrom": [
+            "draft_manifest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.software_blobs": {
+      "name": "software_blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vault_file_id": {
+          "name": "vault_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_binary": {
+          "name": "is_binary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.software_manifests": {
+      "name": "software_manifests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_size": {
+          "name": "total_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "software_manifests_created_by_users_id_fk": {
+          "name": "software_manifests_created_by_users_id_fk",
+          "tableFrom": "software_manifests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execution_sign_offs": {
+      "name": "execution_sign_offs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sign_off_execution": {
+          "name": "idx_sign_off_execution",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sign_off_reviewer": {
+          "name": "idx_sign_off_reviewer",
+          "columns": [
+            {
+              "expression": "reviewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "execution_sign_offs_execution_id_work_instruction_executions_id_fk": {
+          "name": "execution_sign_offs_execution_id_work_instruction_executions_id_fk",
+          "tableFrom": "execution_sign_offs",
+          "tableTo": "work_instruction_executions",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "execution_sign_offs_reviewer_id_users_id_fk": {
+          "name": "execution_sign_offs_reviewer_id_users_id_fk",
+          "tableFrom": "execution_sign_offs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_instruction_executions": {
+      "name": "work_instruction_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_instruction_id": {
+          "name": "work_instruction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_instruction_revision": {
+          "name": "work_instruction_revision",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_order_id": {
+          "name": "work_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_by": {
+          "name": "executed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'In Progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_data": {
+          "name": "step_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step_index": {
+          "name": "current_step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_wi_execution_wi": {
+          "name": "idx_wi_execution_wi",
+          "columns": [
+            {
+              "expression": "work_instruction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wi_execution_wo": {
+          "name": "idx_wi_execution_wo",
+          "columns": [
+            {
+              "expression": "work_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wi_execution_user": {
+          "name": "idx_wi_execution_user",
+          "columns": [
+            {
+              "expression": "executed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wi_execution_status": {
+          "name": "idx_wi_execution_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wi_execution_started": {
+          "name": "idx_wi_execution_started",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_instruction_executions_work_instruction_id_work_instructions_item_id_fk": {
+          "name": "work_instruction_executions_work_instruction_id_work_instructions_item_id_fk",
+          "tableFrom": "work_instruction_executions",
+          "tableTo": "work_instructions",
+          "columnsFrom": [
+            "work_instruction_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_instruction_executions_work_order_id_work_orders_id_fk": {
+          "name": "work_instruction_executions_work_order_id_work_orders_id_fk",
+          "tableFrom": "work_instruction_executions",
+          "tableTo": "work_orders",
+          "columnsFrom": [
+            "work_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "work_instruction_executions_executed_by_users_id_fk": {
+          "name": "work_instruction_executions_executed_by_users_id_fk",
+          "tableFrom": "work_instruction_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "executed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_orders": {
+      "name": "work_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_order_number": {
+          "name": "work_order_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_id": {
+          "name": "part_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Not Started'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Normal'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_order": {
+          "name": "customer_order",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity_completed": {
+          "name": "quantity_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "requires_sign_off": {
+          "name": "requires_sign_off",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_by": {
+          "name": "modified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_work_order_status": {
+          "name": "idx_work_order_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_work_order_part": {
+          "name": "idx_work_order_part",
+          "columns": [
+            {
+              "expression": "part_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_work_order_due_date": {
+          "name": "idx_work_order_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_work_order_program": {
+          "name": "idx_work_order_program",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_work_order_customer": {
+          "name": "idx_work_order_customer",
+          "columns": [
+            {
+              "expression": "customer_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_orders_part_id_items_id_fk": {
+          "name": "work_orders_part_id_items_id_fk",
+          "tableFrom": "work_orders",
+          "tableTo": "items",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "work_orders_program_id_programs_id_fk": {
+          "name": "work_orders_program_id_programs_id_fk",
+          "tableFrom": "work_orders",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "work_orders_created_by_users_id_fk": {
+          "name": "work_orders_created_by_users_id_fk",
+          "tableFrom": "work_orders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "work_orders_modified_by_users_id_fk": {
+          "name": "work_orders_modified_by_users_id_fk",
+          "tableFrom": "work_orders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "modified_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "work_orders_work_order_number_unique": {
+          "name": "work_orders_work_order_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "work_order_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_approval_votes": {
+      "name": "workflow_approval_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_id": {
+          "name": "state_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote": {
+          "name": "vote",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_approval_votes_workflow_instance_id_workflow_instances_id_fk": {
+          "name": "workflow_approval_votes_workflow_instance_id_workflow_instances_id_fk",
+          "tableFrom": "workflow_approval_votes",
+          "tableTo": "workflow_instances",
+          "columnsFrom": [
+            "workflow_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_approval_votes_user_id_users_id_fk": {
+          "name": "workflow_approval_votes_user_id_users_id_fk",
+          "tableFrom": "workflow_approval_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definitions": {
+      "name": "workflow_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_type": {
+          "name": "workflow_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lifecycle_type": {
+          "name": "lifecycle_type",
+          "type": "lifecycle_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Free'"
+        },
+        "drivers": {
+          "name": "drivers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_definitions_name_unique": {
+          "name": "workflow_definitions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_history": {
+      "name": "workflow_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_state": {
+          "name": "from_state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_state": {
+          "name": "to_state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_history_instance_id_workflow_instances_id_fk": {
+          "name": "workflow_history_instance_id_workflow_instances_id_fk",
+          "tableFrom": "workflow_history",
+          "tableTo": "workflow_instances",
+          "columnsFrom": [
+            "instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_history_actor_id_users_id_fk": {
+          "name": "workflow_history_actor_id_users_id_fk",
+          "tableFrom": "workflow_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_instances": {
+      "name": "workflow_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_definition_id": {
+          "name": "workflow_definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_state": {
+          "name": "current_state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_states": {
+          "name": "instance_states",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_transitions": {
+          "name": "instance_transitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_locked": {
+          "name": "scope_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "scope_locked_at": {
+          "name": "scope_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_instances_workflow_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_instances_workflow_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_instances",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "workflow_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_instances_item_id_items_id_fk": {
+          "name": "workflow_instances_item_id_items_id_fk",
+          "tableFrom": "workflow_instances",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_state_approvers": {
+      "name": "workflow_state_approvers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_definition_id": {
+          "name": "workflow_definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_id": {
+          "name": "state_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approver_type": {
+          "name": "approver_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approver_id": {
+          "name": "approver_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_state_approvers_workflow_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_state_approvers_workflow_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_state_approvers",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "workflow_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_state_approvers_created_by_users_id_fk": {
+          "name": "workflow_state_approvers_created_by_users_id_fk",
+          "tableFrom": "workflow_state_approvers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_file_history": {
+      "name": "vault_file_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_vault_history_file_id": {
+          "name": "idx_vault_history_file_id",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vault_history_performed_by": {
+          "name": "idx_vault_history_performed_by",
+          "columns": [
+            {
+              "expression": "performed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vault_history_performed_at": {
+          "name": "idx_vault_history_performed_at",
+          "columns": [
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vault_file_history_file_id_vault_files_id_fk": {
+          "name": "vault_file_history_file_id_vault_files_id_fk",
+          "tableFrom": "vault_file_history",
+          "tableTo": "vault_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vault_file_history_performed_by_users_id_fk": {
+          "name": "vault_file_history_performed_by_users_id_fk",
+          "tableFrom": "vault_file_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_files": {
+      "name": "vault_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_file_name": {
+          "name": "original_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_version": {
+          "name": "file_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_latest_version": {
+          "name": "is_latest_version",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_checked_out": {
+          "name": "is_checked_out",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "checked_out_by": {
+          "name": "checked_out_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_out_at": {
+          "name": "checked_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_category": {
+          "name": "file_category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary_model": {
+          "name": "is_primary_model",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cad_metadata": {
+          "name": "cad_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_file_id": {
+          "name": "thumbnail_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_vault_files_item_id": {
+          "name": "idx_vault_files_item_id",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vault_files_branch_id": {
+          "name": "idx_vault_files_branch_id",
+          "columns": [
+            {
+              "expression": "branch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vault_files_hash": {
+          "name": "idx_vault_files_hash",
+          "columns": [
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vault_files_checked_out_by": {
+          "name": "idx_vault_files_checked_out_by",
+          "columns": [
+            {
+              "expression": "checked_out_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vault_files_latest": {
+          "name": "idx_vault_files_latest",
+          "columns": [
+            {
+              "expression": "is_latest_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vault_files_deleted": {
+          "name": "idx_vault_files_deleted",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vault_files_category": {
+          "name": "idx_vault_files_category",
+          "columns": [
+            {
+              "expression": "file_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vault_files_primary": {
+          "name": "idx_vault_files_primary",
+          "columns": [
+            {
+              "expression": "is_primary_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vault_files_thumbnail": {
+          "name": "idx_vault_files_thumbnail",
+          "columns": [
+            {
+              "expression": "thumbnail_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vault_files_item_id_items_id_fk": {
+          "name": "vault_files_item_id_items_id_fk",
+          "tableFrom": "vault_files",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vault_files_branch_id_branches_id_fk": {
+          "name": "vault_files_branch_id_branches_id_fk",
+          "tableFrom": "vault_files",
+          "tableTo": "branches",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vault_files_checked_out_by_users_id_fk": {
+          "name": "vault_files_checked_out_by_users_id_fk",
+          "tableFrom": "vault_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "checked_out_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vault_files_uploaded_by_users_id_fk": {
+          "name": "vault_files_uploaded_by_users_id_fk",
+          "tableFrom": "vault_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vault_files_deleted_by_users_id_fk": {
+          "name": "vault_files_deleted_by_users_id_fk",
+          "tableFrom": "vault_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "json_value": {
+          "name": "json_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_by": {
+          "name": "modified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_modified_by_users_id_fk": {
+          "name": "settings_modified_by_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "modified_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cots_components": {
+      "name": "cots_components",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mpn": {
+          "name": "mpn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specs": {
+          "name": "specs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datasheet_url": {
+          "name": "datasheet_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_links": {
+          "name": "supplier_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_date": {
+          "name": "import_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cots_components_tags_idx": {
+          "name": "cots_components_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cots_components_manufacturer_idx": {
+          "name": "cots_components_manufacturer_idx",
+          "columns": [
+            {
+              "expression": "manufacturer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cots_components_source_idx": {
+          "name": "cots_components_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.part_cots_mapping": {
+      "name": "part_cots_mapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "part_id": {
+          "name": "part_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cots_component_id": {
+          "name": "cots_component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_preferred": {
+          "name": "is_preferred",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "part_cots_mapping_part_idx": {
+          "name": "part_cots_mapping_part_idx",
+          "columns": [
+            {
+              "expression": "part_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "part_cots_mapping_cots_idx": {
+          "name": "part_cots_mapping_cots_idx",
+          "columns": [
+            {
+              "expression": "cots_component_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "part_cots_mapping_part_id_parts_item_id_fk": {
+          "name": "part_cots_mapping_part_id_parts_item_id_fk",
+          "tableFrom": "part_cots_mapping",
+          "tableTo": "parts",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "part_cots_mapping_cots_component_id_cots_components_id_fk": {
+          "name": "part_cots_mapping_cots_component_id_cots_components_id_fk",
+          "tableFrom": "part_cots_mapping",
+          "tableTo": "cots_components",
+          "columnsFrom": [
+            "cots_component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "part_cots_mapping_created_by_users_id_fk": {
+          "name": "part_cots_mapping_created_by_users_id_fk",
+          "tableFrom": "part_cots_mapping",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_columns": {
+      "name": "report_columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "format_type": {
+          "name": "format_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_report_columns_report": {
+          "name": "idx_report_columns_report",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_columns_report_id_reports_id_fk": {
+          "name": "report_columns_report_id_reports_id_fk",
+          "tableFrom": "report_columns",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_executions": {
+      "name": "report_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_by": {
+          "name": "executed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_report_executions_report": {
+          "name": "idx_report_executions_report",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_report_executions_executed_by": {
+          "name": "idx_report_executions_executed_by",
+          "columns": [
+            {
+              "expression": "executed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_report_executions_executed_at": {
+          "name": "idx_report_executions_executed_at",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_executions_report_id_reports_id_fk": {
+          "name": "report_executions_report_id_reports_id_fk",
+          "tableFrom": "report_executions",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_executions_executed_by_users_id_fk": {
+          "name": "report_executions_executed_by_users_id_fk",
+          "tableFrom": "report_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "executed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_exports": {
+      "name": "report_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exported_by": {
+          "name": "exported_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exported_at": {
+          "name": "exported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'csv'"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_report_exports_report": {
+          "name": "idx_report_exports_report",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_report_exports_exported_by": {
+          "name": "idx_report_exports_exported_by",
+          "columns": [
+            {
+              "expression": "exported_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_exports_report_id_reports_id_fk": {
+          "name": "report_exports_report_id_reports_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_exports_execution_id_report_executions_id_fk": {
+          "name": "report_exports_execution_id_report_executions_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "report_executions",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "report_exports_exported_by_users_id_fk": {
+          "name": "report_exports_exported_by_users_id_fk",
+          "tableFrom": "report_exports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "exported_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_filters": {
+      "name": "report_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value2": {
+          "name": "value2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_report_filters_report": {
+          "name": "idx_report_filters_report",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_filters_report_id_reports_id_fk": {
+          "name": "report_filters_report_id_reports_id_fk",
+          "tableFrom": "report_filters",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_sorts": {
+      "name": "report_sorts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'asc'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_report_sorts_report": {
+          "name": "idx_report_sorts_report",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_sorts_report_id_reports_id_fk": {
+          "name": "report_sorts_report_id_reports_id_fk",
+          "tableFrom": "report_sorts",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "shared_with_roles": {
+          "name": "shared_with_roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_with_users": {
+          "name": "shared_with_users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_by": {
+          "name": "modified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_reports_item_type": {
+          "name": "idx_reports_item_type",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reports_created_by": {
+          "name": "idx_reports_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reports_is_public": {
+          "name": "idx_reports_is_public",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_created_by_users_id_fk": {
+          "name": "reports_created_by_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_modified_by_users_id_fk": {
+          "name": "reports_modified_by_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "modified_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_logs": {
+      "name": "error_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_operational": {
+          "name": "is_operational",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stack": {
+          "name": "stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_errors": {
+          "name": "field_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_logs_code": {
+          "name": "idx_error_logs_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_error_logs_created_at": {
+          "name": "idx_error_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_error_logs_user_id": {
+          "name": "idx_error_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_error_logs_severity": {
+          "name": "idx_error_logs_severity",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "error_logs_user_id_users_id_fk": {
+          "name": "error_logs_user_id_users_id_fk",
+          "tableFrom": "error_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_type_configs": {
+      "name": "item_type_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "modified_by": {
+          "name": "modified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_type_configs_modified_by_users_id_fk": {
+          "name": "item_type_configs_modified_by_users_id_fk",
+          "tableFrom": "item_type_configs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "modified_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item_type_configs_item_type_unique": {
+          "name": "item_type_configs_item_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_logs": {
+      "name": "job_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_job_logs_job": {
+          "name": "idx_job_logs_job",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_logs_created_at": {
+          "name": "idx_job_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_logs_job_id_jobs_id_fk": {
+          "name": "job_logs_job_id_jobs_id_fk",
+          "tableFrom": "job_logs",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "progress_message": {
+          "name": "progress_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_jobs_status": {
+          "name": "idx_jobs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_type": {
+          "name": "idx_jobs_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_item": {
+          "name": "idx_jobs_item",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_created_by": {
+          "name": "idx_jobs_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_created_at": {
+          "name": "idx_jobs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_next_retry": {
+          "name": "idx_jobs_next_retry",
+          "columns": [
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_status_priority": {
+          "name": "idx_jobs_status_priority",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_item_id_items_id_fk": {
+          "name": "jobs_item_id_items_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "jobs_created_by_users_id_fk": {
+          "name": "jobs_created_by_users_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.number_sequences": {
+      "name": "number_sequences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_sequence": {
+          "name": "unique_sequence",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_type",
+            "scope_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_messages": {
+      "name": "ai_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_chat_messages_session_id_idx": {
+          "name": "ai_chat_messages_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_messages_created_at_idx": {
+          "name": "ai_chat_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_messages_session_id_ai_chat_sessions_id_fk": {
+          "name": "ai_chat_messages_session_id_ai_chat_sessions_id_fk",
+          "tableFrom": "ai_chat_messages",
+          "tableTo": "ai_chat_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_sessions": {
+      "name": "ai_chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_chat_sessions_user_id_idx": {
+          "name": "ai_chat_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_sessions_program_id_idx": {
+          "name": "ai_chat_sessions_program_id_idx",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_sessions_user_id_users_id_fk": {
+          "name": "ai_chat_sessions_user_id_users_id_fk",
+          "tableFrom": "ai_chat_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_chat_sessions_program_id_programs_id_fk": {
+          "name": "ai_chat_sessions_program_id_programs_id_fk",
+          "tableFrom": "ai_chat_sessions",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_chat_sessions_design_id_designs_id_fk": {
+          "name": "ai_chat_sessions_design_id_designs_id_fk",
+          "tableFrom": "ai_chat_sessions",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_settings": {
+      "name": "ai_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_settings_program_id_idx": {
+          "name": "ai_settings_program_id_idx",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_settings_program_id_programs_id_fk": {
+          "name": "ai_settings_program_id_programs_id_fk",
+          "tableFrom": "ai_settings",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_params": {
+          "name": "tool_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_result": {
+          "name": "tool_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_usage_logs_session_id_idx": {
+          "name": "ai_usage_logs_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_logs_user_id_idx": {
+          "name": "ai_usage_logs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_logs_timestamp_idx": {
+          "name": "ai_usage_logs_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_usage_logs_session_id_ai_chat_sessions_id_fk": {
+          "name": "ai_usage_logs_session_id_ai_chat_sessions_id_fk",
+          "tableFrom": "ai_usage_logs",
+          "tableTo": "ai_chat_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_usage_logs_user_id_users_id_fk": {
+          "name": "ai_usage_logs_user_id_users_id_fk",
+          "tableFrom": "ai_usage_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upstream_changes": {
+      "name": "upstream_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_design_id": {
+          "name": "target_design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_design_id": {
+          "name": "source_design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_commit_id": {
+          "name": "source_commit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_eco_id": {
+          "name": "source_eco_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_items": {
+          "name": "changed_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_notes": {
+          "name": "review_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_eco_id": {
+          "name": "response_eco_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_upstream_changes_target": {
+          "name": "idx_upstream_changes_target",
+          "columns": [
+            {
+              "expression": "target_design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_upstream_changes_source": {
+          "name": "idx_upstream_changes_source",
+          "columns": [
+            {
+              "expression": "source_design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_upstream_changes_status": {
+          "name": "idx_upstream_changes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_upstream_changes_source_eco": {
+          "name": "idx_upstream_changes_source_eco",
+          "columns": [
+            {
+              "expression": "source_eco_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upstream_changes_target_design_id_designs_id_fk": {
+          "name": "upstream_changes_target_design_id_designs_id_fk",
+          "tableFrom": "upstream_changes",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "target_design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "upstream_changes_source_design_id_designs_id_fk": {
+          "name": "upstream_changes_source_design_id_designs_id_fk",
+          "tableFrom": "upstream_changes",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "source_design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "upstream_changes_source_eco_id_items_id_fk": {
+          "name": "upstream_changes_source_eco_id_items_id_fk",
+          "tableFrom": "upstream_changes",
+          "tableTo": "items",
+          "columnsFrom": [
+            "source_eco_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upstream_changes_reviewed_by_users_id_fk": {
+          "name": "upstream_changes_reviewed_by_users_id_fk",
+          "tableFrom": "upstream_changes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "upstream_changes_response_eco_id_items_id_fk": {
+          "name": "upstream_changes_response_eco_id_items_id_fk",
+          "tableFrom": "upstream_changes",
+          "tableTo": "items",
+          "columnsFrom": [
+            "response_eco_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_path_cache": {
+      "name": "thread_path_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root_item_id": {
+          "name": "root_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_config_hash": {
+          "name": "cache_config_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_data": {
+          "name": "thread_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "included_item_ids": {
+          "name": "included_item_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalidated_at": {
+          "name": "invalidated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "computation_time_ms": {
+          "name": "computation_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_thread_cache_root": {
+          "name": "idx_thread_cache_root",
+          "columns": [
+            {
+              "expression": "root_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thread_cache_expiry": {
+          "name": "idx_thread_cache_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thread_cache_design": {
+          "name": "idx_thread_cache_design",
+          "columns": [
+            {
+              "expression": "design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thread_cache_items": {
+          "name": "idx_thread_cache_items",
+          "columns": [
+            {
+              "expression": "\"included_item_ids\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_thread_cache_invalidated": {
+          "name": "idx_thread_cache_invalidated",
+          "columns": [
+            {
+              "expression": "invalidated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thread_cache_unique_key": {
+          "name": "idx_thread_cache_unique_key",
+          "columns": [
+            {
+              "expression": "root_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cache_config_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"context_type\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"context_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "thread_path_cache_root_item_id_items_id_fk": {
+          "name": "thread_path_cache_root_item_id_items_id_fk",
+          "tableFrom": "thread_path_cache",
+          "tableTo": "items",
+          "columnsFrom": [
+            "root_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_path_cache_design_id_designs_id_fk": {
+          "name": "thread_path_cache_design_id_designs_id_fk",
+          "tableFrom": "thread_path_cache",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.design_cross_references": {
+      "name": "design_cross_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referencing_design_id": {
+          "name": "referencing_design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referenced_item_id": {
+          "name": "referenced_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_design_id": {
+          "name": "source_design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_design_structure": {
+          "name": "in_design_structure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_by": {
+          "name": "modified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cross_ref_design": {
+          "name": "idx_cross_ref_design",
+          "columns": [
+            {
+              "expression": "referencing_design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cross_ref_item": {
+          "name": "idx_cross_ref_item",
+          "columns": [
+            {
+              "expression": "referenced_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cross_ref_source": {
+          "name": "idx_cross_ref_source",
+          "columns": [
+            {
+              "expression": "source_design_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cross_ref_branch": {
+          "name": "idx_cross_ref_branch",
+          "columns": [
+            {
+              "expression": "branch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "design_cross_references_referencing_design_id_designs_id_fk": {
+          "name": "design_cross_references_referencing_design_id_designs_id_fk",
+          "tableFrom": "design_cross_references",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "referencing_design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "design_cross_references_source_design_id_designs_id_fk": {
+          "name": "design_cross_references_source_design_id_designs_id_fk",
+          "tableFrom": "design_cross_references",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "source_design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "design_cross_references_branch_id_branches_id_fk": {
+          "name": "design_cross_references_branch_id_branches_id_fk",
+          "tableFrom": "design_cross_references",
+          "tableTo": "branches",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "design_cross_references_created_by_users_id_fk": {
+          "name": "design_cross_references_created_by_users_id_fk",
+          "tableFrom": "design_cross_references",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "design_cross_references_modified_by_users_id_fk": {
+          "name": "design_cross_references_modified_by_users_id_fk",
+          "tableFrom": "design_cross_references",
+          "tableTo": "users",
+          "columnsFrom": [
+            "modified_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "design_cross_refs_unique": {
+          "name": "design_cross_refs_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "referencing_design_id",
+            "referenced_item_id",
+            "branch_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.design_session_snapshots": {
+      "name": "design_session_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "llm_history_length": {
+          "name": "llm_history_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "design_session_snapshots_session_id_idx": {
+          "name": "design_session_snapshots_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "design_session_snapshots_session_stage_idx": {
+          "name": "design_session_snapshots_session_stage_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "design_session_snapshots_session_id_design_sessions_id_fk": {
+          "name": "design_session_snapshots_session_id_design_sessions_id_fk",
+          "tableFrom": "design_session_snapshots",
+          "tableTo": "design_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.design_sessions": {
+      "name": "design_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_chat_session_id": {
+          "name": "ai_chat_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "design_id": {
+          "name": "design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_history": {
+          "name": "llm_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_guidance": {
+          "name": "pending_guidance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "materialized_design_id": {
+          "name": "materialized_design_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forked_from_session_id": {
+          "name": "forked_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "design_sessions_user_id_idx": {
+          "name": "design_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "design_sessions_program_id_idx": {
+          "name": "design_sessions_program_id_idx",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "design_sessions_status_idx": {
+          "name": "design_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "design_sessions_user_id_users_id_fk": {
+          "name": "design_sessions_user_id_users_id_fk",
+          "tableFrom": "design_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "design_sessions_ai_chat_session_id_ai_chat_sessions_id_fk": {
+          "name": "design_sessions_ai_chat_session_id_ai_chat_sessions_id_fk",
+          "tableFrom": "design_sessions",
+          "tableTo": "ai_chat_sessions",
+          "columnsFrom": [
+            "ai_chat_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "design_sessions_program_id_programs_id_fk": {
+          "name": "design_sessions_program_id_programs_id_fk",
+          "tableFrom": "design_sessions",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "design_sessions_design_id_designs_id_fk": {
+          "name": "design_sessions_design_id_designs_id_fk",
+          "tableFrom": "design_sessions",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "design_sessions_materialized_design_id_designs_id_fk": {
+          "name": "design_sessions_materialized_design_id_designs_id_fk",
+          "tableFrom": "design_sessions",
+          "tableTo": "designs",
+          "columnsFrom": [
+            "materialized_design_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "design_sessions_forked_from_session_id_design_sessions_id_fk": {
+          "name": "design_sessions_forked_from_session_id_design_sessions_id_fk",
+          "tableFrom": "design_sessions",
+          "tableTo": "design_sessions",
+          "columnsFrom": [
+            "forked_from_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.component_catalog_categories": {
+      "name": "component_catalog_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_catalog_categories_parent": {
+          "name": "idx_catalog_categories_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_catalog_categories_slug": {
+          "name": "idx_catalog_categories_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "component_catalog_categories_slug_unique": {
+          "name": "component_catalog_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.component_catalog_entries": {
+      "name": "component_catalog_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'component'"
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mounting_features": {
+          "name": "mounting_features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "electrical": {
+          "name": "electrical",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specs": {
+          "name": "specs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "stock_sizes": {
+          "name": "stock_sizes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppliers": {
+          "name": "suppliers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "design_notes": {
+          "name": "design_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_catalog_fts": {
+          "name": "idx_catalog_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple',\n        coalesce(\"name\", '') || ' ' ||\n        coalesce(\"description\", '') || ' ' ||\n        coalesce(\"design_notes\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_catalog_tags": {
+          "name": "idx_catalog_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_catalog_category": {
+          "name": "idx_catalog_category",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_catalog_entry_type": {
+          "name": "idx_catalog_entry_type",
+          "columns": [
+            {
+              "expression": "entry_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "component_catalog_entries_category_id_component_catalog_categories_id_fk": {
+          "name": "component_catalog_entries_category_id_component_catalog_categories_id_fk",
+          "tableFrom": "component_catalog_entries",
+          "tableTo": "component_catalog_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.component_catalog_media": {
+      "name": "component_catalog_media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_catalog_media_component": {
+          "name": "idx_catalog_media_component",
+          "columns": [
+            {
+              "expression": "component_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "component_catalog_media_component_id_component_catalog_entries_id_fk": {
+          "name": "component_catalog_media_component_id_component_catalog_entries_id_fk",
+          "tableFrom": "component_catalog_media",
+          "tableTo": "component_catalog_entries",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.lifecycle_type": {
+      "name": "lifecycle_type",
+      "schema": "public",
+      "values": [
+        "Free",
+        "Driven",
+        "Driving"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1784766168867,
       "tag": "0004_swift_hedge_knight",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1784769975536,
+      "tag": "0005_steady_rhodey",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@codemirror/lang-python": "^6.2.1",
         "@codemirror/lang-yaml": "^6.1.3",
         "@codemirror/language": "^6.12.4",
+        "@codemirror/merge": "^6.12.2",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@hono/node-server": "^1.19.14",
         "@hono/standard-validator": "^0.2.2",
@@ -966,6 +967,19 @@
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.42.0",
         "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/merge": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/merge/-/merge-6.12.2.tgz",
+      "integrity": "sha512-V8JvyAPjHbPupqP7BeMcsdsYCbyPij74jxIbaIJDORI+VZzW44zFmon8bF+oxGWvOKhcRmkiUMXd8MxHr3YA2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/highlight": "^1.0.0",
+        "style-mod": "^4.1.0"
       }
     },
     "node_modules/@codemirror/search": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@codemirror/lang-python": "^6.2.1",
     "@codemirror/lang-yaml": "^6.1.3",
     "@codemirror/language": "^6.12.4",
+    "@codemirror/merge": "^6.12.2",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@hono/node-server": "^1.19.14",
     "@hono/standard-validator": "^0.2.2",

--- a/src/components/items/ItemHistoryTab.tsx
+++ b/src/components/items/ItemHistoryTab.tsx
@@ -23,13 +23,14 @@ import {
   CardTitle,
 } from '@/components/ui'
 import { apiFetch } from '@/lib/api/client'
+import { SourceChangesList } from '@/components/software/SourceChangesList'
 
 interface FieldChange {
   fieldName: string
   fieldPath?: string
   oldValue: unknown
   newValue: unknown
-  fieldCategory: 'core' | 'type' | 'attribute' | 'relationship'
+  fieldCategory: 'core' | 'type' | 'attribute' | 'relationship' | 'source'
 }
 
 interface HistoryEntry {
@@ -188,7 +189,13 @@ function RelationshipChange({ change }: { change: FieldChange }) {
 }
 
 // Field changes display component
-function FieldChangesList({ changes }: { changes: Array<FieldChange> }) {
+function FieldChangesList({
+  changes,
+  itemId,
+}: {
+  changes: Array<FieldChange>
+  itemId: string
+}) {
   if (changes.length === 0) return null
 
   // Group by category
@@ -206,6 +213,7 @@ function FieldChangesList({ changes }: { changes: Array<FieldChange> }) {
     type: 'Type-Specific Fields',
     attribute: 'Custom Attributes',
     relationship: 'Relationships',
+    source: 'Source Files',
   }
 
   return (
@@ -216,11 +224,14 @@ function FieldChangesList({ changes }: { changes: Array<FieldChange> }) {
             {categoryLabels[category] || category}
           </div>
           <div className="space-y-1">
-            {category === 'relationship'
-              ? categoryChanges.map((change, idx) => (
-                  <RelationshipChange key={idx} change={change} />
-                ))
-              : categoryChanges.map((change, idx) => (
+            {category === 'source' ? (
+              <SourceChangesList itemId={itemId} changes={categoryChanges} />
+            ) : category === 'relationship' ? (
+              categoryChanges.map((change, idx) => (
+                <RelationshipChange key={idx} change={change} />
+              ))
+            ) : (
+              categoryChanges.map((change, idx) => (
                   <div key={idx} className="flex items-start gap-2 text-sm">
                     <span className="font-medium text-slate-700 dark:text-slate-300 min-w-[120px]">
                       {formatFieldName(change.fieldPath || change.fieldName)}:
@@ -235,7 +246,8 @@ function FieldChangesList({ changes }: { changes: Array<FieldChange> }) {
                       {formatValue(change.newValue)}
                     </span>
                   </div>
-                ))}
+              ))
+            )}
           </div>
         </div>
       ))}
@@ -517,6 +529,7 @@ export function ItemHistoryTab({
                                 {expandedCommits.has(entry.commit.id) && (
                                   <FieldChangesList
                                     changes={entry.fieldChanges}
+                                    itemId={itemId}
                                   />
                                 )}
                               </>

--- a/src/components/software/BuildArtifactCard.tsx
+++ b/src/components/software/BuildArtifactCard.tsx
@@ -1,0 +1,159 @@
+import { useRef, useState } from 'react'
+import { Download, Package, Trash2, Upload } from 'lucide-react'
+import type { Software } from '@/lib/items/types/software'
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui'
+import { useErrorHandler } from '@/lib/hooks/useErrorHandler'
+import { apiFetch } from '@/lib/api/client'
+
+interface FileMetadata {
+  id: string
+  originalFileName?: string
+  fileName?: string
+  fileSize?: number
+}
+
+/**
+ * The primary build artifact slot (proposal §5.2): one vault file
+ * (.bin/.hex/.elf/.zip) attached to this software version. Vault files are
+ * branch-scoped, so an artifact uploaded on an ECO branch promotes to main
+ * on release alongside the source it was built from.
+ */
+export function BuildArtifactCard({ software }: { software: Software }) {
+  const { handleError, showSuccess } = useErrorHandler()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [artifactFileId, setArtifactFileId] = useState<string | null>(
+    software.buildArtifactFileId ?? null,
+  )
+  const [artifactName, setArtifactName] = useState<string | null>(null)
+  const [isUploading, setIsUploading] = useState(false)
+
+  const isReleased = ['Released', 'Obsolete', 'Superseded'].includes(
+    software.state ?? '',
+  )
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file || !software.id) return
+
+    setIsUploading(true)
+    try {
+      const formData = new FormData()
+      formData.append('file_0', file)
+      // Raw fetch: multipart needs the browser-set boundary
+      const response = await fetch(
+        `/api/v1/items/${software.id}/files/upload`,
+        { method: 'POST', body: formData },
+      )
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as {
+          error?: { message?: string }
+        } | null
+        throw new Error(
+          body?.error?.message ?? `Upload failed (${response.status})`,
+        )
+      }
+      const result = (await response.json()) as {
+        data: { files: Array<FileMetadata> }
+      }
+      const uploaded = result.data.files[0]
+      if (!uploaded) throw new Error('Upload returned no file')
+
+      await apiFetch(`/api/v1/software/${software.id}`, {
+        method: 'PUT',
+        body: JSON.stringify({ buildArtifactFileId: uploaded.id }),
+      })
+
+      setArtifactFileId(uploaded.id)
+      setArtifactName(file.name)
+      showSuccess('Build artifact attached', file.name)
+    } catch (error) {
+      handleError(error, { title: 'Failed to upload build artifact' })
+    } finally {
+      setIsUploading(false)
+    }
+  }
+
+  const handleRemove = async () => {
+    if (!software.id) return
+    try {
+      await apiFetch(`/api/v1/software/${software.id}`, {
+        method: 'PUT',
+        body: JSON.stringify({ buildArtifactFileId: null }),
+      })
+      setArtifactFileId(null)
+      setArtifactName(null)
+      showSuccess('Build artifact detached', 'The vault file was kept')
+    } catch (error) {
+      handleError(error, { title: 'Failed to detach build artifact' })
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Package className="h-4 w-4" />
+          Build Artifact
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <input
+          ref={inputRef}
+          type="file"
+          className="hidden"
+          onChange={handleUpload}
+        />
+        {artifactFileId ? (
+          <div className="flex items-center justify-between gap-2">
+            <span className="truncate text-sm text-slate-700 dark:text-slate-300">
+              {artifactName ?? 'Attached artifact'}
+            </span>
+            <div className="flex shrink-0 gap-1">
+              <a href={`/api/v1/files/${artifactFileId}/download`} download>
+                <Button variant="ghost" size="sm" title="Download">
+                  <Download className="h-4 w-4" />
+                </Button>
+              </a>
+              {!isReleased && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  title="Detach"
+                  onClick={handleRemove}
+                >
+                  <Trash2 className="h-4 w-4 text-red-500" />
+                </Button>
+              )}
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            No build artifact attached.
+          </p>
+        )}
+        {!isReleased && (
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={isUploading}
+            onClick={() => inputRef.current?.click()}
+          >
+            <Upload className="mr-2 h-4 w-4" />
+            {isUploading
+              ? 'Uploading...'
+              : artifactFileId
+                ? 'Replace artifact'
+                : 'Upload artifact'}
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/software/SoftwareDetail.tsx
+++ b/src/components/software/SoftwareDetail.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@tanstack/react-router'
 import { useEffect, useState } from 'react'
 import { ArrowLeft, Edit, Save, Trash2, X } from 'lucide-react'
+import { BuildArtifactCard } from './BuildArtifactCard'
 import { SourceViewer } from './SourceViewer'
 import type { Software } from '@/lib/items/types/software'
 import type { Design } from '@/lib/types/design'
@@ -381,8 +382,18 @@ export function SoftwareDetail({
                         : 'No source imported yet'
                     }
                   />
+                  {current.draftManifestId && (
+                    <ViewEditStatic
+                      label="Draft"
+                      value="Uncommitted changes (see Source tab)"
+                    />
+                  )}
                 </CardContent>
               </Card>
+
+              {!isCreateMode && current.id && (
+                <BuildArtifactCard software={current} />
+              )}
 
               {isEditing ? (
                 <Card>
@@ -467,6 +478,12 @@ export function SoftwareDetail({
             <SourceViewer
               itemId={current.id}
               canImport={(current.sourceMode ?? 'internal') === 'internal'}
+              canEdit={
+                (current.sourceMode ?? 'internal') === 'internal' &&
+                !['Released', 'Obsolete', 'Superseded'].includes(
+                  current.state ?? '',
+                )
+              }
             />
           </TabsContent>
         )}

--- a/src/components/software/SourceChangesList.tsx
+++ b/src/components/software/SourceChangesList.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+import { SourceDiffDialog } from './SourceDiffDialog'
+import type { SourceDiffTarget } from './SourceDiffDialog'
+import { Badge } from '@/components/ui'
+
+interface SourceFieldChange {
+  fieldName: string // 'added' | 'modified' | 'deleted'
+  fieldPath?: string
+  oldValue: unknown // { hash, size } | null
+  newValue: unknown // { hash, size } | null
+}
+
+const statusVariant: Record<
+  string,
+  'default' | 'success' | 'destructive' | 'secondary'
+> = {
+  added: 'success',
+  modified: 'default',
+  deleted: 'destructive',
+}
+
+function hashOf(value: unknown): string | null {
+  if (value && typeof value === 'object' && 'hash' in value) {
+    return String((value).hash)
+  }
+  return null
+}
+
+/**
+ * Renders 'source'-category field changes (per-file source-tree history rows
+ * on Software items) with click-through to a side-by-side line diff.
+ */
+export function SourceChangesList({
+  itemId,
+  changes,
+}: {
+  itemId: string
+  changes: Array<SourceFieldChange>
+}) {
+  const [diffTarget, setDiffTarget] = useState<SourceDiffTarget | null>(null)
+
+  return (
+    <div className="space-y-1">
+      {changes.map((change, idx) => {
+        const oldHash = hashOf(change.oldValue)
+        const newHash = hashOf(change.newValue)
+        return (
+          <button
+            key={idx}
+            type="button"
+            onClick={() =>
+              setDiffTarget({
+                itemId,
+                path: change.fieldPath ?? '',
+                oldHash,
+                newHash,
+                oldLabel: 'Previous',
+                newLabel: 'This commit',
+              })
+            }
+            className="flex w-full items-center gap-2 rounded px-1 py-0.5 text-left text-sm hover:bg-slate-100 dark:hover:bg-slate-800"
+            title="Show line diff"
+          >
+            <Badge
+              variant={statusVariant[change.fieldName] ?? 'secondary'}
+              className="w-20 justify-center text-xs"
+            >
+              {change.fieldName}
+            </Badge>
+            <span className="truncate font-mono text-slate-700 dark:text-slate-300">
+              {change.fieldPath}
+            </span>
+          </button>
+        )
+      })}
+      <SourceDiffDialog
+        target={diffTarget}
+        onClose={() => setDiffTarget(null)}
+      />
+    </div>
+  )
+}

--- a/src/components/software/SourceDiffDialog.tsx
+++ b/src/components/software/SourceDiffDialog.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useRef, useState } from 'react'
+import { MergeView } from '@codemirror/merge'
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { basicSetup } from 'codemirror'
+import { oneDark } from '@codemirror/theme-one-dark'
+import { languageFor } from './language'
+import type { Extension } from '@codemirror/state'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui'
+import { apiFetch } from '@/lib/api/client'
+import { useErrorHandler } from '@/lib/hooks/useErrorHandler'
+
+interface BlobResponse {
+  blob: {
+    hash: string
+    size: number
+    isBinary: boolean
+    content: string
+    encoding: 'utf8' | 'base64'
+  }
+}
+
+export interface SourceDiffTarget {
+  /** Software item id used to authorize blob reads */
+  itemId: string
+  path: string
+  /** Missing hash = empty side (file added or deleted) */
+  oldHash?: string | null
+  newHash?: string | null
+  oldLabel?: string
+  newLabel?: string
+}
+
+async function fetchBlobText(
+  itemId: string,
+  hash: string | null | undefined,
+): Promise<{ text: string; binary: boolean }> {
+  if (!hash) return { text: '', binary: false }
+  const result = await apiFetch<{ data: BlobResponse }>(
+    `/api/v1/software/${itemId}/blob/${hash}`,
+  )
+  const blob = result.data.blob
+  return { text: blob.isBinary ? '' : blob.content, binary: blob.isBinary }
+}
+
+function SideBySideDiff({
+  path,
+  oldText,
+  newText,
+}: {
+  path: string
+  oldText: string
+  newText: string
+}) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    const isDark = document.documentElement.classList.contains('dark')
+    const shared: Array<Extension> = [
+      basicSetup,
+      EditorState.readOnly.of(true),
+      EditorView.editable.of(false),
+      EditorView.theme({
+        '&': { fontSize: '13px' },
+        '.cm-scroller': { fontFamily: 'ui-monospace, monospace' },
+      }),
+    ]
+    const lang = languageFor(path)
+    if (lang) shared.push(lang)
+    if (isDark) shared.push(oneDark)
+
+    const view = new MergeView({
+      a: { doc: oldText, extensions: shared },
+      b: { doc: newText, extensions: shared },
+      parent: containerRef.current,
+      collapseUnchanged: { margin: 3, minSize: 4 },
+    })
+
+    return () => view.destroy()
+  }, [path, oldText, newText])
+
+  return <div ref={containerRef} className="max-h-[65vh] overflow-auto" />
+}
+
+/**
+ * Side-by-side line diff of one source file between two versions.
+ * Content is fetched by blob hash, so it works for any historical version -
+ * including paths that no longer exist in a current tree.
+ */
+export function SourceDiffDialog({
+  target,
+  onClose,
+}: {
+  target: SourceDiffTarget | null
+  onClose: () => void
+}) {
+  const { handleError } = useErrorHandler()
+  const [contents, setContents] = useState<{
+    oldText: string
+    newText: string
+    binary: boolean
+  } | null>(null)
+
+  useEffect(() => {
+    if (!target) {
+      setContents(null)
+      return
+    }
+    let cancelled = false
+    Promise.all([
+      fetchBlobText(target.itemId, target.oldHash),
+      fetchBlobText(target.itemId, target.newHash),
+    ])
+      .then(([oldBlob, newBlob]) => {
+        if (cancelled) return
+        setContents({
+          oldText: oldBlob.text,
+          newText: newBlob.text,
+          binary: oldBlob.binary || newBlob.binary,
+        })
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          handleError(error, { title: 'Failed to load diff' })
+          onClose()
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [target, handleError, onClose])
+
+  return (
+    <Dialog open={!!target} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-5xl">
+        <DialogHeader>
+          <DialogTitle className="font-mono text-base">
+            {target?.path}
+          </DialogTitle>
+          <DialogDescription>
+            {target?.oldLabel ?? 'Before'} → {target?.newLabel ?? 'After'}
+          </DialogDescription>
+        </DialogHeader>
+        {!contents ? (
+          <div className="py-12 text-center text-sm text-slate-500 dark:text-slate-400">
+            Loading diff...
+          </div>
+        ) : contents.binary ? (
+          <div className="py-12 text-center text-sm text-slate-500 dark:text-slate-400">
+            Binary file - line diff not available
+          </div>
+        ) : (
+          <SideBySideDiff
+            path={target?.path ?? ''}
+            oldText={contents.oldText}
+            newText={contents.newText}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/software/SourceViewer.tsx
+++ b/src/components/software/SourceViewer.tsx
@@ -4,22 +4,38 @@ import {
   ChevronRight,
   File,
   FileArchive,
+  FileDiff,
+  FilePlus,
   Folder,
   FolderOpen,
+  GitCommitHorizontal,
+  Pencil,
+  Trash2,
+  Undo2,
   Upload,
 } from 'lucide-react'
 import { EditorState } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import { basicSetup } from 'codemirror'
-import { cpp } from '@codemirror/lang-cpp'
-import { javascript } from '@codemirror/lang-javascript'
-import { json } from '@codemirror/lang-json'
-import { markdown } from '@codemirror/lang-markdown'
-import { python } from '@codemirror/lang-python'
-import { yaml } from '@codemirror/lang-yaml'
 import { oneDark } from '@codemirror/theme-one-dark'
+import { languageFor } from './language'
+import { SourceDiffDialog } from './SourceDiffDialog'
 import type { Extension } from '@codemirror/state'
-import { Button, Card, CardContent } from '@/components/ui'
+import type { SourceDiffTarget } from './SourceDiffDialog'
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Textarea,
+} from '@/components/ui'
+import { useAlertDialog } from '@/lib/hooks/useAlertDialog'
 import { useErrorHandler } from '@/lib/hooks/useErrorHandler'
 import { apiFetch } from '@/lib/api/client'
 import { cn } from '@/lib/utils'
@@ -38,6 +54,8 @@ interface TreeResponse {
   itemId: string
   revision: string
   manifestId: string | null
+  draftManifestId: string | null
+  isDraft: boolean
   fileCount: number
   totalSize: number
   entries: Array<ManifestEntry>
@@ -54,11 +72,29 @@ interface FileResponse {
   }
 }
 
+interface VersionInfo {
+  id: string
+  revision: string
+  state: string
+  isCurrent: boolean | null
+  modifiedAt: string
+  manifestId: string | null
+}
+
+interface DiffChange {
+  path: string
+  status: 'added' | 'removed' | 'modified'
+  oldHash?: string
+  newHash?: string
+}
+
 interface SourceViewerProps {
   itemId: string
   /** Show the import affordance (server still enforces branch protection) */
   canImport?: boolean
-  /** Called after a successful import so the parent can refresh item data */
+  /** Enable in-app editing (server still enforces checkout/lock rules) */
+  canEdit?: boolean
+  /** Called after a successful import/commit so the parent can refresh */
   onImported?: () => void
 }
 
@@ -110,48 +146,23 @@ function formatSize(bytes: number): string {
 }
 
 // ============================================================================
-// CodeMirror language selection
+// CodeMirror editor (read-only or editable)
 // ============================================================================
 
-function languageFor(path: string): Extension | null {
-  const ext = path.split('.').pop()?.toLowerCase() ?? ''
-  const name = path.split('/').pop()?.toLowerCase() ?? ''
-  switch (ext) {
-    case 'c':
-    case 'h':
-    case 'cpp':
-    case 'cc':
-    case 'cxx':
-    case 'hpp':
-    case 'hh':
-    case 'ino':
-      return cpp()
-    case 'py':
-      return python()
-    case 'json':
-      return json()
-    case 'yml':
-    case 'yaml':
-      return yaml()
-    case 'md':
-    case 'markdown':
-      return markdown()
-    case 'js':
-    case 'mjs':
-    case 'cjs':
-      return javascript()
-    case 'ts':
-    case 'tsx':
-      return javascript({ typescript: true, jsx: ext === 'tsx' })
-    default:
-      if (name === 'makefile' || name === 'cmakelists.txt') return null
-      return null
-  }
-}
-
-function CodeView({ content, path }: { content: string; path: string }) {
+function CodeEditor({
+  content,
+  path,
+  readOnly,
+  onChange,
+}: {
+  content: string
+  path: string
+  readOnly: boolean
+  onChange?: (doc: string) => void
+}) {
   const containerRef = useRef<HTMLDivElement>(null)
-  const viewRef = useRef<EditorView | null>(null)
+  const onChangeRef = useRef(onChange)
+  onChangeRef.current = onChange
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -159,13 +170,25 @@ function CodeView({ content, path }: { content: string; path: string }) {
     const isDark = document.documentElement.classList.contains('dark')
     const extensions: Array<Extension> = [
       basicSetup,
-      EditorState.readOnly.of(true),
-      EditorView.editable.of(false),
       EditorView.theme({
         '&': { fontSize: '13px' },
         '.cm-scroller': { fontFamily: 'ui-monospace, monospace' },
       }),
     ]
+    if (readOnly) {
+      extensions.push(
+        EditorState.readOnly.of(true),
+        EditorView.editable.of(false),
+      )
+    } else {
+      extensions.push(
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            onChangeRef.current?.(update.state.doc.toString())
+          }
+        }),
+      )
+    }
     const lang = languageFor(path)
     if (lang) extensions.push(lang)
     if (isDark) extensions.push(oneDark)
@@ -174,15 +197,13 @@ function CodeView({ content, path }: { content: string; path: string }) {
       state: EditorState.create({ doc: content, extensions }),
       parent: containerRef.current,
     })
-    viewRef.current = view
 
-    return () => {
-      view.destroy()
-      viewRef.current = null
-    }
-  }, [content, path])
+    return () => view.destroy()
+    // Recreate only when switching files or toggling edit mode - `content`
+    // is the initial doc, not a controlled value.
+  }, [path, readOnly])
 
-  return <div ref={containerRef} className="max-h-[70vh] overflow-auto" />
+  return <div ref={containerRef} className="max-h-[65vh] overflow-auto" />
 }
 
 // ============================================================================
@@ -193,11 +214,13 @@ function TreeNodeRow({
   node,
   depth,
   selectedPath,
+  dirtyPaths,
   onSelect,
 }: {
   node: TreeNode
   depth: number
   selectedPath: string | null
+  dirtyPaths: Set<string>
   onSelect: (entry: ManifestEntry) => void
 }) {
   const isDir = node.children.size > 0
@@ -231,12 +254,15 @@ function TreeNodeRow({
               node={child}
               depth={depth + 1}
               selectedPath={selectedPath}
+              dirtyPaths={dirtyPaths}
               onSelect={onSelect}
             />
           ))}
       </div>
     )
   }
+
+  const isDirty = dirtyPaths.has(node.path)
 
   return (
     <button
@@ -252,6 +278,12 @@ function TreeNodeRow({
     >
       <File className="h-4 w-4 shrink-0 text-slate-400" />
       <span className="truncate">{node.name}</span>
+      {isDirty && (
+        <span
+          className="ml-auto h-2 w-2 shrink-0 rounded-full bg-amber-500"
+          title="Unsaved changes"
+        />
+      )}
     </button>
   )
 }
@@ -263,9 +295,11 @@ function TreeNodeRow({
 export function SourceViewer({
   itemId,
   canImport = true,
+  canEdit = false,
   onImported,
 }: SourceViewerProps) {
   const { handleError, showSuccess } = useErrorHandler()
+  const { confirm } = useAlertDialog()
 
   const [tree, setTree] = useState<TreeResponse | null>(null)
   const [isLoadingTree, setIsLoadingTree] = useState(true)
@@ -276,14 +310,37 @@ export function SourceViewer({
   const [isLoadingFile, setIsLoadingFile] = useState(false)
   const [isImporting, setIsImporting] = useState(false)
 
+  // Editing state: path -> edited content (differs from saved draft)
+  const [dirtyFiles, setDirtyFiles] = useState<Map<string, string>>(new Map())
+  const [isSavingDraft, setIsSavingDraft] = useState(false)
+  const [commitDialogOpen, setCommitDialogOpen] = useState(false)
+  const [commitMessage, setCommitMessage] = useState('')
+  const [isCommitting, setIsCommitting] = useState(false)
+  const [newFileDialogOpen, setNewFileDialogOpen] = useState(false)
+  const [newFilePath, setNewFilePath] = useState('')
+  const [renameDialogOpen, setRenameDialogOpen] = useState(false)
+  const [renameTo, setRenameTo] = useState('')
+
+  // Revision compare state
+  const [versions, setVersions] = useState<Array<VersionInfo>>([])
+  const [compareOpen, setCompareOpen] = useState(false)
+  const [compareFrom, setCompareFrom] = useState<VersionInfo | null>(null)
+  const [compareChanges, setCompareChanges] = useState<Array<DiffChange> | null>(
+    null,
+  )
+  const [diffTarget, setDiffTarget] = useState<SourceDiffTarget | null>(null)
+
   const zipInputRef = useRef<HTMLInputElement>(null)
   const filesInputRef = useRef<HTMLInputElement>(null)
+
+  const hasDraft = !!tree?.draftManifestId
+  const dirtyCount = dirtyFiles.size
 
   const loadTree = useCallback(async () => {
     setIsLoadingTree(true)
     try {
       const result = await apiFetch<{ data: TreeResponse }>(
-        `/api/v1/software/${itemId}/tree`,
+        `/api/v1/software/${itemId}/tree?draft=true`,
       )
       setTree(result.data)
     } catch (error) {
@@ -309,7 +366,7 @@ export function SourceViewer({
       setFileContent(null)
       try {
         const result = await apiFetch<{ data: FileResponse }>(
-          `/api/v1/software/${itemId}/file?path=${encodeURIComponent(entry.path)}`,
+          `/api/v1/software/${itemId}/file?path=${encodeURIComponent(entry.path)}&draft=true`,
         )
         setFileContent(result.data.file)
       } catch (error) {
@@ -320,6 +377,164 @@ export function SourceViewer({
     },
     [itemId, handleError],
   )
+
+  // --------------------------------------------------------------------------
+  // Draft editing
+  // --------------------------------------------------------------------------
+
+  const markDirty = useCallback((path: string, content: string) => {
+    setDirtyFiles((prev) => new Map(prev).set(path, content))
+  }, [])
+
+  const saveDraft = useCallback(async (): Promise<boolean> => {
+    if (dirtyFiles.size === 0) return true
+    setIsSavingDraft(true)
+    try {
+      for (const [path, content] of dirtyFiles) {
+        await apiFetch(`/api/v1/software/${itemId}/file`, {
+          method: 'PUT',
+          body: JSON.stringify({ path, content }),
+        })
+      }
+      setDirtyFiles(new Map())
+      await loadTree()
+      return true
+    } catch (error) {
+      handleError(error, { title: 'Failed to save draft' })
+      return false
+    } finally {
+      setIsSavingDraft(false)
+    }
+  }, [dirtyFiles, itemId, handleError, loadTree])
+
+  // Auto-save dirty files every 30s (proposal §5.2)
+  useEffect(() => {
+    if (!canEdit || dirtyFiles.size === 0) return
+    const timer = setInterval(() => {
+      void saveDraft()
+    }, 30_000)
+    return () => clearInterval(timer)
+  }, [canEdit, dirtyFiles.size, saveDraft])
+
+  const handleCommit = useCallback(async () => {
+    if (!commitMessage.trim()) return
+    setIsCommitting(true)
+    try {
+      const saved = await saveDraft()
+      if (!saved) return
+      await apiFetch(`/api/v1/software/${itemId}/commit`, {
+        method: 'POST',
+        body: JSON.stringify({ message: commitMessage.trim() }),
+      })
+      showSuccess('Changes committed', commitMessage.trim())
+      setCommitDialogOpen(false)
+      setCommitMessage('')
+      await loadTree()
+      onImported?.()
+    } catch (error) {
+      handleError(error, { title: 'Failed to commit' })
+    } finally {
+      setIsCommitting(false)
+    }
+  }, [
+    commitMessage,
+    saveDraft,
+    itemId,
+    showSuccess,
+    loadTree,
+    onImported,
+    handleError,
+  ])
+
+  const handleDiscard = useCallback(() => {
+    confirm({
+      title: 'Discard draft',
+      description:
+        'Throw away all uncommitted changes and return to the last committed tree?',
+      actionLabel: 'Discard',
+      cancelLabel: 'Keep editing',
+      variant: 'destructive',
+      onConfirm: async () => {
+        try {
+          await apiFetch(`/api/v1/software/${itemId}/draft/discard`, {
+            method: 'POST',
+          })
+          setDirtyFiles(new Map())
+          setSelected(null)
+          setFileContent(null)
+          await loadTree()
+        } catch (error) {
+          handleError(error, { title: 'Failed to discard draft' })
+        }
+      },
+    })
+  }, [confirm, itemId, loadTree, handleError])
+
+  const handleCreateFile = useCallback(async () => {
+    const path = newFilePath.trim()
+    if (!path) return
+    try {
+      await apiFetch(`/api/v1/software/${itemId}/file`, {
+        method: 'PUT',
+        body: JSON.stringify({ path, content: '' }),
+      })
+      setNewFileDialogOpen(false)
+      setNewFilePath('')
+      await loadTree()
+      await handleSelect({ path, hash: '', size: 0 })
+    } catch (error) {
+      handleError(error, { title: 'Failed to create file' })
+    }
+  }, [newFilePath, itemId, loadTree, handleSelect, handleError])
+
+  const handleRename = useCallback(async () => {
+    if (!selected || !renameTo.trim()) return
+    try {
+      await apiFetch(`/api/v1/software/${itemId}/file/rename`, {
+        method: 'POST',
+        body: JSON.stringify({ fromPath: selected.path, toPath: renameTo }),
+      })
+      setRenameDialogOpen(false)
+      setSelected(null)
+      setFileContent(null)
+      await loadTree()
+    } catch (error) {
+      handleError(error, { title: 'Failed to rename file' })
+    }
+  }, [selected, renameTo, itemId, loadTree, handleError])
+
+  const handleDeleteFile = useCallback(() => {
+    if (!selected) return
+    confirm({
+      title: 'Delete file',
+      description: `Delete ${selected.path} from the draft tree?`,
+      actionLabel: 'Delete',
+      cancelLabel: 'Cancel',
+      variant: 'destructive',
+      onConfirm: async () => {
+        try {
+          await apiFetch(
+            `/api/v1/software/${itemId}/file?path=${encodeURIComponent(selected.path)}`,
+            { method: 'DELETE' },
+          )
+          setDirtyFiles((prev) => {
+            const next = new Map(prev)
+            next.delete(selected.path)
+            return next
+          })
+          setSelected(null)
+          setFileContent(null)
+          await loadTree()
+        } catch (error) {
+          handleError(error, { title: 'Failed to delete file' })
+        }
+      },
+    })
+  }, [selected, confirm, itemId, loadTree, handleError])
+
+  // --------------------------------------------------------------------------
+  // Import (zip / files)
+  // --------------------------------------------------------------------------
 
   const uploadFormData = useCallback(
     async (formData: FormData, successMessage: string) => {
@@ -373,7 +588,6 @@ export function SourceViewer({
       if (!files || files.length === 0) return
       const formData = new FormData()
       for (const file of Array.from(files)) {
-        // webkitRelativePath is set for directory picks; fall back to name
         const rel =
           (file as { webkitRelativePath?: string }).webkitRelativePath ||
           file.name
@@ -388,8 +602,46 @@ export function SourceViewer({
     [uploadFormData],
   )
 
-  const importButtons = canImport && (
-    <div className="flex gap-2">
+  // --------------------------------------------------------------------------
+  // Revision compare
+  // --------------------------------------------------------------------------
+
+  const openCompare = useCallback(async () => {
+    setCompareOpen(true)
+    setCompareFrom(null)
+    setCompareChanges(null)
+    try {
+      const result = await apiFetch<{ data: { versions: Array<VersionInfo> } }>(
+        `/api/v1/software/${itemId}/versions`,
+      )
+      setVersions(result.data.versions.filter((v) => v.id !== itemId))
+    } catch (error) {
+      handleError(error, { title: 'Failed to load versions' })
+    }
+  }, [itemId, handleError])
+
+  const selectCompareFrom = useCallback(
+    async (version: VersionInfo) => {
+      setCompareFrom(version)
+      setCompareChanges(null)
+      try {
+        const result = await apiFetch<{
+          data: { changes: Array<DiffChange> }
+        }>(`/api/v1/software/${itemId}/diff?fromItemId=${version.id}`)
+        setCompareChanges(result.data.changes)
+      } catch (error) {
+        handleError(error, { title: 'Failed to compute diff' })
+      }
+    },
+    [itemId, handleError],
+  )
+
+  // --------------------------------------------------------------------------
+  // Render
+  // --------------------------------------------------------------------------
+
+  const importButtons = canImport && !hasDraft && (
+    <>
       <input
         ref={zipInputRef}
         type="file"
@@ -422,10 +674,49 @@ export function SourceViewer({
         <Upload className="mr-2 h-4 w-4" />
         Add files
       </Button>
-    </div>
+    </>
   )
 
-  if (isLoadingTree) {
+  const editButtons = canEdit && (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setNewFileDialogOpen(true)}
+      >
+        <FilePlus className="mr-2 h-4 w-4" />
+        New file
+      </Button>
+      {(dirtyCount > 0 || hasDraft) && (
+        <>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={isSavingDraft || dirtyCount === 0}
+            onClick={() => void saveDraft()}
+          >
+            {isSavingDraft
+              ? 'Saving...'
+              : dirtyCount > 0
+                ? `Save draft (${dirtyCount})`
+                : 'Draft saved'}
+          </Button>
+          <Button size="sm" onClick={() => setCommitDialogOpen(true)}>
+            <GitCommitHorizontal className="mr-2 h-4 w-4" />
+            Commit
+          </Button>
+          {hasDraft && (
+            <Button variant="outline" size="sm" onClick={handleDiscard}>
+              <Undo2 className="mr-2 h-4 w-4" />
+              Discard
+            </Button>
+          )}
+        </>
+      )}
+    </>
+  )
+
+  if (isLoadingTree && !tree) {
     return (
       <Card>
         <CardContent className="py-12 text-center text-sm text-slate-500 dark:text-slate-400">
@@ -435,7 +726,7 @@ export function SourceViewer({
     )
   }
 
-  if (!tree || tree.entries.length === 0) {
+  if (!tree || (tree.entries.length === 0 && !hasDraft)) {
     return (
       <Card>
         <CardContent className="flex flex-col items-center gap-4 py-12">
@@ -443,7 +734,10 @@ export function SourceViewer({
             No source tree yet. Import a zip archive or individual files to
             get started.
           </p>
-          {importButtons}
+          <div className="flex gap-2">
+            {importButtons}
+            {editButtons}
+          </div>
         </CardContent>
       </Card>
     )
@@ -452,11 +746,25 @@ export function SourceViewer({
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <p className="text-sm text-slate-500 dark:text-slate-400">
-          {tree.fileCount} {tree.fileCount === 1 ? 'file' : 'files'} ·{' '}
-          {formatSize(tree.totalSize)}
-        </p>
-        {importButtons}
+        <div className="flex items-center gap-3">
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            {tree.fileCount} {tree.fileCount === 1 ? 'file' : 'files'} ·{' '}
+            {formatSize(tree.totalSize)}
+          </p>
+          {hasDraft && (
+            <Badge variant="warning" className="text-xs">
+              Draft — uncommitted changes
+            </Badge>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" size="sm" onClick={openCompare}>
+            <FileDiff className="mr-2 h-4 w-4" />
+            Compare
+          </Button>
+          {importButtons}
+          {editButtons}
+        </div>
       </div>
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">
@@ -470,6 +778,7 @@ export function SourceViewer({
                   node={child}
                   depth={0}
                   selectedPath={selected?.path ?? null}
+                  dirtyPaths={new Set(dirtyFiles.keys())}
                   onSelect={handleSelect}
                 />
               ))}
@@ -481,17 +790,43 @@ export function SourceViewer({
           <CardContent className="p-0">
             {!selected ? (
               <div className="py-12 text-center text-sm text-slate-500 dark:text-slate-400">
-                Select a file to view its contents
+                Select a file to view {canEdit ? 'or edit ' : ''}its contents
               </div>
             ) : (
               <div>
                 <div className="flex items-center justify-between border-b border-slate-200 px-4 py-2 dark:border-slate-700">
                   <span className="font-mono text-sm text-slate-700 dark:text-slate-300">
                     {selected.path}
+                    {dirtyFiles.has(selected.path) && (
+                      <span className="ml-2 text-amber-500">●</span>
+                    )}
                   </span>
-                  <span className="text-xs text-slate-400">
-                    {formatSize(selected.size)}
-                  </span>
+                  <div className="flex items-center gap-2">
+                    {canEdit && (
+                      <>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            setRenameTo(selected.path)
+                            setRenameDialogOpen(true)
+                          }}
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={handleDeleteFile}
+                        >
+                          <Trash2 className="h-3.5 w-3.5 text-red-500" />
+                        </Button>
+                      </>
+                    )}
+                    <span className="text-xs text-slate-400">
+                      {formatSize(selected.size)}
+                    </span>
+                  </div>
                 </div>
                 {isLoadingFile ? (
                   <div className="py-12 text-center text-sm text-slate-500 dark:text-slate-400">
@@ -503,9 +838,13 @@ export function SourceViewer({
                     available
                   </div>
                 ) : fileContent ? (
-                  <CodeView
-                    content={fileContent.content}
+                  <CodeEditor
+                    content={
+                      dirtyFiles.get(fileContent.path) ?? fileContent.content
+                    }
                     path={fileContent.path}
+                    readOnly={!canEdit}
+                    onChange={(doc) => markDirty(fileContent.path, doc)}
                   />
                 ) : null}
               </div>
@@ -513,6 +852,169 @@ export function SourceViewer({
           </CardContent>
         </Card>
       </div>
+
+      {/* Commit dialog */}
+      <Dialog open={commitDialogOpen} onOpenChange={setCommitDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Commit source changes</DialogTitle>
+          </DialogHeader>
+          <Textarea
+            value={commitMessage}
+            onChange={(e) => setCommitMessage(e.target.value)}
+            placeholder="Describe the change (required)..."
+            rows={3}
+          />
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setCommitDialogOpen(false)}
+              disabled={isCommitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleCommit}
+              disabled={isCommitting || !commitMessage.trim()}
+            >
+              {isCommitting ? 'Committing...' : 'Commit'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* New file dialog */}
+      <Dialog open={newFileDialogOpen} onOpenChange={setNewFileDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New file</DialogTitle>
+          </DialogHeader>
+          <Input
+            value={newFilePath}
+            onChange={(e) => setNewFilePath(e.target.value)}
+            placeholder="src/module.c"
+            className="font-mono"
+          />
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setNewFileDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleCreateFile} disabled={!newFilePath.trim()}>
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Rename dialog */}
+      <Dialog open={renameDialogOpen} onOpenChange={setRenameDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename {selected?.path}</DialogTitle>
+          </DialogHeader>
+          <Input
+            value={renameTo}
+            onChange={(e) => setRenameTo(e.target.value)}
+            className="font-mono"
+          />
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setRenameDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleRename} disabled={!renameTo.trim()}>
+              Rename
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Revision compare dialog */}
+      <Dialog open={compareOpen} onOpenChange={setCompareOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Compare revisions</DialogTitle>
+          </DialogHeader>
+          {!compareFrom ? (
+            versions.length === 0 ? (
+              <p className="py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+                No other versions of this item to compare against.
+              </p>
+            ) : (
+              <div className="space-y-1">
+                {versions.map((v) => (
+                  <button
+                    key={v.id}
+                    type="button"
+                    onClick={() => void selectCompareFrom(v)}
+                    className="flex w-full items-center justify-between rounded border border-slate-200 px-3 py-2 text-left text-sm hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
+                  >
+                    <span className="font-mono">Rev {v.revision}</span>
+                    <span className="text-slate-500 dark:text-slate-400">
+                      {v.state}
+                      {v.isCurrent ? ' · current' : ''}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )
+          ) : !compareChanges ? (
+            <p className="py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+              Computing diff...
+            </p>
+          ) : compareChanges.length === 0 ? (
+            <p className="py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+              No source differences between Rev {compareFrom.revision} and this
+              version.
+            </p>
+          ) : (
+            <div className="max-h-[50vh] space-y-1 overflow-auto">
+              {compareChanges.map((change) => (
+                <button
+                  key={change.path}
+                  type="button"
+                  onClick={() =>
+                    setDiffTarget({
+                      itemId,
+                      path: change.path,
+                      oldHash: change.oldHash ?? null,
+                      newHash: change.newHash ?? null,
+                      oldLabel: `Rev ${compareFrom.revision}`,
+                      newLabel: 'This version',
+                    })
+                  }
+                  className="flex w-full items-center gap-2 rounded px-3 py-1.5 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-800"
+                >
+                  <Badge
+                    variant={
+                      change.status === 'added'
+                        ? 'success'
+                        : change.status === 'removed'
+                          ? 'destructive'
+                          : 'default'
+                    }
+                    className="w-20 justify-center text-xs"
+                  >
+                    {change.status}
+                  </Badge>
+                  <span className="truncate font-mono">{change.path}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Per-file line diff */}
+      <SourceDiffDialog
+        target={diffTarget}
+        onClose={() => setDiffTarget(null)}
+      />
     </div>
   )
 }

--- a/src/components/software/language.ts
+++ b/src/components/software/language.ts
@@ -1,0 +1,42 @@
+import { cpp } from '@codemirror/lang-cpp'
+import { javascript } from '@codemirror/lang-javascript'
+import { json } from '@codemirror/lang-json'
+import { markdown } from '@codemirror/lang-markdown'
+import { python } from '@codemirror/lang-python'
+import { yaml } from '@codemirror/lang-yaml'
+import type { Extension } from '@codemirror/state'
+
+/** CodeMirror language extension for a source path, or null for plain text. */
+export function languageFor(path: string): Extension | null {
+  const ext = path.split('.').pop()?.toLowerCase() ?? ''
+  switch (ext) {
+    case 'c':
+    case 'h':
+    case 'cpp':
+    case 'cc':
+    case 'cxx':
+    case 'hpp':
+    case 'hh':
+    case 'ino':
+      return cpp()
+    case 'py':
+      return python()
+    case 'json':
+      return json()
+    case 'yml':
+    case 'yaml':
+      return yaml()
+    case 'md':
+    case 'markdown':
+      return markdown()
+    case 'js':
+    case 'mjs':
+    case 'cjs':
+      return javascript()
+    case 'ts':
+    case 'tsx':
+      return javascript({ typescript: true, jsx: ext === 'tsx' })
+    default:
+      return null
+  }
+}

--- a/src/lib/db/schema/software.ts
+++ b/src/lib/db/schema/software.ts
@@ -94,6 +94,13 @@ export const software = pgTable(
     // Internal mode: the immutable source-tree snapshot for THIS item version
     manifestId: uuid('manifest_id').references(() => softwareManifests.id),
 
+    // In-progress edits on a working copy: saved without a commit, promoted
+    // to manifestId by an explicit commit (with message), discarded on
+    // release. Never copied to new versions and never in field history.
+    draftManifestId: uuid('draft_manifest_id').references(
+      () => softwareManifests.id,
+    ),
+
     // Primary build artifact (vault file: .bin/.hex/.elf/.zip)
     buildArtifactFileId: uuid('build_artifact_file_id'),
   },

--- a/src/lib/items/services/ItemService.ts
+++ b/src/lib/items/services/ItemService.ts
@@ -17,6 +17,7 @@ import {
   ValidationError,
 } from '../../errors'
 import { CommitService } from '../../services/CommitService'
+import { expandSourceFieldChanges } from '../../services/software-source-changes'
 import {
   computeFieldChanges,
   computeInitialFieldValues,
@@ -247,12 +248,17 @@ export class ItemService {
    *   - Exception: ECO release operations can bypass this with bypassBranchProtection option
    *
    * @param options.skipCommit - Skip creating a commit for this update (for bulk operations)
+   * @param options.commitMessage - Override the auto-generated commit message
    */
   static async update<T extends BaseItem>(
     id: string,
     data: Partial<T>,
     userId: string,
-    options?: { bypassBranchProtection?: boolean; skipCommit?: boolean },
+    options?: {
+      bypassBranchProtection?: boolean
+      skipCommit?: boolean
+      commitMessage?: string
+    },
   ): Promise<T> {
     // Get current item with type-specific data (for computing field changes)
     const oldItem = await this.findById(id)
@@ -353,10 +359,14 @@ export class ItemService {
       // Create commit for history tracking if item has a designId and skipCommit is not set
       if (oldItem.designId && !options?.skipCommit) {
         try {
-          const fieldChanges = computeFieldChanges(
-            oldItem as unknown as Record<string, unknown>,
-            completeItem as unknown as Record<string, unknown>,
+          // Software manifest changes become per-file 'source' rows
+          const fieldChanges = await expandSourceFieldChanges(
             oldItem.itemType,
+            computeFieldChanges(
+              oldItem as unknown as Record<string, unknown>,
+              completeItem as unknown as Record<string, unknown>,
+              oldItem.itemType,
+            ),
           )
 
           if (fieldChanges.length > 0) {
@@ -375,7 +385,9 @@ export class ItemService {
               const commit = await CommitService.create(
                 {
                   branchId,
-                  message: `${oldItem.itemType} ${oldItem.itemNumber || 'item'} updated`,
+                  message:
+                    options?.commitMessage ??
+                    `${oldItem.itemType} ${oldItem.itemNumber || 'item'} updated`,
                   itemChanges: [
                     {
                       itemId: id,

--- a/src/lib/items/type-handlers/software.ts
+++ b/src/lib/items/type-handlers/software.ts
@@ -15,6 +15,7 @@ registerTypeHandler('Software', {
       targetHardware: data.targetHardware || null,
       toolchain: data.toolchain || null,
       manifestId: data.manifestId || null,
+      draftManifestId: data.draftManifestId || null,
       buildArtifactFileId: data.buildArtifactFileId || null,
     })
   },
@@ -46,6 +47,8 @@ registerTypeHandler('Software', {
       updateData.toolchain = data.toolchain || null
     if (data.manifestId !== undefined)
       updateData.manifestId = data.manifestId || null
+    if (data.draftManifestId !== undefined)
+      updateData.draftManifestId = data.draftManifestId || null
     if (data.buildArtifactFileId !== undefined)
       updateData.buildArtifactFileId = data.buildArtifactFileId || null
 

--- a/src/lib/items/types/software.ts
+++ b/src/lib/items/types/software.ts
@@ -41,6 +41,8 @@ export interface Software extends BaseItem {
   toolchain?: string
   // Immutable source-tree snapshot for THIS item version (internal mode)
   manifestId?: string | null
+  // In-progress (uncommitted) edits on a working copy
+  draftManifestId?: string | null
   // Primary build artifact (vault file)
   buildArtifactFileId?: string | null
 }
@@ -55,6 +57,7 @@ export const softwareSchema = baseItemSchema.extend({
   targetHardware: z.string().max(200).optional(),
   toolchain: z.string().max(200).optional(),
   manifestId: z.string().uuid().nullable().optional(),
+  draftManifestId: z.string().uuid().nullable().optional(),
   buildArtifactFileId: z.string().uuid().nullable().optional(),
 })
 

--- a/src/lib/services/ChangeOrderMergeService.ts
+++ b/src/lib/services/ChangeOrderMergeService.ts
@@ -9,6 +9,7 @@ import {
   changeOrderDesigns,
   itemRelationships,
   items,
+  software,
 } from '../db/schema'
 import { MergeConflictError, NotFoundError, ValidationError } from '../errors'
 import { getTypeHandler } from '../items/type-handlers'
@@ -111,9 +112,13 @@ async function copyExtensionRow(
 ): Promise<void> {
   const handler = getTypeHandler(itemType)
   if (!handler) return
-  const data = await handler.get(sourceItemId, tx)
+  const data = (await handler.get(sourceItemId, tx)) as
+    | Record<string, unknown>
+    | undefined
   if (data) {
-    await handler.insert(targetItemId, data, tx)
+    // Released versions never carry uncommitted editor state
+    const { draftManifestId: _draft, ...clean } = data
+    await handler.insert(targetItemId, clean, tx)
   }
 }
 
@@ -1160,6 +1165,15 @@ export class ChangeOrderMergeService {
                     modifiedBy: userId,
                   })
                   .where(eq(items.id, currentItem.id))
+
+                // Working copy promoted in place: drop any uncommitted draft -
+                // only the committed manifest is what the release means
+                if (currentItem.itemType === 'Software') {
+                  await tx
+                    .update(software)
+                    .set({ draftManifestId: null })
+                    .where(eq(software.itemId, currentItem.id))
+                }
 
                 releasedItemId = currentItem.id
               } else {

--- a/src/lib/services/CheckoutService.ts
+++ b/src/lib/services/CheckoutService.ts
@@ -12,6 +12,7 @@ import { NotFoundError, ValidationError } from '../errors'
 import { BranchService } from './BranchService'
 import { CommitService } from './CommitService'
 import { VersionResolver } from './VersionResolver'
+import { expandSourceFieldChanges } from './software-source-changes'
 import type { commits } from '../db/schema'
 import type { FieldChange } from './CommitService'
 
@@ -63,6 +64,9 @@ const ignoreFields = [
   'designId',
   'commitId',
   'itemType',
+  // Uncommitted editor state on Software working copies - never part of the
+  // committed history (the commit records the manifestId change instead)
+  'draftManifestId',
   'createdAt',
   'createdBy',
   'modifiedAt',
@@ -625,13 +629,17 @@ export class CheckoutService {
 
         // 3. Compute field-level changes (only for modified items)
         // Include extension fields on both sides so type-category changes
-        // (weight, manifestId, ...) are recorded in the commit.
+        // (weight, manifestId, ...) are recorded in the commit. Software
+        // manifest changes expand into per-file 'source' rows.
         const fieldChanges =
           changeType === 'modified'
-            ? computeFieldChanges(
-                { ...item, ...extData },
-                { ...newItem, ...extData, ...validated.changes },
+            ? await expandSourceFieldChanges(
                 item.itemType,
+                computeFieldChanges(
+                  { ...item, ...extData },
+                  { ...newItem, ...extData, ...validated.changes },
+                  item.itemType,
+                ),
               )
             : []
 

--- a/src/lib/services/CommitService.ts
+++ b/src/lib/services/CommitService.ts
@@ -28,7 +28,9 @@ export interface FieldChange {
   fieldPath?: string
   oldValue: unknown
   newValue: unknown
-  fieldCategory: 'core' | 'type' | 'attribute' | 'relationship'
+  // 'source' = per-file source-tree changes on Software items (fieldPath is
+  // the file path, fieldName is added|modified|deleted, values are {hash,size})
+  fieldCategory: 'core' | 'type' | 'attribute' | 'relationship' | 'source'
 }
 
 // Zod schemas for validation
@@ -37,7 +39,7 @@ const fieldChangeSchema = z.object({
   fieldPath: z.string().optional(),
   oldValue: z.unknown(),
   newValue: z.unknown(),
-  fieldCategory: z.enum(['core', 'type', 'attribute', 'relationship']),
+  fieldCategory: z.enum(['core', 'type', 'attribute', 'relationship', 'source']),
 })
 
 export const commitCreateSchema = z.object({

--- a/src/lib/services/ConflictDetectionService.ts
+++ b/src/lib/services/ConflictDetectionService.ts
@@ -144,6 +144,7 @@ const IGNORED_COMPARISON_FIELDS = [
   'revision',
   'itemId',
   'state', // Lifecycle state changes are managed by workflow, not user-editable
+  'draftManifestId', // Uncommitted editor state - only committed manifests conflict
 ] as const
 
 // ============================================
@@ -340,10 +341,16 @@ export class ConflictDetectionService {
         }
 
         // Detect field-level conflicts using three-way comparison
-        const fieldConflicts = this.detectFieldConflicts(
+        // (Software manifest conflicts are refined to per-file granularity)
+        const fieldConflicts = await this.refineSourceConflicts(
           baseItem as unknown as Record<string, unknown> | null,
           ourFullItem as unknown as Record<string, unknown>,
           latestMainItem as unknown as Record<string, unknown>,
+          this.detectFieldConflicts(
+            baseItem as unknown as Record<string, unknown> | null,
+            ourFullItem as unknown as Record<string, unknown>,
+            latestMainItem as unknown as Record<string, unknown>,
+          ),
         )
 
         const hasFieldConflicts = fieldConflicts.length > 0
@@ -453,6 +460,67 @@ export class ConflictDetectionService {
     }
 
     return null
+  }
+
+  /**
+   * Sharpen Software manifest conflicts to per-file granularity.
+   *
+   * A raw three-way comparison reports one opaque `manifestId` conflict when
+   * both branches changed the source tree. Here we diff each side's manifest
+   * against the base: only paths changed *differently on both sides* are true
+   * conflicts, emitted as one FieldConflict per file (fieldPath = the file).
+   * If the two branches touched disjoint files, the manifestId conflict is
+   * dropped entirely - the caller's existing logic then downgrades the item
+   * to a concurrent-modification/cross-ECO warning instead of an error.
+   */
+  static async refineSourceConflicts(
+    baseItem: Record<string, unknown> | null,
+    ourItem: Record<string, unknown>,
+    theirItem: Record<string, unknown>,
+    fieldConflicts: Array<FieldConflict>,
+  ): Promise<Array<FieldConflict>> {
+    if (ourItem.itemType !== 'Software') return fieldConflicts
+    const manifestConflict = fieldConflicts.find(
+      (c) => c.fieldName === 'manifestId',
+    )
+    if (!manifestConflict) return fieldConflicts
+
+    // Lazy import: SoftwareSourceService pulls in ItemService, which this
+    // module must not import at top level.
+    const { SoftwareSourceService } = await import('./SoftwareSourceService')
+
+    const baseManifest = (baseItem?.manifestId as string | null) ?? null
+    const [ourDiff, theirDiff] = await Promise.all([
+      SoftwareSourceService.diffManifests(
+        baseManifest,
+        (ourItem.manifestId as string | null) ?? null,
+      ),
+      SoftwareSourceService.diffManifests(
+        baseManifest,
+        (theirItem.manifestId as string | null) ?? null,
+      ),
+    ])
+
+    const theirByPath = new Map(theirDiff.map((d) => [d.path, d]))
+    const perFile: Array<FieldConflict> = []
+    for (const ours of ourDiff) {
+      const theirs = theirByPath.get(ours.path)
+      if (!theirs) continue
+      // Same path changed on both sides - only a conflict if the results differ
+      if ((ours.newHash ?? null) === (theirs.newHash ?? null)) continue
+      perFile.push({
+        fieldName: 'source',
+        fieldPath: ours.path,
+        baseValue: ours.oldHash ?? null,
+        ourValue: ours.newHash ?? null,
+        theirValue: theirs.newHash ?? null,
+      })
+    }
+
+    return [
+      ...fieldConflicts.filter((c) => c.fieldName !== 'manifestId'),
+      ...perFile,
+    ]
   }
 
   /**
@@ -734,10 +802,16 @@ export class ConflictDetectionService {
         // Base = common ancestor (what both branched from)
         // Ours = our working copy
         // Theirs = other ECO's working copy
-        const fieldConflicts = this.detectFieldConflicts(
+        // (Software manifest conflicts are refined to per-file granularity)
+        const fieldConflicts = await this.refineSourceConflicts(
           baseItem as unknown as Record<string, unknown>,
           ourFullItem as unknown as Record<string, unknown>,
           otherFullItem as unknown as Record<string, unknown>,
+          this.detectFieldConflicts(
+            baseItem as unknown as Record<string, unknown>,
+            ourFullItem as unknown as Record<string, unknown>,
+            otherFullItem as unknown as Record<string, unknown>,
+          ),
         )
 
         const hasFieldConflicts = fieldConflicts.length > 0

--- a/src/lib/services/SoftwareSourceService.test.ts
+++ b/src/lib/services/SoftwareSourceService.test.ts
@@ -25,6 +25,8 @@ import { strToU8, zipSync } from 'fflate'
 import { ItemService } from '../items/services/ItemService'
 import { ChangeOrderService } from '../items/services/ChangeOrderService'
 import { ChangeOrderMergeService } from './ChangeOrderMergeService'
+import { CheckoutService } from './CheckoutService'
+import { ConflictDetectionService } from './ConflictDetectionService'
 import { SoftwareSourceService } from './SoftwareSourceService'
 import { BranchService } from './BranchService'
 import { DesignService } from './DesignService'
@@ -34,6 +36,10 @@ import { TestDatabase } from '@/__tests__/helpers/db'
 import { insertTestUser } from '@/__tests__/fixtures/users'
 import {
   branchItems,
+  branches,
+  commits,
+  itemFieldChanges,
+  itemVersions,
   items,
   programs,
   software,
@@ -44,7 +50,11 @@ import {
 import { ItemTypeRegistry } from '@/lib/items/registry'
 import { seedStandardPartLifecycle } from '@/__tests__/fixtures/lifecycles'
 import { takeFirst } from '@/lib/db/take-first'
-import { ValidationError } from '@/lib/errors'
+import {
+  BranchProtectionError,
+  ResourceLockedError,
+  ValidationError,
+} from '@/lib/errors'
 
 // Import to register item types
 import '@/lib/items/registerItemTypes.server'
@@ -651,6 +661,523 @@ describe('SoftwareSourceService', () => {
           user.id,
         ),
       ).rejects.toThrow(ValidationError)
+    })
+  })
+
+  // ==========================================================================
+  // Phase 2: draft editing (edit -> commit) and source field-change history
+  // ==========================================================================
+
+  describe('draft editing', () => {
+    async function countCommits(branchId: string) {
+      const rows = await testDb.db
+        .select({ id: commits.id })
+        .from(commits)
+        .where(eq(commits.branchId, branchId))
+      return rows.length
+    }
+
+    it('draft saves accumulate without commits; commitDraft promotes with per-file source history', async () => {
+      const sw = await createSoftware()
+      const r1 = await SoftwareSourceService.importFiles(
+        sw.id!,
+        [
+          file('src/main.c', 'int main() {}\n'),
+          file('src/pid.c', 'float pid() { return 0; }\n'),
+        ],
+        user.id,
+      )
+      const m1 = r1.manifest
+
+      const mainBranch = await BranchService.getMainBranch(designId)
+      const commitsBefore = await countCommits(mainBranch!.id)
+
+      // Two draft saves - no commits, committed manifest untouched
+      await SoftwareSourceService.saveFileToDraft(
+        sw.id!,
+        'src/pid.c',
+        Buffer.from('float pid() { return 1; }\n'),
+        user.id,
+      )
+      const d2 = await SoftwareSourceService.saveFileToDraft(
+        sw.id!,
+        'src/util.c',
+        Buffer.from('int util() { return 2; }\n'),
+        user.id,
+      )
+
+      expect(await countCommits(mainBranch!.id)).toBe(commitsBefore)
+      const rowMid = await getSoftwareRow(sw.id!)
+      expect(rowMid!.manifestId).toBe(m1.id)
+      expect(rowMid!.draftManifestId).toBe(d2.manifest.id)
+      // Draft builds on draft: second save sees the first save's edit
+      expect(d2.manifest.fileCount).toBe(3)
+
+      // Commit with a message
+      const { item: committed } = await SoftwareSourceService.commitDraft(
+        sw.id!,
+        'Clamp integrator on saturation',
+        user.id,
+      )
+      expect(committed.manifestId).toBe(d2.manifest.id)
+      expect(committed.draftManifestId ?? null).toBeNull()
+      expect(await countCommits(mainBranch!.id)).toBe(commitsBefore + 1)
+
+      // The commit carries per-file source rows, not an opaque manifestId row
+      const [commit] = await testDb.db
+        .select()
+        .from(commits)
+        .where(
+          and(
+            eq(commits.branchId, mainBranch!.id),
+            eq(commits.message, 'Clamp integrator on saturation'),
+          ),
+        )
+        .limit(1)
+      expect(commit).toBeDefined()
+
+      const versions = await testDb.db
+        .select()
+        .from(itemVersions)
+        .where(eq(itemVersions.commitId, commit!.id))
+      expect(versions).toHaveLength(1)
+
+      const changes = await testDb.db
+        .select()
+        .from(itemFieldChanges)
+        .where(eq(itemFieldChanges.itemVersionId, versions[0]!.id))
+
+      const sourceRows = changes.filter((c) => c.fieldCategory === 'source')
+      expect(sourceRows.map((c) => `${c.fieldName}:${c.fieldPath}`).sort())
+        .toEqual(['added:src/util.c', 'modified:src/pid.c'])
+
+      const modified = sourceRows.find((c) => c.fieldPath === 'src/pid.c')!
+      const oldEntry = m1.entries.find((e) => e.path === 'src/pid.c')!
+      const newEntry = d2.manifest.entries.find(
+        (e) => e.path === 'src/pid.c',
+      )!
+      expect(modified.oldValue).toEqual({
+        hash: oldEntry.hash,
+        size: oldEntry.size,
+      })
+      expect(modified.newValue).toEqual({
+        hash: newEntry.hash,
+        size: newEntry.size,
+      })
+
+      expect(changes.some((c) => c.fieldName === 'manifestId')).toBe(false)
+      expect(changes.some((c) => c.fieldName === 'draftManifestId')).toBe(
+        false,
+      )
+    })
+
+    it('delete and rename operate on the draft tree', async () => {
+      const sw = await createSoftware()
+      await SoftwareSourceService.importFiles(
+        sw.id!,
+        [file('a.c', 'a\n'), file('b.c', 'b\n')],
+        user.id,
+      )
+
+      await SoftwareSourceService.renameFileInDraft(
+        sw.id!,
+        'a.c',
+        'src/a.c',
+        user.id,
+      )
+      const afterDelete = await SoftwareSourceService.deleteFileFromDraft(
+        sw.id!,
+        'b.c',
+        user.id,
+      )
+
+      const paths = afterDelete.manifest.entries.map((e) => e.path)
+      expect(paths).toEqual(['src/a.c'])
+
+      // Committed tree untouched until commit
+      const row = await getSoftwareRow(sw.id!)
+      const committedManifest = await SoftwareSourceService.getManifestById(
+        row!.manifestId!,
+      )
+      expect(committedManifest!.entries.map((e) => e.path).sort()).toEqual([
+        'a.c',
+        'b.c',
+      ])
+    })
+
+    it('discardDraft reverts to the committed tree', async () => {
+      const sw = await createSoftware()
+      await SoftwareSourceService.importFiles(
+        sw.id!,
+        [file('main.c', 'v1\n')],
+        user.id,
+      )
+      await SoftwareSourceService.saveFileToDraft(
+        sw.id!,
+        'main.c',
+        Buffer.from('v2\n'),
+        user.id,
+      )
+
+      const item = await SoftwareSourceService.discardDraft(sw.id!, user.id)
+      expect(item.draftManifestId ?? null).toBeNull()
+    })
+
+    it('commitDraft refuses without a draft; import refuses while a draft exists', async () => {
+      const sw = await createSoftware()
+      await SoftwareSourceService.importFiles(
+        sw.id!,
+        [file('main.c', 'v1\n')],
+        user.id,
+      )
+
+      await expect(
+        SoftwareSourceService.commitDraft(sw.id!, 'nothing to do', user.id),
+      ).rejects.toThrow(ValidationError)
+
+      await SoftwareSourceService.saveFileToDraft(
+        sw.id!,
+        'main.c',
+        Buffer.from('v2\n'),
+        user.id,
+      )
+      await expect(
+        SoftwareSourceService.importFiles(
+          sw.id!,
+          [file('other.c', 'x\n')],
+          user.id,
+        ),
+      ).rejects.toThrow(ValidationError)
+    })
+  })
+
+  // ==========================================================================
+  // Phase 2: checkout gating (security gate)
+  // ==========================================================================
+
+  describe('checkout gating', () => {
+    it("another user's checkout blocks draft edits; the holder can edit", async () => {
+      const sw = await createSoftware()
+      await SoftwareSourceService.importFiles(
+        sw.id!,
+        [file('main.c', 'v1\n')],
+        user.id,
+      )
+      await releaseOnMain(sw)
+
+      const eco = await createChangeOrder()
+      await ChangeOrderService.addAffectedItem(
+        eco.id,
+        { affectedItemId: sw.id!, changeAction: 'revise' },
+        user.id,
+      )
+      const [workingCopy] = await testDb.db
+        .select()
+        .from(items)
+        .where(
+          and(eq(items.masterId, sw.masterId!), like(items.revision, '-%')),
+        )
+        .limit(1)
+
+      // Another user takes the checkout lock
+      const otherUser = await insertTestUser(testDb.db)
+      const { branch } = await BranchService.getOrCreateEcoBranch(
+        designId,
+        eco.id,
+        user.id,
+      )
+      await CheckoutService.checkout(
+        { branchId: branch.id, itemMasterId: sw.masterId! },
+        otherUser.id,
+      )
+
+      await expect(
+        SoftwareSourceService.saveFileToDraft(
+          workingCopy!.id,
+          'main.c',
+          Buffer.from('v2\n'),
+          user.id,
+        ),
+      ).rejects.toThrow(ResourceLockedError)
+
+      // The checkout holder can edit
+      const saved = await SoftwareSourceService.saveFileToDraft(
+        workingCopy!.id,
+        'main.c',
+        Buffer.from('v2\n'),
+        otherUser.id,
+      )
+      expect(saved.manifest.fileCount).toBe(1)
+    })
+
+    it('a locked branch blocks draft edits', async () => {
+      const sw = await createSoftware()
+      await SoftwareSourceService.importFiles(
+        sw.id!,
+        [file('main.c', 'v1\n')],
+        user.id,
+      )
+      await releaseOnMain(sw)
+
+      const eco = await createChangeOrder()
+      await ChangeOrderService.addAffectedItem(
+        eco.id,
+        { affectedItemId: sw.id!, changeAction: 'revise' },
+        user.id,
+      )
+      const [workingCopy] = await testDb.db
+        .select()
+        .from(items)
+        .where(
+          and(eq(items.masterId, sw.masterId!), like(items.revision, '-%')),
+        )
+        .limit(1)
+
+      const { branch } = await BranchService.getOrCreateEcoBranch(
+        designId,
+        eco.id,
+        user.id,
+      )
+      await testDb.db
+        .update(branches)
+        .set({ isLocked: true })
+        .where(eq(branches.id, branch.id))
+
+      await expect(
+        SoftwareSourceService.saveFileToDraft(
+          workingCopy!.id,
+          'main.c',
+          Buffer.from('v2\n'),
+          user.id,
+        ),
+      ).rejects.toThrow(BranchProtectionError)
+    })
+
+    it('released items on protected main cannot be edited', async () => {
+      const sw = await createSoftware()
+      await SoftwareSourceService.importFiles(
+        sw.id!,
+        [file('main.c', 'v1\n')],
+        user.id,
+      )
+      await releaseOnMain(sw) // design now has a Released item -> main protected
+
+      await expect(
+        SoftwareSourceService.saveFileToDraft(
+          sw.id!,
+          'main.c',
+          Buffer.from('v2\n'),
+          user.id,
+        ),
+      ).rejects.toThrow(BranchProtectionError)
+    })
+  })
+
+  // ==========================================================================
+  // Phase 2: per-file conflict sharpening (complex algorithm gate)
+  // ==========================================================================
+
+  describe('per-file conflict sharpening', () => {
+    // Build three manifests (base / ours / theirs) via replace imports on a
+    // scratch item, then exercise refineSourceConflicts directly.
+    async function buildManifests() {
+      const scratch = await createSoftware('scratch')
+      const base = (
+        await SoftwareSourceService.importFiles(
+          scratch.id!,
+          [file('a.c', 'a v1\n'), file('b.c', 'b v1\n')],
+          user.id,
+          { replace: true },
+        )
+      ).manifest
+      const oursAC = (
+        await SoftwareSourceService.importFiles(
+          scratch.id!,
+          [file('a.c', 'a v2-ours\n'), file('b.c', 'b v1\n')],
+          user.id,
+          { replace: true },
+        )
+      ).manifest
+      const theirsBC = (
+        await SoftwareSourceService.importFiles(
+          scratch.id!,
+          [file('a.c', 'a v1\n'), file('b.c', 'b v2-theirs\n')],
+          user.id,
+          { replace: true },
+        )
+      ).manifest
+      const theirsAC = (
+        await SoftwareSourceService.importFiles(
+          scratch.id!,
+          [file('a.c', 'a v2-theirs\n'), file('b.c', 'b v1\n')],
+          user.id,
+          { replace: true },
+        )
+      ).manifest
+      return { base, oursAC, theirsBC, theirsAC }
+    }
+
+    const swRecord = (manifestId: string | null) => ({
+      itemType: 'Software',
+      manifestId,
+    })
+
+    const manifestConflict = (
+      base: string,
+      ours: string,
+      theirs: string,
+    ) => [
+      {
+        fieldName: 'manifestId',
+        baseValue: base,
+        ourValue: ours,
+        theirValue: theirs,
+      },
+    ]
+
+    it('drops the manifest conflict when branches touched disjoint files', async () => {
+      const { base, oursAC, theirsBC } = await buildManifests()
+
+      const refined = await ConflictDetectionService.refineSourceConflicts(
+        swRecord(base.id),
+        swRecord(oursAC.id),
+        swRecord(theirsBC.id),
+        manifestConflict(base.id, oursAC.id, theirsBC.id),
+      )
+
+      expect(refined).toEqual([])
+    })
+
+    it('emits one per-file conflict when the same file changed differently', async () => {
+      const { base, oursAC, theirsAC } = await buildManifests()
+
+      const refined = await ConflictDetectionService.refineSourceConflicts(
+        swRecord(base.id),
+        swRecord(oursAC.id),
+        swRecord(theirsAC.id),
+        manifestConflict(base.id, oursAC.id, theirsAC.id),
+      )
+
+      expect(refined).toHaveLength(1)
+      expect(refined[0]).toMatchObject({
+        fieldName: 'source',
+        fieldPath: 'a.c',
+      })
+    })
+
+    it('does not conflict when both sides made the identical change', async () => {
+      const { base, oursAC } = await buildManifests()
+
+      const refined = await ConflictDetectionService.refineSourceConflicts(
+        swRecord(base.id),
+        swRecord(oursAC.id),
+        swRecord(oursAC.id),
+        manifestConflict(base.id, oursAC.id, oursAC.id),
+      )
+
+      expect(refined).toEqual([])
+    })
+
+    it('cross-ECO detection reports file-level conflicts through the real flow', async () => {
+      // Released software with two files, revised by two concurrent ECOs
+      const sw = await createSoftware('xeco')
+      await SoftwareSourceService.importFiles(
+        sw.id!,
+        [file('main.c', 'int main() {}\n'), file('pid.c', 'v1\n')],
+        user.id,
+      )
+      await releaseOnMain(sw)
+
+      const eco1 = await createChangeOrder()
+      await ChangeOrderService.addAffectedItem(
+        eco1.id,
+        { affectedItemId: sw.id!, changeAction: 'revise' },
+        user.id,
+      )
+      const eco2 = await createChangeOrder()
+      await ChangeOrderService.addAffectedItem(
+        eco2.id,
+        { affectedItemId: sw.id!, changeAction: 'revise' },
+        user.id,
+      )
+
+      const { branch: branch1 } = await BranchService.getOrCreateEcoBranch(
+        designId,
+        eco1.id,
+        user.id,
+      )
+      const { branch: branch2 } = await BranchService.getOrCreateEcoBranch(
+        designId,
+        eco2.id,
+        user.id,
+      )
+
+      const wcOn = async (branchId: string) => {
+        const [bi] = await testDb.db
+          .select()
+          .from(branchItems)
+          .where(
+            and(
+              eq(branchItems.branchId, branchId),
+              eq(branchItems.itemMasterId, sw.masterId!),
+            ),
+          )
+          .limit(1)
+        return bi!.currentItemId!
+      }
+
+      const wc1 = await wcOn(branch1.id)
+      const wc2 = await wcOn(branch2.id)
+
+      // ECO1 edits pid.c; ECO2 edits main.c (disjoint) -> warning only
+      await SoftwareSourceService.saveFileToDraft(
+        wc1,
+        'pid.c',
+        Buffer.from('v2-eco1\n'),
+        user.id,
+      )
+      await SoftwareSourceService.commitDraft(wc1, 'eco1 pid fix', user.id)
+
+      await SoftwareSourceService.saveFileToDraft(
+        wc2,
+        'main.c',
+        Buffer.from('int main() { return 1; }\n'),
+        user.id,
+      )
+      await SoftwareSourceService.commitDraft(wc2, 'eco2 main fix', user.id)
+
+      const disjoint = await ConflictDetectionService.detectConflictsForEco(
+        eco1.id,
+      )
+      const swConflicts = disjoint.conflicts.filter(
+        (c) => c.itemMasterId === sw.masterId,
+      )
+      expect(swConflicts.some((c) => c.conflictType === 'field_conflict')).toBe(
+        false,
+      )
+      expect(swConflicts.some((c) => c.conflictType === 'cross_eco')).toBe(true)
+
+      // ECO2 now also edits pid.c differently -> real per-file conflict
+      await SoftwareSourceService.saveFileToDraft(
+        wc2,
+        'pid.c',
+        Buffer.from('v2-eco2\n'),
+        user.id,
+      )
+      await SoftwareSourceService.commitDraft(wc2, 'eco2 pid tweak', user.id)
+
+      const overlapping = await ConflictDetectionService.detectConflictsForEco(
+        eco1.id,
+      )
+      const fileConflict = overlapping.conflicts.find(
+        (c) =>
+          c.itemMasterId === sw.masterId &&
+          c.conflictType === 'field_conflict',
+      )
+      expect(fileConflict).toBeDefined()
+      expect(fileConflict!.fieldConflicts).toEqual([
+        expect.objectContaining({ fieldName: 'source', fieldPath: 'pid.c' }),
+      ])
     })
   })
 })

--- a/src/lib/services/SoftwareSourceService.ts
+++ b/src/lib/services/SoftwareSourceService.ts
@@ -20,13 +20,15 @@
  */
 
 import { createHash } from 'node:crypto'
-import { eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import { unzipSync } from 'fflate'
 import { db } from '../db'
-import { softwareBlobs, softwareManifests } from '../db/schema'
-import { NotFoundError, ValidationError } from '../errors'
+import { branchItems, softwareBlobs, softwareManifests } from '../db/schema'
+import { NotFoundError, ResourceLockedError, ValidationError } from '../errors'
 import { ItemService } from '../items/services/ItemService'
 import { VersionResolver } from './VersionResolver'
+import { diffManifestEntries } from './software-source-changes'
+import type { ManifestDiffEntry } from './software-source-changes'
 import type { TransactionClient } from '../db'
 import type {
   SoftwareManifest,
@@ -35,6 +37,8 @@ import type {
 import type { Software } from '../items/types/software'
 import type { VersionContext } from './VersionResolver'
 import { takeFirst } from '@/lib/db/take-first'
+
+export type { ManifestDiffEntry } from './software-source-changes'
 
 // Size guardrails (proposal §3.2): firmware-scale trees, not monorepos.
 const MAX_FILE_SIZE = 1024 * 1024 // 1 MB per file
@@ -58,15 +62,6 @@ export interface SourceFileContent {
   /** UTF-8 text for text files, base64 for binary files */
   content: string
   encoding: 'utf8' | 'base64'
-}
-
-export interface ManifestDiffEntry {
-  path: string
-  status: 'added' | 'removed' | 'modified'
-  oldHash?: string
-  newHash?: string
-  oldSize?: number
-  newSize?: number
 }
 
 export interface ImportResult {
@@ -98,19 +93,10 @@ export class SoftwareSourceService {
     userId: string,
     options?: { replace?: boolean },
   ): Promise<ImportResult> {
-    const item = await ItemService.findById(itemId)
-    if (!item) {
-      throw new NotFoundError('Software', itemId, { operation: 'importFiles' })
-    }
-    if (item.itemType !== 'Software') {
+    const softwareItem = await this.getEditableSoftware(itemId, userId)
+    if (softwareItem.draftManifestId) {
       throw new ValidationError(
-        `Item ${itemId} is not a Software item (got ${item.itemType})`,
-      )
-    }
-    const softwareItem = item as unknown as Software
-    if ((softwareItem.sourceMode ?? 'internal') !== 'internal') {
-      throw new ValidationError(
-        'Source files can only be imported into internal-mode Software items',
+        'This item has uncommitted draft changes. Commit or discard the draft before importing.',
       )
     }
 
@@ -228,6 +214,223 @@ export class SoftwareSourceService {
   }
 
   // ==========================================================================
+  // Draft editing (checkout-gated write path)
+  //
+  // Edits accumulate on software.draftManifestId without commits; an explicit
+  // commitDraft() promotes the draft to manifestId through the standard
+  // update path, which records the per-file 'source' field changes. This
+  // mirrors the platform's edit -> commit model for item fields.
+  // ==========================================================================
+
+  /** Save one file into the item's draft tree. */
+  static async saveFileToDraft(
+    itemId: string,
+    path: string,
+    data: Buffer,
+    userId: string,
+  ): Promise<{ item: Software; manifest: SoftwareManifest }> {
+    const item = await this.getEditableSoftware(itemId, userId)
+    const normalized = this.normalizePath(path)
+    if (data.length > MAX_FILE_SIZE) {
+      throw new ValidationError(
+        `File "${normalized}" exceeds the ${MAX_FILE_SIZE / 1024 / 1024} MB source file limit`,
+      )
+    }
+
+    const baseEntries = await this.getEffectiveEntries(item)
+    const manifest = await db.transaction(async (tx) => {
+      await this.storeBlobs([{ path: normalized, data }], tx)
+      const merged = new Map(baseEntries.map((e) => [e.path, e]))
+      merged.set(normalized, {
+        path: normalized,
+        hash: sha256(data),
+        size: data.length,
+      })
+      return this.createManifest(Array.from(merged.values()), userId, tx)
+    })
+
+    const updated = await this.setDraft(itemId, manifest.id, userId)
+    return { item: updated, manifest }
+  }
+
+  /** Delete one file from the item's draft tree. */
+  static async deleteFileFromDraft(
+    itemId: string,
+    path: string,
+    userId: string,
+  ): Promise<{ item: Software; manifest: SoftwareManifest }> {
+    const item = await this.getEditableSoftware(itemId, userId)
+    const normalized = this.normalizePath(path)
+
+    const baseEntries = await this.getEffectiveEntries(item)
+    if (!baseEntries.some((e) => e.path === normalized)) {
+      throw new NotFoundError('SourceFile', normalized, {
+        operation: 'deleteFileFromDraft',
+      })
+    }
+
+    const manifest = await db.transaction(async (tx) =>
+      this.createManifest(
+        baseEntries.filter((e) => e.path !== normalized),
+        userId,
+        tx,
+      ),
+    )
+
+    const updated = await this.setDraft(itemId, manifest.id, userId)
+    return { item: updated, manifest }
+  }
+
+  /** Rename/move one file within the item's draft tree (content untouched). */
+  static async renameFileInDraft(
+    itemId: string,
+    fromPath: string,
+    toPath: string,
+    userId: string,
+  ): Promise<{ item: Software; manifest: SoftwareManifest }> {
+    const item = await this.getEditableSoftware(itemId, userId)
+    const from = this.normalizePath(fromPath)
+    const to = this.normalizePath(toPath)
+
+    const baseEntries = await this.getEffectiveEntries(item)
+    const source = baseEntries.find((e) => e.path === from)
+    if (!source) {
+      throw new NotFoundError('SourceFile', from, {
+        operation: 'renameFileInDraft',
+      })
+    }
+    if (baseEntries.some((e) => e.path === to)) {
+      throw new ValidationError(`A file already exists at "${to}"`)
+    }
+
+    const manifest = await db.transaction(async (tx) =>
+      this.createManifest(
+        baseEntries.map((e) => (e.path === from ? { ...e, path: to } : e)),
+        userId,
+        tx,
+      ),
+    )
+
+    const updated = await this.setDraft(itemId, manifest.id, userId)
+    return { item: updated, manifest }
+  }
+
+  /** Throw away the item's uncommitted draft. */
+  static async discardDraft(itemId: string, userId: string): Promise<Software> {
+    const item = await this.getEditableSoftware(itemId, userId)
+    if (!item.draftManifestId) return item
+    return ItemService.update<Software>(
+      itemId,
+      { draftManifestId: null },
+      userId,
+      { skipCommit: true },
+    )
+  }
+
+  /**
+   * Promote the draft to the committed manifest with a required message.
+   * Runs through ItemService.update, so branch protection applies and the
+   * commit records per-file 'source' field changes.
+   */
+  static async commitDraft(
+    itemId: string,
+    message: string,
+    userId: string,
+  ): Promise<{ item: Software; manifest: SoftwareManifest | null }> {
+    if (!message.trim()) {
+      throw new ValidationError('A commit message is required')
+    }
+    const item = await this.getEditableSoftware(itemId, userId)
+    if (!item.draftManifestId) {
+      throw new ValidationError('No draft changes to commit')
+    }
+
+    const updated = await ItemService.update<Software>(
+      itemId,
+      { manifestId: item.draftManifestId, draftManifestId: null },
+      userId,
+      { commitMessage: message.trim() },
+    )
+    const manifest = updated.manifestId
+      ? await this.getManifestById(updated.manifestId)
+      : null
+    return { item: updated, manifest }
+  }
+
+  /**
+   * Editability gate for source writes: must be an internal-mode Software
+   * item not checked out by another user. Branch locks and main-branch
+   * protection are enforced by ItemService.update on the actual write.
+   */
+  private static async getEditableSoftware(
+    itemId: string,
+    userId: string,
+  ): Promise<Software> {
+    const item = await ItemService.findById(itemId)
+    if (!item) {
+      throw new NotFoundError('Software', itemId, {
+        operation: 'editSource',
+      })
+    }
+    if (item.itemType !== 'Software') {
+      throw new ValidationError(
+        `Item ${itemId} is not a Software item (got ${item.itemType})`,
+      )
+    }
+    const softwareItem = item as unknown as Software
+    if ((softwareItem.sourceMode ?? 'internal') !== 'internal') {
+      throw new ValidationError(
+        'Source can only be edited on internal-mode Software items',
+      )
+    }
+
+    // Checkout lock IS the concurrency model: a checkout held by another
+    // user blocks edits (holding it yourself, or nobody holding it, allows
+    // them - consistent with how working-copy field edits behave).
+    const branchInfo = await ItemService.getItemBranchInfo(itemId)
+    if (branchInfo) {
+      const [bi] = await db
+        .select()
+        .from(branchItems)
+        .where(
+          and(
+            eq(branchItems.branchId, branchInfo.branchId),
+            eq(branchItems.itemMasterId, item.masterId),
+          ),
+        )
+        .limit(1)
+      if (bi?.checkedOutBy && bi.checkedOutBy !== userId) {
+        throw new ResourceLockedError(
+          `${item.itemNumber}`,
+          'checked out by another user',
+          { operation: 'editSource', itemId },
+        )
+      }
+    }
+
+    return softwareItem
+  }
+
+  /** The tree the editor sees: draft if present, else the committed manifest. */
+  private static async getEffectiveEntries(
+    item: Software,
+  ): Promise<Array<SoftwareManifestEntry>> {
+    const manifestId = item.draftManifestId ?? item.manifestId
+    if (!manifestId) return []
+    return (await this.getManifestById(manifestId))?.entries ?? []
+  }
+
+  private static async setDraft(
+    itemId: string,
+    draftManifestId: string,
+    userId: string,
+  ): Promise<Software> {
+    return ItemService.update<Software>(itemId, { draftManifestId }, userId, {
+      skipCommit: true,
+    })
+  }
+
+  // ==========================================================================
   // Read path
   // ==========================================================================
 
@@ -334,6 +537,34 @@ export class SoftwareSourceService {
   }
 
   /**
+   * Read one blob's content by hash (for history diffs of superseded
+   * versions, where the path may no longer exist in any current manifest).
+   */
+  static async getBlob(hash: string): Promise<{
+    hash: string
+    size: number
+    isBinary: boolean
+    content: string
+    encoding: 'utf8' | 'base64'
+  }> {
+    const [blob] = await db
+      .select()
+      .from(softwareBlobs)
+      .where(eq(softwareBlobs.hash, hash))
+      .limit(1)
+    if (!blob || blob.content === null) {
+      throw new NotFoundError('SoftwareBlob', hash, { operation: 'getBlob' })
+    }
+    return {
+      hash: blob.hash,
+      size: blob.size,
+      isBinary: blob.isBinary,
+      content: blob.content,
+      encoding: blob.isBinary ? 'base64' : 'utf8',
+    }
+  }
+
+  /**
    * Path-level diff between two manifests (either side may be null for
    * "empty tree"). Line-level diffs are computed client-side from the two
    * file contents.
@@ -349,42 +580,7 @@ export class SoftwareSourceService {
       ? ((await this.getManifestById(toManifestId))?.entries ?? [])
       : []
 
-    const fromMap = new Map(fromEntries.map((e) => [e.path, e]))
-    const toMap = new Map(toEntries.map((e) => [e.path, e]))
-
-    const diff: Array<ManifestDiffEntry> = []
-    for (const [path, from] of fromMap) {
-      const to = toMap.get(path)
-      if (!to) {
-        diff.push({
-          path,
-          status: 'removed',
-          oldHash: from.hash,
-          oldSize: from.size,
-        })
-      } else if (to.hash !== from.hash) {
-        diff.push({
-          path,
-          status: 'modified',
-          oldHash: from.hash,
-          newHash: to.hash,
-          oldSize: from.size,
-          newSize: to.size,
-        })
-      }
-    }
-    for (const [path, to] of toMap) {
-      if (!fromMap.has(path)) {
-        diff.push({
-          path,
-          status: 'added',
-          newHash: to.hash,
-          newSize: to.size,
-        })
-      }
-    }
-
-    return diff.sort((a, b) => a.path.localeCompare(b.path))
+    return diffManifestEntries(fromEntries, toEntries)
   }
 
   // ==========================================================================

--- a/src/lib/services/software-source-changes.ts
+++ b/src/lib/services/software-source-changes.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Cascadia PLM contributors
+
+/**
+ * Manifest diffing and source-level field-change expansion for Software items.
+ *
+ * Lives apart from SoftwareSourceService so ItemService / CheckoutService can
+ * expand manifest changes into per-file history rows without importing the
+ * full source service (which itself imports ItemService).
+ */
+
+import { eq } from 'drizzle-orm'
+import { db } from '../db'
+import { softwareManifests } from '../db/schema'
+import type { SoftwareManifestEntry } from '../db/schema/software'
+import type { FieldChange } from './CommitService'
+
+export interface ManifestDiffEntry {
+  path: string
+  status: 'added' | 'removed' | 'modified'
+  oldHash?: string
+  newHash?: string
+  oldSize?: number
+  newSize?: number
+}
+
+/** Pure path-level diff between two entry lists. */
+export function diffManifestEntries(
+  fromEntries: Array<SoftwareManifestEntry>,
+  toEntries: Array<SoftwareManifestEntry>,
+): Array<ManifestDiffEntry> {
+  const fromMap = new Map(fromEntries.map((e) => [e.path, e]))
+  const toMap = new Map(toEntries.map((e) => [e.path, e]))
+
+  const diff: Array<ManifestDiffEntry> = []
+  for (const [path, from] of fromMap) {
+    const to = toMap.get(path)
+    if (!to) {
+      diff.push({
+        path,
+        status: 'removed',
+        oldHash: from.hash,
+        oldSize: from.size,
+      })
+    } else if (to.hash !== from.hash) {
+      diff.push({
+        path,
+        status: 'modified',
+        oldHash: from.hash,
+        newHash: to.hash,
+        oldSize: from.size,
+        newSize: to.size,
+      })
+    }
+  }
+  for (const [path, to] of toMap) {
+    if (!fromMap.has(path)) {
+      diff.push({ path, status: 'added', newHash: to.hash, newSize: to.size })
+    }
+  }
+
+  return diff.sort((a, b) => a.path.localeCompare(b.path))
+}
+
+async function getManifestEntries(
+  manifestId: string | null,
+): Promise<Array<SoftwareManifestEntry>> {
+  if (!manifestId) return []
+  const [manifest] = await db
+    .select()
+    .from(softwareManifests)
+    .where(eq(softwareManifests.id, manifestId))
+    .limit(1)
+  return manifest?.entries ?? []
+}
+
+/**
+ * Expand a Software item's `manifestId` field change into per-file `source`
+ * rows (proposal §3.5): one row per added/modified/deleted path, with
+ * {hash, size} as old/new values. The opaque manifestId row is replaced -
+ * the per-file rows ARE the change. Non-Software items and change sets
+ * without a manifestId change pass through untouched.
+ */
+export async function expandSourceFieldChanges(
+  itemType: string,
+  fieldChanges: Array<FieldChange>,
+): Promise<Array<FieldChange>> {
+  if (itemType !== 'Software') return fieldChanges
+
+  const manifestChange = fieldChanges.find(
+    (fc) => fc.fieldName === 'manifestId',
+  )
+  if (!manifestChange) return fieldChanges
+
+  const [fromEntries, toEntries] = await Promise.all([
+    getManifestEntries((manifestChange.oldValue as string | null) ?? null),
+    getManifestEntries((manifestChange.newValue as string | null) ?? null),
+  ])
+
+  const sourceRows: Array<FieldChange> = diffManifestEntries(
+    fromEntries,
+    toEntries,
+  ).map((d) => ({
+    fieldCategory: 'source',
+    fieldName: d.status === 'removed' ? 'deleted' : d.status,
+    fieldPath: d.path,
+    oldValue: d.oldHash ? { hash: d.oldHash, size: d.oldSize } : null,
+    newValue: d.newHash ? { hash: d.newHash, size: d.newSize } : null,
+  }))
+
+  return [
+    ...fieldChanges.filter((fc) => fc.fieldName !== 'manifestId'),
+    ...sourceRows,
+  ]
+}

--- a/src/server/routes/software.ts
+++ b/src/server/routes/software.ts
@@ -1,8 +1,11 @@
 import { Hono } from 'hono'
+import { desc, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { tagged } from '../adapter'
 import type { Software } from '@/lib/items/types/software'
 import type { VersionContext } from '@/lib/services/VersionResolver'
+import { items, software } from '@/lib/db/schema'
+import { db } from '@/lib/db'
 import { ItemService } from '@/lib/items/services/ItemService'
 import { SoftwareSourceService } from '@/lib/services/SoftwareSourceService'
 import { NotFoundError, ValidationError } from '@/lib/errors'
@@ -103,7 +106,8 @@ app.delete(
   ),
 )
 
-// GET /api/v1/software/:id/tree - source tree at an optional version context
+// GET /api/v1/software/:id/tree - source tree at an optional version context.
+// draft=true returns the uncommitted draft tree when one exists.
 app.get(
   '/:id/tree',
   adapt(
@@ -114,7 +118,9 @@ app.get(
           summary: 'Get the source tree of a software item',
           request: {
             params: softwareIdParamSchema,
-            query: contextQuerySchema,
+            query: contextQuerySchema.extend({
+              draft: z.enum(['true', 'false']).optional(),
+            }),
           },
           responses: {
             200: {
@@ -122,6 +128,8 @@ app.get(
                 itemId: z.string(),
                 revision: z.string(),
                 manifestId: z.string().nullable(),
+                draftManifestId: z.string().nullable(),
+                isDraft: z.boolean(),
                 fileCount: z.number(),
                 totalSize: z.number(),
                 entries: z.array(manifestEntrySchema),
@@ -131,18 +139,31 @@ app.get(
         },
       },
       async ({ params, request }) => {
-        const query = parseQuery(request, contextQuerySchema)
+        const query = parseQuery(
+          request,
+          contextQuerySchema.extend({
+            draft: z.enum(['true', 'false']).optional(),
+          }),
+        )
         const { item, manifest } = await SoftwareSourceService.getTree(
           params.id,
           toVersionContext(query),
         )
+
+        const useDraft = query.draft === 'true' && !!item.draftManifestId
+        const effective = useDraft
+          ? await SoftwareSourceService.getManifestById(item.draftManifestId!)
+          : manifest
+
         return {
           itemId: item.id,
           revision: item.revision,
           manifestId: item.manifestId ?? null,
-          fileCount: manifest?.fileCount ?? 0,
-          totalSize: manifest?.totalSize ?? 0,
-          entries: manifest?.entries ?? [],
+          draftManifestId: item.draftManifestId ?? null,
+          isDraft: useDraft,
+          fileCount: effective?.fileCount ?? 0,
+          totalSize: effective?.totalSize ?? 0,
+          entries: effective?.entries ?? [],
         }
       },
     ),
@@ -167,22 +188,241 @@ app.get(
       async ({ params, request }) => {
         const query = parseQuery(
           request,
-          contextQuerySchema.extend({ path: z.string().min(1) }),
+          contextQuerySchema.extend({
+            path: z.string().min(1),
+            draft: z.enum(['true', 'false']).optional(),
+          }),
         )
         const { item } = await SoftwareSourceService.getTree(
           params.id,
           toVersionContext(query),
         )
-        if (!item.manifestId) {
+        const manifestId =
+          query.draft === 'true' && item.draftManifestId
+            ? item.draftManifestId
+            : item.manifestId
+        if (!manifestId) {
           throw new NotFoundError('SourceFile', query.path, {
             detail: 'Software item has no source tree',
           })
         }
         const file = await SoftwareSourceService.getFileContent(
-          item.manifestId,
+          manifestId,
           query.path,
         )
         return { file }
+      },
+    ),
+  ),
+)
+
+// PUT /api/v1/software/:id/file - save one file into the draft tree
+app.put(
+  '/:id/file',
+  adapt(
+    apiHandler<{ id: string }>(
+      {
+        permission: ['software', 'update'],
+        openapi: {
+          summary: 'Save a source file to the draft tree',
+          request: {
+            params: softwareIdParamSchema,
+            body: {
+              schema: z.object({
+                path: z.string().min(1),
+                content: z.string(),
+                encoding: z.enum(['utf8', 'base64']).optional(),
+              }),
+            },
+          },
+        },
+      },
+      async ({ params, request, user }) => {
+        const body = (await request.json()) as {
+          path?: string
+          content?: string
+          encoding?: 'utf8' | 'base64'
+        }
+        if (!body.path || body.content === undefined) {
+          throw new ValidationError('path and content are required')
+        }
+        const data = Buffer.from(
+          body.content,
+          body.encoding === 'base64' ? 'base64' : 'utf8',
+        )
+        const { item, manifest } = await SoftwareSourceService.saveFileToDraft(
+          params.id,
+          body.path,
+          data,
+          user.id,
+        )
+        return {
+          draftManifestId: manifest.id,
+          fileCount: manifest.fileCount,
+          itemId: item.id,
+        }
+      },
+    ),
+  ),
+)
+
+// DELETE /api/v1/software/:id/file?path=... - delete from the draft tree
+app.delete(
+  '/:id/file',
+  adapt(
+    apiHandler<{ id: string }>(
+      {
+        permission: ['software', 'update'],
+        openapi: {
+          summary: 'Delete a source file from the draft tree',
+          request: {
+            params: softwareIdParamSchema,
+            query: z.object({ path: z.string().min(1) }),
+          },
+        },
+      },
+      async ({ params, request, user }) => {
+        const query = parseQuery(request, z.object({ path: z.string().min(1) }))
+        const { item, manifest } =
+          await SoftwareSourceService.deleteFileFromDraft(
+            params.id,
+            query.path,
+            user.id,
+          )
+        return {
+          draftManifestId: manifest.id,
+          fileCount: manifest.fileCount,
+          itemId: item.id,
+        }
+      },
+    ),
+  ),
+)
+
+// POST /api/v1/software/:id/file/rename - rename/move within the draft tree
+app.post(
+  '/:id/file/rename',
+  adapt(
+    apiHandler<{ id: string }>(
+      {
+        permission: ['software', 'update'],
+        openapi: {
+          summary: 'Rename a source file in the draft tree',
+          request: {
+            params: softwareIdParamSchema,
+            body: {
+              schema: z.object({
+                fromPath: z.string().min(1),
+                toPath: z.string().min(1),
+              }),
+            },
+          },
+        },
+      },
+      async ({ params, request, user }) => {
+        const body = (await request.json()) as {
+          fromPath?: string
+          toPath?: string
+        }
+        if (!body.fromPath || !body.toPath) {
+          throw new ValidationError('fromPath and toPath are required')
+        }
+        const { item, manifest } = await SoftwareSourceService.renameFileInDraft(
+          params.id,
+          body.fromPath,
+          body.toPath,
+          user.id,
+        )
+        return {
+          draftManifestId: manifest.id,
+          fileCount: manifest.fileCount,
+          itemId: item.id,
+        }
+      },
+    ),
+  ),
+)
+
+// POST /api/v1/software/:id/commit - promote the draft with a message
+app.post(
+  '/:id/commit',
+  adapt(
+    apiHandler<{ id: string }>(
+      {
+        permission: ['software', 'update'],
+        openapi: {
+          summary: 'Commit the draft source tree',
+          request: {
+            params: softwareIdParamSchema,
+            body: { schema: z.object({ message: z.string().min(1) }) },
+          },
+        },
+      },
+      async ({ params, request, user }) => {
+        const body = (await request.json()) as { message?: string }
+        if (!body.message) {
+          throw new ValidationError('A commit message is required')
+        }
+        const { item, manifest } = await SoftwareSourceService.commitDraft(
+          params.id,
+          body.message,
+          user.id,
+        )
+        return {
+          itemId: item.id,
+          manifestId: manifest?.id ?? null,
+          fileCount: manifest?.fileCount ?? 0,
+        }
+      },
+    ),
+  ),
+)
+
+// POST /api/v1/software/:id/draft/discard - throw away uncommitted edits
+app.post(
+  '/:id/draft/discard',
+  adapt(
+    apiHandler<{ id: string }>(
+      {
+        permission: ['software', 'update'],
+        openapi: {
+          summary: 'Discard the draft source tree',
+          request: { params: softwareIdParamSchema },
+        },
+      },
+      async ({ params, user }) => {
+        const item = await SoftwareSourceService.discardDraft(
+          params.id,
+          user.id,
+        )
+        return { itemId: item.id, draftManifestId: null }
+      },
+    ),
+  ),
+)
+
+// GET /api/v1/software/:id/blob/:hash - blob content by hash (history diffs)
+app.get(
+  '/:id/blob/:hash',
+  adapt(
+    apiHandler<{ id: string; hash: string }>(
+      {
+        permission: ['software', 'read'],
+        openapi: {
+          summary: 'Get source blob content by hash',
+          request: {
+            params: softwareIdParamSchema.extend({
+              hash: z.string().regex(/^[a-f0-9]{64}$/),
+            }),
+          },
+        },
+      },
+      async ({ params }) => {
+        if (!/^[a-f0-9]{64}$/.test(params.hash)) {
+          throw new ValidationError('Invalid blob hash')
+        }
+        const blob = await SoftwareSourceService.getBlob(params.hash)
+        return { blob }
       },
     ),
   ),
@@ -246,6 +486,43 @@ app.post(
           { replace },
         )
         return { import: toImportResponse(result) }
+      },
+    ),
+  ),
+)
+
+// GET /api/v1/software/:id/versions - all versions of this software master
+// (for revision compare pickers)
+app.get(
+  '/:id/versions',
+  adapt(
+    apiHandler<{ id: string }>(
+      {
+        permission: ['software', 'read'],
+        openapi: {
+          summary: 'List all versions of a software item',
+          request: { params: softwareIdParamSchema },
+        },
+      },
+      async ({ params }) => {
+        const item = await ItemService.findById(params.id)
+        if (!item || item.itemType !== 'Software') {
+          throw new NotFoundError('Software', params.id)
+        }
+        const versions = await db
+          .select({
+            id: items.id,
+            revision: items.revision,
+            state: items.state,
+            isCurrent: items.isCurrent,
+            modifiedAt: items.modifiedAt,
+            manifestId: software.manifestId,
+          })
+          .from(items)
+          .leftJoin(software, eq(software.itemId, items.id))
+          .where(eq(items.masterId, item.masterId))
+          .orderBy(desc(items.modifiedAt))
+        return { versions }
       },
     ),
   ),


### PR DESCRIPTION
> **Stacked on #56** (Software as a first-class item type, Phase 1). Review that first; this PR contains only the Phase 2 delta. If #56 merges, this rebases onto main cleanly.

## What

Implements **Phase 2** of [`docs/proposals/software-management.md`](docs/proposals/software-management.md): the write path for internal-mode Software items.

### Draft-manifest editing (edit → commit)
- New `software.draft_manifest_id` column (migration `0005`, additive). In-app edits — save file, create, rename, delete — accumulate on an uncommitted draft manifest with **no commits**; blobs/manifests stay content-addressed and immutable.
- An explicit **Commit** (message required) promotes the draft to `manifestId` through `ItemService.update()`, so branch protection applies and the commit lands in normal history. `ItemService.update` gains a `commitMessage` option.
- Drafts never leak: excluded from field-change history and conflict comparison, not copied to working copies or released versions, and cleared when a merge promotes a working copy in place. Zip import refuses while a draft exists (protects uncommitted work).

### Per-file source history (`source` field category)
- A Software `manifestId` change now expands into per-file rows — `added`/`modified`/`deleted` with `{hash, size}` old/new values and `fieldPath` = the file — in both commit paths (`ItemService.update` and `CheckoutService.saveChanges`), replacing the opaque manifestId row. One history, one UI, same trail as weight changes (proposal §3.5).
- History tab renders these with status badges and click-through **side-by-side line diffs** (`@codemirror/merge`), fetched by blob hash so superseded versions stay diffable forever.

### Checkout gating (security)
Source writes are refused when another user holds the item checkout (`ResourceLockedError`), the branch is locked, or the item sits on protected main (`BranchProtectionError`). Holding the checkout yourself — or no checkout existing — allows edits, matching how working-copy field edits already behave.

### Per-file conflict sharpening (proposal §3.6)
`ConflictDetectionService` now refines Software manifest conflicts: each branch's manifest is diffed against the base, and only *same file changed differently on both sides* produces a `field_conflict` (one entry per file). Two ECOs touching disjoint files downgrade from a blocking error to a cross-ECO coordination warning.

### API + UI
- New endpoints: `PUT/DELETE /software/:id/file`, `/file/rename`, `/commit`, `/draft/discard`, `/blob/:hash`, `/versions`; `tree`/`file` gain `draft=true`. OpenAPI snapshot regenerated (all changes within software paths).
- Editor UI: editable CodeMirror with per-file dirty tracking and 30s auto-save, commit/discard dialogs, file create/rename/delete, revision compare (pick any other version → path-level diff → per-file line diff), and a **build-artifact vault card** on the detail page (branch-scoped, promotes on release).

## Testing

- 11 new tests (23 total in the scoped suite), covering the three gates: draft saves create no commits + commit produces correct per-file `source` rows with exact hashes (data integrity); other-user checkout / locked branch / protected main all block edits (security); per-file conflict refinement unit + full two-ECO integration flow (complex algorithm).
- Full unit suite: **1164 tests passing**. Lint + strict typecheck clean. Production build clean.
- Live smoke test on a dev server: draft save → `tree?draft=true` → commit with message → history shows `source modified src/pid.c`; versions + discard endpoints verified.

## Out of scope (later phases)

External repository linking with pin-and-freeze semantics (Phase 3), webhook drift alerts and more providers (Phase 4). Line-level *merge* remains intentionally out of scope — the checkout lock is the concurrency model (proposal §3.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)