### PR TITLE
Fix createRequire collision in server bundles

### DIFF
--- a/scripts/build-jobs-worker.mjs
+++ b/scripts/build-jobs-worker.mjs
@@ -8,6 +8,7 @@
 import * as esbuild from 'esbuild'
 import { existsSync, mkdirSync } from 'node:fs'
 import { dirname } from 'node:path'
+import { assertBundleParses, cjsInteropBanner } from './build-shared.mjs'
 
 const outfile = '.output/server/jobs-worker.mjs'
 
@@ -25,12 +26,7 @@ await esbuild.build({
   format: 'esm',
   outfile,
   // Banner to support require() in ESM for packages that need it
-  banner: {
-    js: `
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
-`,
-  },
+  banner: { js: cjsInteropBanner },
   // Externalize packages that should come from node_modules at runtime
   external: [
     // Native modules
@@ -62,5 +58,7 @@ const require = createRequire(import.meta.url);
   // Log level
   logLevel: 'info',
 })
+
+await assertBundleParses(outfile)
 
 console.log(`✅ Jobs worker built: ${outfile}`)

--- a/scripts/build-server.mjs
+++ b/scripts/build-server.mjs
@@ -9,6 +9,7 @@
 import * as esbuild from 'esbuild'
 import { existsSync, mkdirSync } from 'node:fs'
 import { dirname } from 'node:path'
+import { assertBundleParses, cjsInteropBanner } from './build-shared.mjs'
 
 const outfile = '.output/server/index.mjs'
 
@@ -24,13 +25,7 @@ await esbuild.build({
   target: 'node20',
   format: 'esm',
   outfile,
-  // CommonJS interop shim — many transitive deps use require()
-  banner: {
-    js: `
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
-`,
-  },
+  banner: { js: cjsInteropBanner },
   // Packages that must be loaded from node_modules at runtime
   // (native bindings, dynamic requires, or pulled in by admin scripts only).
   external: [
@@ -57,5 +52,7 @@ const require = createRequire(import.meta.url);
   },
   logLevel: 'info',
 })
+
+await assertBundleParses(outfile)
 
 console.log(`✅ Server built: ${outfile}`)

--- a/scripts/build-shared.mjs
+++ b/scripts/build-shared.mjs
@@ -1,0 +1,54 @@
+/**
+ * Shared pieces of the esbuild Node bundles
+ * (.output/server/index.mjs and .output/server/jobs-worker.mjs).
+ */
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * CommonJS interop shim — many transitive deps call require() at runtime, which
+ * does not exist in an ESM bundle, so we recreate it from import.meta.url.
+ *
+ * The import is aliased on purpose. esbuild treats a banner as opaque text: it
+ * never parses it, so it cannot rename around it. Any bundled dependency whose
+ * ESM entry starts with `import { createRequire } from 'module'` gets that
+ * import emitted verbatim into the same bundle, and the two top-level bindings
+ * collide:
+ *
+ *   SyntaxError: Identifier 'createRequire' has already been declared
+ *
+ * fflate/esm/index.mjs does exactly this, which broke every production boot.
+ * Importing under a private alias keeps the banner collision-proof regardless
+ * of what a dependency does.
+ *
+ * The `require` const itself needs no alias: esbuild knows `require` is
+ * significant on platform: 'node' and renames a dependency's own top-level
+ * `require` binding out of the way (fflate's becomes `require2`).
+ */
+export const cjsInteropBanner = `
+import { createRequire as __cascadiaCreateRequire } from 'node:module';
+const require = __cascadiaCreateRequire(import.meta.url);
+`
+
+/**
+ * Parse the emitted bundle the way Node will on boot.
+ *
+ * esbuild cannot detect banner/bundle collisions like the one above — the build
+ * succeeds and the breakage only surfaces when the server starts. This turns
+ * that into a build failure.
+ */
+export async function assertBundleParses(outfile) {
+  try {
+    await execFileAsync(process.execPath, ['--check', outfile])
+  } catch (error) {
+    console.error(
+      `\n❌ ${outfile} is not valid ESM — it would fail to boot:\n\n${
+        error.stderr || error.message
+      }`,
+    )
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
The esbuild CommonJS-interop banner is opaque text to esbuild, so it cannot rename around it. fflate/esm/index.mjs opens with its own `import { createRequire } from 'module'`, which esbuild emitted verbatim into the same bundle, giving two top-level `createRequire` bindings and a SyntaxError on every boot. Both .output/server/index.mjs and .output/server/jobs-worker.mjs were affected; fflate reaches the worker via ConflictDetectionService -> SoftwareSourceService.

- Fix the collision by importing createRequire under a private alias in the banner. The `require` const needs no alias: esbuild knows `require` is significant on platform 'node' and renames a dependency's own top-level binding out of the way (fflate's becomes `require2`).
- Extract the shared banner into scripts/build-shared.mjs so the server and jobs-worker builds cannot drift apart again.
- Add assertBundleParses(): a `node --check` on each emitted bundle. esbuild reports success on this class of breakage, so it previously surfaced only at boot on the server; it is now a build failure.


Claude-Session: https://claude.ai/code/session_01Y4EzYtzUQ2Q1GXrjsdtY2X