### PR TITLE
Fix the demo-image paths-filter that stopped matching after the workspace split

### DIFF
--- a/.github/workflows/publish-demo-images.yml
+++ b/.github/workflows/publish-demo-images.yml
@@ -72,6 +72,32 @@ jobs:
       # historical demo-data blob for no benefit.
       - uses: actions/checkout@v4
 
+      # A filter pattern that matches nothing has stopped protecting anything,
+      # and it fails silently: the image simply stops being rebuilt, and the
+      # only symptom is a `:latest` that is quietly older than main. That is
+      # how `src/**`, `index.html`, `vite.config.ts`, `drizzle.config.ts` and
+      # `test-data/**` survived the workspace split here — all five had moved
+      # under packages/ or apps/, and nothing said so.
+      #
+      # Everything up to the first wildcard has to exist. That is enough to
+      # catch a path that moved, without pretending to verify a glob.
+      - name: Refuse a filter pattern that matches nothing
+        run: |
+          set -euo pipefail
+          workflow=.github/workflows/publish-demo-images.yml
+          stale=0
+          while read -r pattern; do
+            base=${pattern%%\**}
+            base=${base%/}
+            [ -n "$base" ] || continue
+            if [ ! -e "$base" ]; then
+              echo "::error file=$workflow::paths-filter pattern '$pattern' matches nothing in the tree. It moved or was deleted; update the filters block."
+              stale=1
+            fi
+          done < <(sed -n "/filters: |/,/- name: Select images to build/p" "$workflow" |
+                   sed -n "s/^ *- '\(.*\)'\$/\1/p")
+          [ "$stale" -eq 0 ]
+
       # Skipped entirely on tag pushes, workflow_dispatch, and the all-zeros
       # `before` SHA (branch creation / history-rewriting force-push). In those
       # cases `changes` is unset and the next step force-builds everything.
@@ -85,20 +111,33 @@ jobs:
         with:
           filters: |
             # Anchor for the sources shared by cascadia-app and cascadia-jobs-worker.
-            # Both Dockerfiles `COPY . .` and run the identical `npm run build`, so a
-            # change to any of these genuinely invalidates both images. It surfaces as
-            # its own filter key, which the catalog below has no entry for and drops.
+            # Both Dockerfiles `COPY . .` and run the identical `npm run build:app`,
+            # so a change to any of these genuinely invalidates both images. It
+            # surfaces as its own filter key, which the catalog below has no entry
+            # for and drops.
+            #
+            # `packages/**` and `apps/**` are deliberately whole subtrees rather
+            # than a list of the files inside them. This block named `src/**`,
+            # `index.html`, `vite.config.ts`, `drizzle.config.ts` and `test-data/**`
+            # long after the workspace split moved every one of them under
+            # packages/ or apps/, so an ordinary source change matched nothing and
+            # rebuilt nothing — `:latest` went stale silently, which is the worst
+            # way for a selective build to fail. Whole subtrees also pick up a new
+            # package or app for free, instead of waiting to be noticed.
+            #
+            # The rest is what the runtime stage of docker/app.Dockerfile copies:
+            # public/, scripts/, tsconfig.json and tsconfig.base.json. `tests/**`
+            # and `docs/**` are absent on purpose — neither reaches the image, and
+            # a test-only or docs-only commit should build nothing.
             _app_sources: &app_sources
-              - 'src/**'
+              - 'packages/**'
+              - 'apps/**'
               - 'scripts/**'
               - 'public/**'
-              - 'test-data/**'
               - 'package.json'
               - 'package-lock.json'
-              - 'index.html'
-              - 'vite.config.ts'
               - 'tsconfig.json'
-              - 'drizzle.config.ts'
+              - 'tsconfig.base.json'
               - '.dockerignore'
             # Editing the pipeline itself rebuilds everything, so a change to how
             # images are built is always exercised by the commit that makes it.


### PR DESCRIPTION
Five of the eleven patterns in `_app_sources` named paths that no longer exist. `src/**`, `test-data/**`, `index.html`, `vite.config.ts` and `drizzle.config.ts` all moved under `packages/` or `apps/` when the repo became a workspace, and the filter was never updated.

The effect: **an ordinary source change matched nothing.** A commit touching only `packages/core/src/**` — which is most of them — selected zero images, so `cascadia-app` and `cascadia-jobs-worker` were not rebuilt and `:latest` fell behind `main` with no signal anywhere.

The images weren't frozen outright, which is what made this hard to see. `package.json`, `package-lock.json`, `scripts/**`, `public/**` and the Dockerfiles still matched, so a dependency bump or a Dockerfile edit did rebuild everything. The pipeline looked alive.

## The fix

`packages/**` and `apps/**` replace the five dead patterns as whole subtrees rather than another list of the files inside them — a list is exactly what rotted, and a subtree picks up a new package or app for free. `tsconfig.base.json` joins them: it postdates the split, is copied by the runtime stage of `docker/app.Dockerfile`, and was never matched.

`tests/**` and `docs/**` stay out deliberately. Neither reaches the image, and a test-only or docs-only commit should still build nothing — that property is the point of the selective build.

## The guard

This failure is silent by construction: a filter matching nothing produces a green run and a stale image. So the `plan` job now fails when any pattern's pre-wildcard prefix is absent from the tree. It checks every pattern in the block, not just `_app_sources`, so the three Dockerfile paths are covered too.

It deliberately doesn't try to evaluate globs — just "everything up to the first wildcard must exist", which is enough to catch a path that moved.

## Verification

Both halves were run, not just reasoned about.

**Guard, against this commit** — passes. **Guard, against the previous revision** — exits 1 and names all five:

```
::error::paths-filter pattern 'src/**' matches nothing in the tree...
::error::paths-filter pattern 'test-data/**' matches nothing in the tree...
::error::paths-filter pattern 'index.html' matches nothing in the tree...
::error::paths-filter pattern 'vite.config.ts' matches nothing in the tree...
::error::paths-filter pattern 'drizzle.config.ts' matches nothing in the tree...
```

**Patterns, against picomatch** (what `dorny/paths-filter` uses) — 12/12 cases as intended:

| Path | Result |
|---|---|
| `packages/core/src/lib/auth/UserService.ts` | match — the file from #71 that matched nothing before |
| `packages/core/test-data/catalog.json` | match |
| `packages/core/vite.config.base.ts` | match |
| `apps/cascadia/index.html` | match |
| `apps/cascadia/drizzle.config.ts` | match |
| `apps/cascadia/src/main.tsx` | match |
| `scripts/build-app.mjs` | match |
| `tsconfig.base.json` | match — newly covered |
| `package-lock.json` | match |
| `tests/e2e/pages/PartsPage.ts` | **skip** |
| `docs/features/versioning.md` | **skip** |
| `README.md` | **skip** |

YAML parses, `bash -n` clean on the guard, `prettier --check` passes.

## Note

Merging this rebuilds all three images, since `_pipeline` matches the workflow file itself — same as #72. That's the intended self-test.

---
_Generated by [Claude Code](https://claude.ai/code/session_016XdBzgTMipXF2B5NmT9HQd)_