### PR TITLE
Add tools seed dataset for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "db:studio": "drizzle-kit studio",
     "db:seed": "tsx scripts/seed-minimal.ts",
     "db:seed:catalog": "tsx scripts/seed-catalog.ts",
+    "db:seed:tools": "tsx scripts/seed-tools.ts",
     "db:seed:demo": "tsx scripts/seed-demo-robot-arm.ts",
     "db:drop": "tsx scripts/drop-all-tables.ts",
     "db:reset": "tsx scripts/truncate-all.ts",

--- a/scripts/seed-tools.ts
+++ b/scripts/seed-tools.ts
@@ -1,0 +1,175 @@
+/**
+ * Tool Seed Script
+ *
+ * Loads the shop equipment dataset from `test-data/tools.json` — manufacturing
+ * machines, quality instruments and utility devices, each with its structured
+ * `capabilities` blob. Tools are standalone items: no design, no commit, no BOM.
+ *
+ * Idempotent: tools are matched on itemNumber, and any that already exist are
+ * left untouched. Re-running only inserts what is missing.
+ *
+ * Run with:
+ *   npm run db:seed:tools
+ *
+ * Requires the minimal seed to have run first (needs the admin user and the
+ * Tool item-type config / lifecycle):
+ *   npm run db:seed
+ */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { randomUUID } from 'node:crypto'
+import { and, eq, inArray, sql } from 'drizzle-orm'
+import { db } from '../src/lib/db/index.ts'
+import { users } from '../src/lib/db/schema/users.ts'
+import { items, tools } from '../src/lib/db/schema/items.ts'
+import { numberSequences } from '../src/lib/db/schema/numbering.ts'
+
+// ============================================================================
+// Config
+// ============================================================================
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..')
+const DATA_FILE = join(REPO_ROOT, 'test-data', 'tools.json')
+
+/** Mirrors the `Tool` interface in src/lib/items/types/tool.ts */
+interface ToolSeedRow {
+  itemNumber: string
+  revision: string
+  name: string
+  state: string
+  toolType: 'manufacturing' | 'quality' | 'utility'
+  toolSubtype: string
+  manufacturer?: string
+  model?: string
+  toolStatus?: 'available' | 'in_use' | 'maintenance' | 'retired'
+  location?: string
+  notes?: string
+  attributes?: Record<string, string>
+  capabilities?: Record<string, unknown>
+}
+
+console.log('=== Tool Seed ===\n')
+
+const seedRows = JSON.parse(
+  readFileSync(DATA_FILE, 'utf8'),
+) as Array<ToolSeedRow>
+
+// ---- 1. Admin user ---------------------------------------------------------
+
+const adminRows = await db
+  .select()
+  .from(users)
+  .where(eq(users.email, 'admin@cascadia.local'))
+  .limit(1)
+
+const admin = adminRows.at(0)
+if (!admin) {
+  console.error(
+    'Admin user (admin@cascadia.local) not found. Run scripts/seed-minimal.ts first.',
+  )
+  process.exit(1)
+}
+
+// ---- 2. Idempotency: skip tools that already exist --------------------------
+
+const seedNumbers = seedRows.map((t) => t.itemNumber)
+
+const existingRows = await db
+  .select({ itemNumber: items.itemNumber })
+  .from(items)
+  .where(
+    and(eq(items.itemType, 'Tool'), inArray(items.itemNumber, seedNumbers)),
+  )
+
+const existing = new Set(existingRows.map((r) => r.itemNumber))
+const pending = seedRows.filter((t) => !existing.has(t.itemNumber))
+
+if (pending.length === 0) {
+  console.log(`All ${seedRows.length} tools already present — nothing to do.`)
+  process.exit(0)
+}
+
+// ---- 3. Insert -------------------------------------------------------------
+
+await db.transaction(async (tx) => {
+  for (const row of pending) {
+    const itemId = randomUUID()
+
+    await tx.insert(items).values({
+      id: itemId,
+      masterId: itemId,
+      designId: null,
+      itemNumber: row.itemNumber,
+      revision: row.revision,
+      itemType: 'Tool',
+      name: row.name,
+      state: row.state,
+      attributes: row.attributes ?? {},
+      isCurrent: true,
+      createdBy: admin.id,
+      modifiedBy: admin.id,
+    })
+
+    await tx.insert(tools).values({
+      itemId,
+      toolType: row.toolType,
+      toolSubtype: row.toolSubtype,
+      manufacturer: row.manufacturer ?? null,
+      model: row.model ?? null,
+      capabilities: row.capabilities ?? null,
+      toolStatus: row.toolStatus ?? 'available',
+      location: row.location ?? null,
+      notes: row.notes ?? null,
+    })
+  }
+})
+
+// ---- 4. Advance the Tool number sequence -----------------------------------
+//
+// The dataset ships auto-generated numbers (TOOL-000001…). Without this, the
+// next tool created in the UI would reuse a number already in the dataset and
+// collide on the (item_number, revision, design_id, item_type) unique index.
+// Tool uses a global-scope sequence, so scopeKey is just the item type.
+
+const highestSeeded = seedRows.reduce((max, row) => {
+  const match = /^TOOL-(\d+)$/.exec(row.itemNumber)
+  return match ? Math.max(max, Number(match[1])) : max
+}, 0)
+
+if (highestSeeded > 0) {
+  await db
+    .insert(numberSequences)
+    .values({
+      itemType: 'Tool',
+      scopeKey: 'Tool',
+      currentValue: highestSeeded,
+    })
+    .onConflictDoUpdate({
+      target: [numberSequences.itemType, numberSequences.scopeKey],
+      set: {
+        currentValue: sql`GREATEST(${numberSequences.currentValue}, ${highestSeeded})`,
+        modifiedAt: new Date(),
+      },
+    })
+}
+
+// ---- Summary ---------------------------------------------------------------
+
+const byType = pending.reduce<Record<string, number>>((acc, t) => {
+  acc[t.toolType] = (acc[t.toolType] ?? 0) + 1
+  return acc
+}, {})
+
+console.log(`✓ ${pending.length} tools inserted`)
+if (existing.size > 0) {
+  console.log(`  ${existing.size} already present, skipped`)
+}
+for (const [type, count] of Object.entries(byType).sort()) {
+  console.log(`  ${type}: ${count}`)
+}
+console.log(`  Tool number sequence at ${highestSeeded}`)
+
+process.exit(0)

