### PR TITLE
Add freeform text editor for Tool capabilities

### DIFF
--- a/src/components/tools/CapabilitiesEditor.tsx
+++ b/src/components/tools/CapabilitiesEditor.tsx
@@ -2,9 +2,16 @@
  * Subtype-aware capabilities editor for Tool items.
  *
  * Renders typed form fields for known subtypes and falls back
- * to a JSON textarea for unknown subtypes.
+ * to a forgiving freeform text editor for unknown subtypes.
  */
 
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  displayCapabilityValue,
+  formatCapabilityText,
+  humanizeCapabilityKey,
+  parseCapabilityText,
+} from '@/lib/items/capability-text'
 import {
   FormField,
   Input,
@@ -740,6 +747,86 @@ const EDITORS: Record<
   surface_grinder: SurfaceGrinderEditor,
 }
 
+const FREEFORM_PLACEHOLDER = [
+  'Build volume: 250 x 210 x 220',
+  'Materials: PLA, PETG, ABS',
+  'Heated bed: yes',
+  'Max power: 60',
+].join('\n')
+
+/**
+ * Fallback editor for subtypes without a dedicated form.
+ *
+ * Accepts plain text — one capability per line, `name: value`, commas for
+ * lists, no quotes or braces required — and shows what was understood.
+ */
+function FreeformCapabilitiesEditor({
+  capabilities,
+  onChange,
+}: Omit<CapabilitiesEditorProps, 'subtype'>) {
+  const [text, setText] = useState(() => formatCapabilityText(capabilities))
+
+  // What the current text parses to; also what we last handed to the parent.
+  const parsed = useMemo(() => parseCapabilityText(text), [text])
+  const lastEmitted = useRef(parsed)
+
+  // Re-sync when the record changes underneath us (item reload, edit cancel).
+  useEffect(() => {
+    if (JSON.stringify(capabilities) !== JSON.stringify(lastEmitted.current)) {
+      lastEmitted.current = capabilities
+      setText(formatCapabilityText(capabilities))
+    }
+  }, [capabilities])
+
+  const handleChange = (value: string) => {
+    setText(value)
+    const next = parseCapabilityText(value)
+    lastEmitted.current = next
+    onChange(next)
+  }
+
+  const entries = Object.entries(parsed)
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium text-zinc-400">Capabilities</p>
+      <Textarea
+        rows={5}
+        value={text}
+        onChange={(e) => handleChange(e.target.value)}
+        placeholder={FREEFORM_PLACEHOLDER}
+      />
+      <p className="text-xs text-slate-500">
+        One capability per line, as{' '}
+        <span className="font-medium">name: value</span>. Separate list values
+        with commas (<span className="font-medium">PLA, PETG</span>), use{' '}
+        <span className="font-medium">yes</span>/
+        <span className="font-medium">no</span> for on-off capabilities, and{' '}
+        <span className="font-medium">250 x 210 x 220</span> for dimensions. No
+        quotes or brackets needed.
+      </p>
+      {entries.length > 0 && (
+        <div className="rounded-md border border-slate-200 dark:border-slate-700 p-3">
+          <p className="text-xs font-medium text-slate-500 mb-2">
+            Saved as {entries.length}{' '}
+            {entries.length === 1 ? 'capability' : 'capabilities'}
+          </p>
+          <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+            {entries.map(([key, value]) => (
+              <div key={key} className="contents">
+                <dt className="text-slate-500">{humanizeCapabilityKey(key)}</dt>
+                <dd className="text-slate-800 dark:text-slate-200 break-words">
+                  {displayCapabilityValue(value)}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      )}
+    </div>
+  )
+}
+
 export function CapabilitiesEditor({
   subtype,
   capabilities,
@@ -765,23 +852,38 @@ export function CapabilitiesEditor({
     )
   }
 
-  // Generic JSON fallback for subtypes without a dedicated editor
   return (
-    <div className="space-y-3">
-      <p className="text-sm font-medium text-zinc-400">Capabilities (JSON)</p>
-      <Textarea
-        rows={5}
-        value={JSON.stringify(capabilities, null, 2)}
-        onChange={(e) => {
-          try {
-            onChange(JSON.parse(e.target.value))
-          } catch {
-            /* ignore while typing */
-          }
-        }}
-        className="font-mono text-xs"
-        placeholder='{"key": "value"}'
-      />
-    </div>
+    <FreeformCapabilitiesEditor
+      capabilities={capabilities}
+      onChange={onChange}
+    />
+  )
+}
+
+/** Read-only rendering of a capabilities record. */
+export function CapabilitiesView({
+  capabilities,
+}: {
+  capabilities: Record<string, unknown>
+}) {
+  const entries = Object.entries(capabilities)
+
+  if (entries.length === 0) {
+    return <p className="text-sm text-slate-500">No capabilities recorded.</p>
+  }
+
+  return (
+    <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3">
+      {entries.map(([key, value]) => (
+        <div key={key}>
+          <dt className="text-sm font-medium text-slate-500 dark:text-slate-400">
+            {humanizeCapabilityKey(key)}
+          </dt>
+          <dd className="text-sm text-slate-900 dark:text-slate-100 break-words">
+            {displayCapabilityValue(value)}
+          </dd>
+        </div>
+      ))}
+    </dl>
   )
 }

--- a/src/components/tools/ToolDetail.tsx
+++ b/src/components/tools/ToolDetail.tsx
@@ -1,7 +1,7 @@
 import { Link } from '@tanstack/react-router'
 import { useCallback, useEffect, useState } from 'react'
 import { ArrowLeft, Edit, Save, Trash2, X } from 'lucide-react'
-import { CapabilitiesEditor } from './CapabilitiesEditor'
+import { CapabilitiesEditor, CapabilitiesView } from './CapabilitiesEditor'
 import type { KnownToolSubtype, Tool } from '@/lib/items/types/tool'
 import type { SearchableSelectOption } from '@/components/ui/SearchableSelect'
 import type { UrlEnrichmentResult } from '@/components/items/useUrlDropEnrichment'
@@ -468,9 +468,9 @@ export function ToolDetail({
                           onChange={setCapabilities}
                         />
                       ) : (
-                        <pre className="text-sm font-mono bg-slate-100 dark:bg-slate-800 p-4 rounded-md overflow-x-auto">
-                          {JSON.stringify(currentTool.capabilities, null, 2)}
-                        </pre>
+                        <CapabilitiesView
+                          capabilities={currentTool.capabilities ?? {}}
+                        />
                       )}
                     </CardContent>
                   </Card>

--- a/src/components/tools/ToolForm.tsx
+++ b/src/components/tools/ToolForm.tsx
@@ -257,8 +257,8 @@ export function ToolForm({
         </form.Field>
       </div>
 
-      {/* Capabilities (JSON) */}
-      {currentSubtype && currentSubtype !== 'other' && (
+      {/* Capabilities — typed fields for known subtypes, freeform otherwise */}
+      {currentSubtype && (
         <CapabilitiesEditor
           subtype={currentSubtype}
           capabilities={capabilities}

--- a/src/lib/items/capability-text.test.ts
+++ b/src/lib/items/capability-text.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import {
+  displayCapabilityValue,
+  formatCapabilityText,
+  humanizeCapabilityKey,
+  parseCapabilityText,
+} from './capability-text'
+
+describe('parseCapabilityText', () => {
+  it('returns an empty record for blank input', () => {
+    expect(parseCapabilityText('')).toEqual({})
+    expect(parseCapabilityText('   \n  \n')).toEqual({})
+  })
+
+  it('reads one capability per line without quotes or braces', () => {
+    expect(parseCapabilityText('Max power: 60\nLaser type: fiber')).toEqual({
+      'Max power': 60,
+      'Laser type': 'fiber',
+    })
+  })
+
+  it('accepts = as a separator', () => {
+    expect(parseCapabilityText('maxPower = 60')).toEqual({ maxPower: 60 })
+  })
+
+  it('splits comma-separated values into a list', () => {
+    expect(parseCapabilityText('Materials: PLA, PETG, ABS')).toEqual({
+      Materials: ['PLA', 'PETG', 'ABS'],
+    })
+  })
+
+  it('reads dimension shorthand as a numeric tuple', () => {
+    expect(parseCapabilityText('Build volume: 250 x 210 x 220')).toEqual({
+      'Build volume': [250, 210, 220],
+    })
+  })
+
+  it('coerces yes/no and numbers', () => {
+    expect(
+      parseCapabilityText('Heated bed: yes\nEnclosed: no\nNozzle: 0.4'),
+    ).toEqual({ 'Heated bed': true, Enclosed: false, Nozzle: 0.4 })
+  })
+
+  it('treats a line with no separator as yes-flags', () => {
+    expect(parseCapabilityText('Enclosed, Filtered exhaust')).toEqual({
+      Enclosed: true,
+      'Filtered exhaust': true,
+    })
+  })
+
+  it('tolerates bullets and trailing punctuation', () => {
+    expect(parseCapabilityText('- Max power: 60,\n* Heated bed: yes;')).toEqual(
+      {
+        'Max power': 60,
+        'Heated bed': true,
+      },
+    )
+  })
+
+  it('keeps commas that sit inside quotes or brackets', () => {
+    expect(parseCapabilityText('Note: "cuts steel, brass"')).toEqual({
+      Note: 'cuts steel, brass',
+    })
+    expect(
+      parseCapabilityText('Cuttable: [{"material":"acrylic","max":6}]'),
+    ).toEqual({ Cuttable: [{ material: 'acrylic', max: 6 }] })
+  })
+
+  it('accepts a pasted JSON object verbatim', () => {
+    expect(parseCapabilityText('{"maxPower": 60, "cnc": true}')).toEqual({
+      maxPower: 60,
+      cnc: true,
+    })
+  })
+
+  it('never throws on half-typed input', () => {
+    expect(() => parseCapabilityText('{"maxPower":')).not.toThrow()
+    expect(() => parseCapabilityText('Materials: [PLA,')).not.toThrow()
+    expect(parseCapabilityText('Materials:')).toEqual({ Materials: '' })
+  })
+})
+
+describe('capability text round-trip', () => {
+  // The editor formats a stored record into text and re-parses what the user
+  // leaves behind, so format -> parse must be lossless for stored shapes.
+  const cases: Array<[string, Record<string, unknown>]> = [
+    ['empty', {}],
+    ['numbers', { maxPower: 60, nozzleDiameter: 0.4 }],
+    ['booleans', { heatedBed: true, enclosedChamber: false }],
+    ['tuples', { buildVolume: [250, 210, 220], layerHeightRange: [0.05, 0.3] }],
+    ['string lists', { compatibleMaterials: ['PLA', 'PETG', 'ABS'] }],
+    ['plain strings', { spindleTaper: 'R8', laserType: 'co2' }],
+    ['numeric-looking strings', { firmware: '42', serial: 'yes' }],
+    ['strings with commas', { note: 'cuts steel, brass' }],
+    ['strings with separators', { docs: 'https://example.com/a=1' }],
+    ['nested objects', { multiMaterial: { type: 'MMU', materialSlots: 5 } }],
+    [
+      'nested arrays',
+      { cuttableMaterials: [{ material: 'acrylic', maxThickness: 6 }] },
+    ],
+    ['empty values', { location: '' }],
+  ]
+
+  it.each(cases)('preserves %s', (_label, capabilities) => {
+    expect(parseCapabilityText(formatCapabilityText(capabilities))).toEqual(
+      capabilities,
+    )
+  })
+
+  it('renders an empty record as empty text, not "{}"', () => {
+    expect(formatCapabilityText({})).toBe('')
+  })
+
+  it('is stable across repeated format/parse cycles', () => {
+    const first = formatCapabilityText({
+      buildVolume: [250, 210, 220],
+      compatibleMaterials: ['PLA', 'PETG'],
+      heatedBed: true,
+    })
+    expect(formatCapabilityText(parseCapabilityText(first))).toBe(first)
+  })
+})
+
+describe('display helpers', () => {
+  it('humanizes camelCase and snake_case keys', () => {
+    expect(humanizeCapabilityKey('buildVolume')).toBe('Build Volume')
+    expect(humanizeCapabilityKey('max_power')).toBe('Max Power')
+    expect(humanizeCapabilityKey('Heated bed')).toBe('Heated Bed')
+  })
+
+  it('formats values for reading', () => {
+    expect(displayCapabilityValue(true)).toBe('Yes')
+    expect(displayCapabilityValue([250, 210, 220])).toBe('250 × 210 × 220')
+    expect(displayCapabilityValue(['PLA', 'PETG'])).toBe('PLA, PETG')
+    expect(displayCapabilityValue('')).toBe('—')
+  })
+})

--- a/src/lib/items/capability-text.ts
+++ b/src/lib/items/capability-text.ts
@@ -1,0 +1,285 @@
+/**
+ * Freeform capability text <-> capabilities record.
+ *
+ * Tool subtypes without a dedicated editor (including "other") fall back to a
+ * plain-text capabilities field. The syntax is deliberately forgiving so a
+ * non-technical user never has to type JSON punctuation:
+ *
+ *   Build volume: 250 x 210 x 220
+ *   Materials: PLA, PETG, ABS
+ *   Heated bed: yes
+ *   Max power: 60
+ *   Enclosed, Filtered exhaust
+ *
+ * Rules:
+ *  - One capability per line, `key: value` or `key = value`.
+ *  - Commas inside a value make a list; `A x B x C` numbers make a dimension.
+ *  - A line with no separator becomes yes/no flags (comma-separated).
+ *  - `yes`/`no`/`true`/`false` become booleans, bare numbers become numbers.
+ *  - Quotes are optional, but JSON is still accepted verbatim so previously
+ *    saved data (nested objects, pasted JSON) round-trips without loss.
+ */
+
+const TRUE_WORDS = new Set(['true', 'yes', 'y'])
+const FALSE_WORDS = new Set(['false', 'no', 'n'])
+
+// ============================================================================
+// Low-level scanning helpers
+// ============================================================================
+
+/** Split on top-level commas — commas inside quotes or brackets are kept. */
+function splitTopLevel(input: string): Array<string> {
+  const parts: Array<string> = []
+  let current = ''
+  let depth = 0
+  let quote: string | null = null
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input.charAt(i)
+
+    if (quote) {
+      current += ch
+      if (ch === '\\' && i + 1 < input.length) {
+        current += input.charAt(i + 1)
+        i++
+      } else if (ch === quote) {
+        quote = null
+      }
+      continue
+    }
+
+    if (ch === '"' || ch === "'") quote = ch
+    else if (ch === '[' || ch === '{') depth++
+    else if (ch === ']' || ch === '}') depth = Math.max(0, depth - 1)
+    else if (ch === ',' && depth === 0) {
+      parts.push(current)
+      current = ''
+      continue
+    }
+
+    current += ch
+  }
+
+  parts.push(current)
+  return parts.map((part) => part.trim()).filter((part) => part !== '')
+}
+
+/** Index of the first top-level `:` or `=`, or -1 when the line has neither. */
+function findSeparator(line: string): number {
+  let depth = 0
+  let quote: string | null = null
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line.charAt(i)
+
+    if (quote) {
+      if (ch === '\\') i++
+      else if (ch === quote) quote = null
+      continue
+    }
+
+    if (ch === '"' || ch === "'") quote = ch
+    else if (ch === '[' || ch === '{') depth++
+    else if (ch === ']' || ch === '}') depth = Math.max(0, depth - 1)
+    else if ((ch === ':' || ch === '=') && depth === 0) return i
+  }
+
+  return -1
+}
+
+function isNumeric(value: string): boolean {
+  return /^-?\d+(\.\d+)?$/.test(value)
+}
+
+/** Strip a matching pair of surrounding quotes, if present. */
+function unquote(value: string): string {
+  const first = value.charAt(0)
+  if (
+    value.length >= 2 &&
+    (first === '"' || first === "'") &&
+    value.endsWith(first)
+  ) {
+    return value.slice(1, -1)
+  }
+  return value
+}
+
+// ============================================================================
+// Parsing
+// ============================================================================
+
+function coerceScalar(raw: string): string | number | boolean {
+  const value = unquote(raw.trim())
+  if (value === '') return ''
+
+  const lower = value.toLowerCase()
+  if (TRUE_WORDS.has(lower)) return true
+  if (FALSE_WORDS.has(lower)) return false
+  if (isNumeric(value)) return Number(value)
+  return value
+}
+
+function coerceValue(raw: string): unknown {
+  const value = raw.trim()
+  if (value === '') return ''
+
+  // Verbatim JSON — the only way to express nested structures.
+  if (/^[[{"]/.test(value)) {
+    try {
+      return JSON.parse(value) as unknown
+    } catch {
+      // Not valid JSON (likely mid-typing) — fall through to plain parsing.
+    }
+  }
+
+  // Dimension shorthand: "250 x 210 x 220" -> [250, 210, 220]
+  const dims = value.split(/\s*[x×]\s*/i)
+  if (dims.length > 1 && dims.every(isNumeric)) return dims.map(Number)
+
+  const parts = splitTopLevel(value)
+  if (parts.length > 1) return parts.map(coerceScalar)
+  return coerceScalar(value)
+}
+
+function normalizeKey(raw: string): string {
+  return unquote(raw.trim()).replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * Parse freeform capability text into a capabilities record.
+ * Never throws — partially typed input yields a partial record.
+ */
+export function parseCapabilityText(text: string): Record<string, unknown> {
+  const trimmed = text.trim()
+  if (trimmed === '') return {}
+
+  // A whole pasted JSON object is taken as-is.
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>
+      }
+    } catch {
+      // Not (yet) valid JSON — parse it line by line instead.
+    }
+  }
+
+  const result: Record<string, unknown> = {}
+
+  for (const rawLine of trimmed.split('\n')) {
+    const line = rawLine
+      .replace(/^\s*[-*•]\s+/, '') // bullet prefixes
+      .replace(/[,;]+$/, '') // trailing list punctuation
+      .trim()
+    if (line === '') continue
+
+    const separator = findSeparator(line)
+
+    // No separator: every comma-separated token is a yes-flag.
+    if (separator === -1) {
+      for (const token of splitTopLevel(line)) {
+        const key = normalizeKey(token)
+        if (key !== '') result[key] = true
+      }
+      continue
+    }
+
+    const key = normalizeKey(line.slice(0, separator))
+    if (key === '') continue
+    result[key] = coerceValue(line.slice(separator + 1))
+  }
+
+  return result
+}
+
+// ============================================================================
+// Formatting
+// ============================================================================
+
+function isScalar(value: unknown): value is string | number | boolean {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  )
+}
+
+/** Render a scalar so that parsing it again returns the same value. */
+function formatScalar(value: string | number | boolean): string {
+  if (typeof value === 'boolean') return value ? 'yes' : 'no'
+  if (typeof value === 'number') return String(value)
+  if (value === '') return ''
+  // Quote strings that would otherwise parse back as another type or split.
+  if (coerceScalar(value) !== value || /[,\n:=]/.test(value)) {
+    return JSON.stringify(value)
+  }
+  return value
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (isScalar(value)) return formatScalar(value)
+  if (Array.isArray(value) && value.every(isScalar)) {
+    return value.map(formatScalar).join(', ')
+  }
+  return JSON.stringify(value)
+}
+
+/**
+ * Render a capabilities record back into freeform text.
+ * An empty record yields an empty string — never a bare `{}`.
+ */
+export function formatCapabilityText(
+  capabilities: Record<string, unknown>,
+): string {
+  return Object.entries(capabilities)
+    .map(([key, value]) => {
+      const safeKey = /[:=\n]/.test(key) ? JSON.stringify(key) : key
+      const rendered = formatValue(value)
+      return rendered === '' ? `${safeKey}: ` : `${safeKey}: ${rendered}`
+    })
+    .join('\n')
+}
+
+// ============================================================================
+// Display helpers (read-only rendering)
+// ============================================================================
+
+/** `buildVolume` / `build_volume` -> `Build Volume`; human labels pass through. */
+export function humanizeCapabilityKey(key: string): string {
+  const spaced = key
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (spaced === '') return key
+  return spaced
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+/** Human-readable value for read-only display (not round-trip safe). */
+export function displayCapabilityValue(value: unknown): string {
+  if (value === null || value === undefined || value === '') return '—'
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+  if (typeof value === 'number') return String(value)
+  if (typeof value === 'string') return value
+  if (Array.isArray(value) && value.every(isScalar)) {
+    // 2–3 numbers read as dimensions: 250 × 210 × 220
+    if (
+      value.length >= 2 &&
+      value.length <= 3 &&
+      value.every(Number.isFinite)
+    ) {
+      return value.join(' × ')
+    }
+    return value
+      .map((entry) =>
+        typeof entry === 'boolean' ? (entry ? 'Yes' : 'No') : entry,
+      )
+      .join(', ')
+  }
+  return JSON.stringify(value)
+}


### PR DESCRIPTION
- Add capability-text parser/formatter for lenient name: value input
- Interpret newlines, commas, dimensions, yes/no, and bare numbers
- Accept pasted JSON verbatim so nested shapes still round-trip
- Replace JSON fallback in CapabilitiesEditor with freeform editor + live preview
- Render capabilities read view as a labelled list instead of JSON
- Show the editor for the "Other" subtype in ToolForm
- Add unit tests covering parsing, round-trips, and display helpers