--- a/test-data/tools.json
+++ b/test-data/tools.json
@@ -1,0 +1,295 @@
+[
+  {
+    "itemNumber": "LATHE-001",
+    "revision": "A",
+    "name": "Grizzly G0765 - 7\" x 14\" Variable-Speed Benchtop Metal Lathe",
+    "state": "Active",
+    "toolType": "manufacturing",
+    "toolSubtype": "manual_lathe",
+    "manufacturer": "Grizzly",
+    "model": "G0765",
+    "toolStatus": "available",
+    "attributes": {
+      "HP": "3/4"
+    },
+    "capabilities": {
+      "threading": true,
+      "spindleBore": 20,
+      "maxSwingDiameter": 177.8,
+      "spindleSpeedRange": [
+        100,
+        2000
+      ],
+      "compatibleMaterials": [
+        "steel"
+      ],
+      "distanceBetweenCenters": 330.2
+    }
+  },
+  {
+    "itemNumber": "MILL-001",
+    "revision": "A",
+    "name": "Grizzly G0704 7\" x 27\" 1 HP Mill",
+    "state": "Active",
+    "toolType": "manufacturing",
+    "toolSubtype": "manual_mill",
+    "manufacturer": "Grizzly",
+    "model": "G0704",
+    "toolStatus": "available",
+    "attributes": {
+      "HP": "1",
+      "Amps": "12",
+      "Phase": "Single"
+    },
+    "capabilities": {
+      "tableSize": [
+        676.275,
+        176.2125
+      ],
+      "spindleTaper": "R8",
+      "maxSpindleToTable": 330.2,
+      "spindleSpeedRange": [
+        0,
+        4300
+      ],
+      "compatibleMaterials": [
+        "steel"
+      ]
+    }
+  },
+  {
+    "itemNumber": "TOOL-000001",
+    "revision": "A",
+    "name": "Original Prusa i3 MK3S+",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "fdm_printer",
+    "manufacturer": "Prusa Research",
+    "model": "i3 MK3S+ MMU",
+    "toolStatus": "available",
+    "capabilities": {
+      "heatedBed": true,
+      "buildVolume": [
+        250,
+        210,
+        210
+      ],
+      "enclosedChamber": true,
+      "compatibleMaterials": [
+        "PLA"
+      ]
+    }
+  },
+  {
+    "itemNumber": "TOOL-000002",
+    "revision": "A",
+    "name": "WEN 3962T 3.5-Amp 10-Inch Two-Speed Band Saw",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "band_saw",
+    "manufacturer": "WEN",
+    "model": "3962T",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000003",
+    "revision": "A",
+    "name": "Craftsman Bench Grinder",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "bench_grinder",
+    "manufacturer": "Craftsman",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000004",
+    "revision": "A",
+    "name": "Lincoln 140 MP Multi-Process Welder",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "mig_welder",
+    "manufacturer": "Lincoln",
+    "model": "Power MIG 140 MP",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000005",
+    "revision": "A",
+    "name": "Dewalt 20V Max Drill/Driver",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "other",
+    "manufacturer": "Dewalt",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000006",
+    "revision": "A",
+    "name": "Granite Surface Plate",
+    "state": "Draft",
+    "toolType": "quality",
+    "toolSubtype": "surface_plate",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000007",
+    "revision": "A",
+    "name": "Height Gauge",
+    "state": "Draft",
+    "toolType": "quality",
+    "toolSubtype": "height_gauge",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000008",
+    "revision": "A",
+    "name": "Mitutoyo Micrometer Set",
+    "state": "Draft",
+    "toolType": "quality",
+    "toolSubtype": "micrometer",
+    "manufacturer": "Mitutoyo",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000009",
+    "revision": "A",
+    "name": "Mitutoyo 12\" calipers",
+    "state": "Draft",
+    "toolType": "quality",
+    "toolSubtype": "calipers",
+    "manufacturer": "Mitutoyo",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000010",
+    "revision": "A",
+    "name": "WEN 4208T 2.3-Amp 8-Inch 5-Speed Cast Iron Benchtop Drill Press",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "drill_press",
+    "manufacturer": "WEN",
+    "model": "4208T",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000011",
+    "revision": "A",
+    "name": "VEVOR Sheet Metal Brake 36\"",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "box_brake",
+    "manufacturer": "VEVOR",
+    "toolStatus": "available",
+    "notes": "Capacity for 20 gauge low carbon steel and 14 gauge aluminum. 0-130 degree adjustable angle."
+  },
+  {
+    "itemNumber": "TOOL-000012",
+    "revision": "A",
+    "name": "Dewalt Heavy Duty Heat Gun",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "heat_gun",
+    "manufacturer": "Dewalt",
+    "model": "D26960K",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000013",
+    "revision": "A",
+    "name": "Weller 70 Watt Digital Soldering Station",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "soldering_station",
+    "manufacturer": "Weller",
+    "model": "WE1010NA",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000014",
+    "revision": "A",
+    "name": "Propane Torch Head",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "other",
+    "manufacturer": "RTTOOA",
+    "model": "GJ-8000pro",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000015",
+    "revision": "A",
+    "name": "DC Power Supply Variable, 0-32V 0-10A Switching Bench Power Supply",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "other",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000016",
+    "revision": "A",
+    "name": "IRWIN Vise-Grip Wire Stripper",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "other",
+    "manufacturer": "IRWIN",
+    "model": "2078300",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000017",
+    "revision": "A",
+    "name": "AstroAI Digital Multimeter, True RMS 6000 Counts Auto-Ranging Volt Meter",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "other",
+    "manufacturer": "AstroAI",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000018",
+    "revision": "A",
+    "name": "DEWALT 10-Inch Table Saw, 32-1/2-Inch Rip Capacity",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "table_saw",
+    "manufacturer": "DEWALT",
+    "model": "DWE7491RS",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000019",
+    "revision": "A",
+    "name": "DEWALT 2-1/4 HP EVS Fixed Base/Plunge Router Combo Kit",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "other",
+    "manufacturer": "DEWALT",
+    "model": "DW618PKB",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000020",
+    "revision": "A",
+    "name": "DEWALT 20V MAX Brushless Cut Off Tool/Grinder",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "angle_grinder",
+    "manufacturer": "DEWALT",
+    "model": "DCG413B",
+    "toolStatus": "available"
+  },
+  {
+    "itemNumber": "TOOL-000021",
+    "revision": "A",
+    "name": "DEWALT Sliding Compound Miter Saw, 12-Inch",
+    "state": "Draft",
+    "toolType": "manufacturing",
+    "toolSubtype": "miter_saw",
+    "manufacturer": "DEWALT",
+    "model": "DWS779",
+    "toolStatus": "available",
+    "capabilities": {
+      "slidingCompound": true
+    }
+  }
+]


### PR DESCRIPTION
Captures the 23-tool shop equipment dataset (19 manufacturing, 4 quality) as test-data/tools.json, so local dev databases can be seeded with the same tools rather than recreating them by hand.

The JSON mirrors the camelCase `Tool` shape from src/lib/items/types/tool.ts rather than raw DB columns; all 23 rows validate against `toolSchema`, including the per-subtype capability schemas.

scripts/seed-tools.ts follows the existing seed convention (direct Drizzle inserts, admin lookup by email) and is idempotent — tools are matched on itemNumber and existing ones are left alone.

Tool numbers are preserved from the source data, which means the global Tool number sequence has to be advanced past the seeded range; otherwise the next tool created in the UI would reuse TOOL-000001 and collide on the (item_number, revision, design_id, item_type) unique index. The seeder bumps it with a GREATEST() upsert so it never walks an already-ahead counter back.

Opt-in via `npm run db:seed:tools`, mirroring db:seed:catalog.


Claude-Session: https://claude.ai/code/session_0177ZdD74wMxp3pY6dJimyqv