### PR TITLE
Add formal baseline revision import

### DIFF
--- a/docs/api/import.md
+++ b/docs/api/import.md
@@ -48,7 +48,8 @@ Bulk-create parts from an array of row data. Optionally includes BOM relationshi
       "referenceDesignator": "R1, R2"
     }
   ],
-  "bypassBranchProtection": false
+  "bypassBranchProtection": false,
+  "importAsReleased": false
 }
 ```
 
@@ -56,13 +57,14 @@ Bulk-create parts from an array of row data. Optionally includes BOM relationshi
 
 #### Top-level fields
 
-| Field                    | Type    | Required    | Description                                                                     |
-| ------------------------ | ------- | ----------- | ------------------------------------------------------------------------------- |
-| `designId`               | UUID    | Yes         | Target design for the imported parts                                            |
-| `branchId`               | UUID    | Conditional | Required for post-release designs (unless `bypassBranchProtection` is true)     |
-| `rows`                   | Array   | Yes         | 1-500 part rows to import                                                       |
-| `bomRelationships`       | Array   | No          | BOM parent-child relationships to create after parts are imported               |
-| `bypassBranchProtection` | boolean | No          | If true, create directly on main even for post-release designs (default: false) |
+| Field                    | Type    | Required    | Description                                                                                |
+| ------------------------ | ------- | ----------- | ------------------------------------------------------------------------------------------ |
+| `designId`               | UUID    | Yes         | Target design for the imported parts                                                       |
+| `branchId`               | UUID    | Conditional | Required for post-release designs unless bypass or formal baseline import is enabled       |
+| `rows`                   | Array   | Yes         | 1-500 part rows to import                                                                  |
+| `bomRelationships`       | Array   | No          | BOM parent-child relationships to create after parts are imported                          |
+| `bypassBranchProtection` | boolean | No          | If true, create directly on main even for post-release designs (default: false)            |
+| `importAsReleased`       | boolean | No          | Administrator-only import of existing formal revisions directly onto main (default: false) |
 
 #### Row fields
 
@@ -123,13 +125,32 @@ Bulk-create parts from an array of row data. Optionally includes BOM relationshi
 
 The import behavior depends on the design's lifecycle phase:
 
-| Design Phase | `branchId` provided | `bypassBranchProtection` | Behavior                                                     |
-| ------------ | ------------------- | ------------------------ | ------------------------------------------------------------ |
-| Pre-release  | No                  | -                        | Creates directly on main                                     |
-| Pre-release  | Yes                 | -                        | Creates on specified branch                                  |
-| Post-release | Yes                 | false                    | Creates on specified branch via `ItemService.createOnBranch` |
-| Post-release | No                  | false                    | **Error**: Branch ID required                                |
-| Post-release | No                  | true                     | Creates directly, bypassing branch protection                |
+| Design Phase | `branchId` provided | Bypass | Formal baseline | Behavior                                                     |
+| ------------ | ------------------- | ------ | --------------- | ------------------------------------------------------------ |
+| Pre-release  | No                  | -      | false           | Creates directly on main                                     |
+| Pre-release  | Yes                 | -      | false           | Creates on specified branch                                  |
+| Post-release | Yes                 | false  | false           | Creates on specified branch via `ItemService.createOnBranch` |
+| Post-release | No                  | false  | false           | **Error**: Branch ID required                                |
+| Post-release | No                  | true   | false           | Creates directly, bypassing branch protection                |
+| Any          | No                  | -      | true            | Creates an existing formal release directly on main          |
+| Any          | Yes                 | -      | true            | **Error**: formal baseline imports cannot target a branch    |
+
+### Importing an existing formal release
+
+Set `importAsReleased` to `true` when migrating Parts or Documents whose
+release already happened in the source system. This mode is restricted to the
+`Administrator` role. It is not a shortcut for ordinary revision changes.
+
+- Every row must provide a formal `revision`; the ordinary `-` default is
+  rejected.
+- The revision must match the revision scheme active in the lifecycle's
+  release state, for example `R4` for an `R`-prefixed numeric scheme.
+- The item is created in the lifecycle state targeted by its `release` action,
+  directly on main, as the current formal version.
+- `branchId` must be omitted. No placeholder ECO or intermediate revisions are
+  created.
+- A later normal revise action continues from the imported value (for example,
+  `R4` becomes `R5`). The revision is not encoded in the Item Number.
 
 ### BOM relationship resolution
 
@@ -170,7 +191,8 @@ Bulk-create documents. Follows the same branch-aware pattern as parts import. Ad
       "mimeType": "application/pdf"
     }
   ],
-  "bypassBranchProtection": false
+  "bypassBranchProtection": false,
+  "importAsReleased": false
 }
 ```
 
@@ -189,7 +211,8 @@ Bulk-create documents. Follows the same branch-aware pattern as parts import. Ad
 
 ### Response
 
-Same structure as parts import (without BOM relationship fields).
+Same structure as parts import (without BOM relationship fields). Documents
+also support the Administrator-only `importAsReleased` mode described above.
 
 ---
 

--- a/docs/api/openapi.v1.json
+++ b/docs/api/openapi.v1.json
@@ -10535,6 +10535,10 @@
                     "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
                   },
+                  "importAsReleased": {
+                    "default": false,
+                    "type": "boolean"
+                  },
                   "rows": {
                     "items": {
                       "properties": {
@@ -10791,6 +10795,10 @@
                     "format": "uuid",
                     "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
                     "type": "string"
+                  },
+                  "importAsReleased": {
+                    "default": false,
+                    "type": "boolean"
                   },
                   "rows": {
                     "items": {

--- a/docs/features/import-export.md
+++ b/docs/features/import-export.md
@@ -14,6 +14,7 @@ The import system is designed for migrating data from other PLM systems, ERP exp
 - Create up to 500 items per import batch
 - Detect and import BOM structure from level-based, parent-child, or flat formats
 - Branch-aware import: create items on ECO branches for post-release designs
+- Administrator-only migration of existing formal Part and Document revisions
 - Collect unmapped columns as custom attributes on the created items
 
 **Supported item types:** Part, Document, Issue
@@ -194,6 +195,10 @@ Before any data is written to the database, every row is validated and presented
 4. **Warnings**: Non-blocking issues like missing descriptions or special characters in item numbers.
 5. **Default values**: Revision defaults to `"-"` for Parts and Documents if not provided.
 
+The default revision represents an unreleased item. When **Import as existing
+formal releases** is selected, every row must instead contain a formal revision
+matching the lifecycle's release-phase scheme.
+
 ### Validation Summary
 
 The review step displays:
@@ -235,6 +240,7 @@ The import behavior depends on the design's lifecycle phase:
 
 - **Pre-release design**: Items are created directly on the main branch. The `bypassBranchProtection` flag is set automatically.
 - **Post-release design**: Items must be created on an ECO or workspace branch. The user selects the target branch in the context step. Items are created via `ItemService.createOnBranch()`.
+- **Existing formal release import**: Administrators may import Parts or Documents directly on main at their source-system revision and release state. This mode requires a revision in every row, forbids `branchId`, and does not create intermediate ECOs.
 
 ---
 
@@ -365,6 +371,7 @@ Creates parts in bulk, optionally with BOM relationships.
   "designId": "uuid",
   "branchId": "uuid (optional, required for post-release)",
   "bypassBranchProtection": false,
+  "importAsReleased": false,
   "rows": [
     {
       "name": "Aluminum Housing",
@@ -455,6 +462,7 @@ Creates documents in bulk. Same structure as parts import but without BOM suppor
   "designId": "uuid",
   "branchId": "uuid (optional)",
   "bypassBranchProtection": false,
+  "importAsReleased": false,
   "rows": [
     {
       "name": "Assembly Instructions",
@@ -482,7 +490,7 @@ Creates documents in bulk. Same structure as parts import but without BOM suppor
 | `mimeType`    | string (max 100)  | No       |                                                                      |
 | `attributes`  | object            | No       | Any JSON document                                                    |
 
-This endpoint requires design access (`requireDesignAccess`) and branch access (`requireBranchAccess`) if a branch is specified. Bypassing branch protection requires the Administrator role.
+This endpoint requires design access (`requireDesignAccess`) and branch access (`requireBranchAccess`) if a branch is specified. Bypassing branch protection or importing existing formal releases requires the Administrator role.
 
 ### POST /api/v1/import/issues
 
@@ -572,7 +580,7 @@ Exports the flat list of items affected by an ECO, with current and target revis
 
 The import wizard (`ImportDialog` component) guides users through a five-step process:
 
-1. **Select Design** (or Select Program for Issues) -- Choose the target program, design, and branch.
+1. **Select Design** (or Select Program for Issues) -- Choose the target program, design, and branch. Administrators can instead select **Import as existing formal releases**, which targets main without a branch.
 2. **Upload File** -- Drag-and-drop or browse for .xlsx/.csv files. Shows a preview of the first 3 rows.
 3. **Map Columns** -- Review auto-detected mappings. Manually adjust via dropdowns. See which columns will become custom attributes.
 4. **Review** -- Validation summary with error/warning counts, row-level detail table, BOM structure detection info, and filter controls.

--- a/packages/core/src/components/import/ImportDialog.tsx
+++ b/packages/core/src/components/import/ImportDialog.tsx
@@ -250,7 +250,14 @@ export function ImportDialog({
           const mappedRows = applyMappings(parsedFile!.rows, mappings, {
             collectUnmappedAsAttributes: true,
           })
-          const validated = validateRows(mappedRows, parsedFile!.rows, itemType)
+          const validated = validateRows(
+            mappedRows,
+            parsedFile!.rows,
+            itemType,
+            {
+              importAsReleased: context?.importAsReleased,
+            },
+          )
           setValidatedRows(validated)
 
           // Detect BOM format and extract relationships (only for Parts)
@@ -277,7 +284,14 @@ export function ImportDialog({
         setCurrentStep('importing')
         break
     }
-  }, [currentStep, parsedFile, mappings, itemType, config.supportsBom])
+  }, [
+    currentStep,
+    parsedFile,
+    mappings,
+    itemType,
+    config.supportsBom,
+    context?.importAsReleased,
+  ])
 
   // Render step content
   const renderStepContent = () => {

--- a/packages/core/src/components/import/steps/ContextSelectStep.tsx
+++ b/packages/core/src/components/import/steps/ContextSelectStep.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/Select'
 import { Badge, Checkbox, FormField } from '@/components/ui'
 import {
+  authSessionQuery,
   designBranchesQuery,
   designListQuery,
   designStatusQuery,
@@ -73,6 +74,8 @@ export function ContextSelectStep({
   const [importAsReleased, setImportAsReleased] = useState(false)
 
   // The three cascading lists, each enabled by the one above it.
+  const { data: session } = useQuery(authSessionQuery())
+  const isSystemAdmin = session?.setupStatus?.isAdmin ?? false
   const { data: programs = [], isPending: loadingPrograms } =
     useQuery(programListQuery())
   const { data: designs = [], isFetching: loadingDesigns } = useQuery(
@@ -265,7 +268,7 @@ export function ContextSelectStep({
       )}
 
       {/* A migration/import exception, not an alternative revision editor. */}
-      {requiresDesign && selectedDesignId && (
+      {requiresDesign && selectedDesignId && isSystemAdmin && (
         <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/30">
           <div className="flex items-start gap-3">
             <Checkbox
@@ -284,9 +287,9 @@ export function ContextSelectStep({
                 Import as existing formal releases
               </label>
               <p className="text-xs text-blue-700 dark:text-blue-300">
-                Administrator only. Each row must provide a revision matching
-                the lifecycle (for example R4). Items are recorded as released
-                directly on main; no placeholder ECOs are created.
+                Each row must provide a revision matching the lifecycle (for
+                example R4). Items are recorded as released directly on main; no
+                placeholder ECOs are created.
               </p>
             </div>
           </div>

--- a/packages/core/src/components/import/steps/ContextSelectStep.tsx
+++ b/packages/core/src/components/import/steps/ContextSelectStep.tsx
@@ -13,7 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/Select'
-import { Badge, FormField } from '@/components/ui'
+import { Badge, Checkbox, FormField } from '@/components/ui'
 import {
   designBranchesQuery,
   designListQuery,
@@ -70,6 +70,7 @@ export function ContextSelectStep({
   const [selectedBranchId, setSelectedBranchId] = useState<string | undefined>(
     initialBranchId,
   )
+  const [importAsReleased, setImportAsReleased] = useState(false)
 
   // The three cascading lists, each enabled by the one above it.
   const { data: programs = [], isPending: loadingPrograms } =
@@ -101,6 +102,10 @@ export function ContextSelectStep({
       setSelectedBranchId(undefined)
       return
     }
+    if (importAsReleased) {
+      setSelectedBranchId(undefined)
+      return
+    }
     if (designStatus.protection.isMainBranchProtected) {
       const unlocked = branches.filter(
         (b) => !b.isLocked && b.branchType !== 'main',
@@ -111,7 +116,7 @@ export function ContextSelectStep({
       const mainBranch = branches.find((b) => b.branchType === 'main')
       if (mainBranch) setSelectedBranchId(mainBranch.id)
     }
-  }, [selectedDesignId, designStatus, branches])
+  }, [selectedDesignId, designStatus, branches, importAsReleased])
 
   // Update context when selection changes
   useEffect(() => {
@@ -132,7 +137,7 @@ export function ContextSelectStep({
     const phase = designStatus.protection.phase
 
     // For post-release, require branch selection
-    if (phase === 'post-release' && !selectedBranchId) {
+    if (phase === 'post-release' && !selectedBranchId && !importAsReleased) {
       onChange(null)
       return
     }
@@ -140,9 +145,10 @@ export function ContextSelectStep({
     onChange({
       programId: selectedProgramId,
       designId: selectedDesignId,
-      branchId: selectedBranchId,
+      branchId: importAsReleased ? undefined : selectedBranchId,
       designPhase: phase,
       itemType,
+      importAsReleased,
     })
   }, [
     selectedProgramId,
@@ -152,6 +158,7 @@ export function ContextSelectStep({
     onChange,
     requiresDesign,
     itemType,
+    importAsReleased,
   ])
 
   const isPostRelease = designStatus?.protection.phase === 'post-release'
@@ -257,88 +264,130 @@ export function ContextSelectStep({
         </FormField>
       )}
 
-      {/* Branch Selection (only for post-release designs that require design) */}
-      {requiresDesign && selectedDesignId && designStatus && (
-        <FormField
-          label="Branch"
-          required={isPostRelease}
-          helpText={
-            isPostRelease
-              ? 'This design has released items. Select a branch to import new parts.'
-              : 'Parts will be imported to the main branch.'
-          }
-        >
-          <div className="flex items-center gap-2">
-            <GitBranch className="h-5 w-5 text-slate-400" />
-            <Select
-              value={selectedBranchId}
-              onValueChange={setSelectedBranchId}
-              disabled={loadingBranches || !isPostRelease}
-            >
-              <SelectTrigger className="flex-1">
-                <SelectValue
-                  placeholder={
-                    loadingBranches
-                      ? 'Loading branches...'
-                      : isPostRelease
-                        ? 'Select a branch...'
-                        : 'main'
-                  }
-                />
-              </SelectTrigger>
-              <SelectContent>
-                {availableBranches.map((branch) => (
-                  <SelectItem key={branch.id} value={branch.id}>
-                    <div className="flex items-center gap-2">
-                      {branch.branchType === BRANCH_TYPES.changeOrder && (
-                        <Badge variant="default" className="text-xs">
-                          ECO
-                        </Badge>
-                      )}
-                      {branch.branchType === 'workspace' && (
-                        <Badge variant="secondary" className="text-xs">
-                          WS
-                        </Badge>
-                      )}
-                      <span>{branch.name}</span>
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+      {/* A migration/import exception, not an alternative revision editor. */}
+      {requiresDesign && selectedDesignId && (
+        <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/30">
+          <div className="flex items-start gap-3">
+            <Checkbox
+              id="importAsReleased"
+              checked={importAsReleased}
+              onCheckedChange={(checked) =>
+                setImportAsReleased(checked === true)
+              }
+              className="mt-0.5"
+            />
+            <div className="space-y-1">
+              <label
+                htmlFor="importAsReleased"
+                className="cursor-pointer text-sm font-medium text-blue-900 dark:text-blue-100"
+              >
+                Import as existing formal releases
+              </label>
+              <p className="text-xs text-blue-700 dark:text-blue-300">
+                Administrator only. Each row must provide a revision matching
+                the lifecycle (for example R4). Items are recorded as released
+                directly on main; no placeholder ECOs are created.
+              </p>
+            </div>
           </div>
-        </FormField>
+        </div>
       )}
+
+      {/* Branch Selection (only for post-release designs that require design) */}
+      {requiresDesign &&
+        selectedDesignId &&
+        designStatus &&
+        !importAsReleased && (
+          <FormField
+            label="Branch"
+            required={isPostRelease}
+            helpText={
+              isPostRelease
+                ? 'This design has released items. Select a branch to import new parts.'
+                : 'Parts will be imported to the main branch.'
+            }
+          >
+            <div className="flex items-center gap-2">
+              <GitBranch className="h-5 w-5 text-slate-400" />
+              <Select
+                value={selectedBranchId}
+                onValueChange={setSelectedBranchId}
+                disabled={loadingBranches || !isPostRelease}
+              >
+                <SelectTrigger className="flex-1">
+                  <SelectValue
+                    placeholder={
+                      loadingBranches
+                        ? 'Loading branches...'
+                        : isPostRelease
+                          ? 'Select a branch...'
+                          : 'main'
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableBranches.map((branch) => (
+                    <SelectItem key={branch.id} value={branch.id}>
+                      <div className="flex items-center gap-2">
+                        {branch.branchType === BRANCH_TYPES.changeOrder && (
+                          <Badge variant="default" className="text-xs">
+                            ECO
+                          </Badge>
+                        )}
+                        {branch.branchType === 'workspace' && (
+                          <Badge variant="secondary" className="text-xs">
+                            WS
+                          </Badge>
+                        )}
+                        <span>{branch.name}</span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </FormField>
+        )}
 
       {/* Status Info - only shown for items that require design */}
       {requiresDesign && designStatus && (
         <div
           className={`p-3 rounded-lg text-sm ${
-            isPostRelease
-              ? 'bg-amber-50 border border-amber-200 dark:bg-amber-900/20 dark:border-amber-800'
-              : 'bg-green-50 border border-green-200 dark:bg-green-900/20 dark:border-green-800'
+            importAsReleased
+              ? 'bg-blue-50 border border-blue-200 dark:bg-blue-950/30 dark:border-blue-800'
+              : isPostRelease
+                ? 'bg-amber-50 border border-amber-200 dark:bg-amber-900/20 dark:border-amber-800'
+                : 'bg-green-50 border border-green-200 dark:bg-green-900/20 dark:border-green-800'
           }`}
         >
           <div className="flex items-start gap-2">
             <AlertCircle
               className={`h-4 w-4 mt-0.5 shrink-0 ${
-                isPostRelease
-                  ? 'text-amber-600 dark:text-amber-400'
-                  : 'text-green-600'
+                importAsReleased
+                  ? 'text-blue-600 dark:text-blue-400'
+                  : isPostRelease
+                    ? 'text-amber-600 dark:text-amber-400'
+                    : 'text-green-600'
               }`}
             />
             <div>
               <p
-                className={`font-medium ${isPostRelease ? 'text-amber-800 dark:text-amber-200' : 'text-green-800 dark:text-green-200'}`}
+                className={`font-medium ${importAsReleased ? 'text-blue-800 dark:text-blue-200' : isPostRelease ? 'text-amber-800 dark:text-amber-200' : 'text-green-800 dark:text-green-200'}`}
               >
-                {isPostRelease ? 'Post-Release Design' : 'Pre-Release Design'}
+                {importAsReleased
+                  ? 'Existing release import'
+                  : isPostRelease
+                    ? 'Post-Release Design'
+                    : 'Pre-Release Design'}
               </p>
               <p
-                className={`text-xs ${isPostRelease ? 'text-amber-700 dark:text-amber-300' : 'text-green-700 dark:text-green-300'}`}
+                className={`text-xs ${importAsReleased ? 'text-blue-700 dark:text-blue-300' : isPostRelease ? 'text-amber-700 dark:text-amber-300' : 'text-green-700 dark:text-green-300'}`}
               >
-                {isPostRelease
-                  ? 'New parts must be imported through a change-order or workspace branch.'
-                  : 'Parts can be imported directly to this design.'}
+                {importAsReleased
+                  ? 'Rows will become the current formal releases on main.'
+                  : isPostRelease
+                    ? 'New parts must be imported through a change-order or workspace branch.'
+                    : 'Parts can be imported directly to this design.'}
               </p>
             </div>
           </div>

--- a/packages/core/src/components/import/steps/ImportProgressStep.tsx
+++ b/packages/core/src/components/import/steps/ImportProgressStep.tsx
@@ -88,9 +88,10 @@ export function ImportProgressStep({
 
         requestBody = {
           designId: context.designId,
-          branchId: context.branchId,
+          branchId: context.importAsReleased ? undefined : context.branchId,
           rows,
           bypassBranchProtection: context.designPhase === 'pre-release',
+          importAsReleased: context.importAsReleased,
           bomRelationships:
             bomRelationshipsForApi.length > 0
               ? bomRelationshipsForApi
@@ -111,9 +112,10 @@ export function ImportProgressStep({
 
         requestBody = {
           designId: context.designId,
-          branchId: context.branchId,
+          branchId: context.importAsReleased ? undefined : context.branchId,
           rows,
           bypassBranchProtection: context.designPhase === 'pre-release',
+          importAsReleased: context.importAsReleased,
         }
       } else {
         // Issue

--- a/packages/core/src/lib/api/openapi-types.gen.ts
+++ b/packages/core/src/lib/api/openapi-types.gen.ts
@@ -9452,6 +9452,8 @@ export interface operations {
                     bypassBranchProtection?: boolean;
                     /** Format: uuid */
                     designId: string;
+                    /** @default false */
+                    importAsReleased?: boolean;
                     rows: {
                         attributes?: {
                             [key: string]: unknown;
@@ -9541,6 +9543,8 @@ export interface operations {
                     bypassBranchProtection?: boolean;
                     /** Format: uuid */
                     designId: string;
+                    /** @default false */
+                    importAsReleased?: boolean;
                     rows: {
                         attributes?: {
                             [key: string]: unknown;

--- a/packages/core/src/lib/import/baseline-revision.test.ts
+++ b/packages/core/src/lib/import/baseline-revision.test.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Cascadia PLM LLC
+
+import { describe, expect, it } from 'vitest'
+import { parseBaselineReleaseRevision } from './baseline-revision'
+import type { RevisionScheme } from '@/lib/types/lifecycle'
+import { ValidationError } from '@/lib/errors'
+
+describe('parseBaselineReleaseRevision', () => {
+  it('accepts revisions that match the configured release scheme', () => {
+    expect(parseBaselineReleaseRevision(' B ', { type: 'alpha' })).toBe('B')
+    expect(parseBaselineReleaseRevision('4', { type: 'numeric' })).toBe('4')
+    expect(
+      parseBaselineReleaseRevision('R4', {
+        type: 'prefixed-numeric',
+        prefix: 'R',
+      }),
+    ).toBe('R4')
+    expect(parseBaselineReleaseRevision('N/A', { type: 'none' })).toBe('N/A')
+  })
+
+  it.each(['', '-', '-abc12345', 'DRAFT'])(
+    'rejects working revision %j',
+    (revision) => {
+      expect(() =>
+        parseBaselineReleaseRevision(revision, { type: 'alpha' }),
+      ).toThrow(ValidationError)
+    },
+  )
+
+  it('rejects a revision from another scheme', () => {
+    expect(() => parseBaselineReleaseRevision('R4', { type: 'alpha' })).toThrow(
+      /expected A, B/,
+    )
+    expect(() =>
+      parseBaselineReleaseRevision('4', {
+        type: 'prefixed-numeric',
+        prefix: 'R',
+      }),
+    ).toThrow(/expected R1/)
+  })
+
+  it('honors a configured zero-based starting revision', () => {
+    const scheme = { type: 'numeric', startAt: 0 } as RevisionScheme
+
+    expect(parseBaselineReleaseRevision('0', scheme)).toBe('0')
+  })
+})

--- a/packages/core/src/lib/import/baseline-revision.ts
+++ b/packages/core/src/lib/import/baseline-revision.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Cascadia PLM LLC
+
+import type { RevisionScheme } from '@/lib/types/lifecycle'
+import { ValidationError } from '@/lib/errors'
+import { RevisionService } from '@/lib/services/RevisionService'
+
+function fail(revision: string, expected: string): never {
+  const message = `Revision '${revision}' is not a valid formal revision for this lifecycle; expected ${expected}`
+  throw new ValidationError(message, [{ field: 'revision', message }], {
+    operation: 'importBaselineRelease',
+  })
+}
+
+function configuredStart(scheme: RevisionScheme): number {
+  // `startAt` was added after the original revision-scheme contract. Keeping
+  // this reader tolerant lets an import branch merge cleanly with trees that
+  // already support R0 without weakening older R1-based configurations.
+  return (scheme as { startAt?: number }).startAt ?? 1
+}
+
+/**
+ * Validate and normalize an imported release revision against the lifecycle's
+ * release-phase scheme. The ordinary create flow may carry a working marker;
+ * this path may not, because its caller is declaring that the source system's
+ * revision is already a formal release.
+ */
+export function parseBaselineReleaseRevision(
+  input: string | null | undefined,
+  scheme?: RevisionScheme,
+): string {
+  const revision = input?.trim() ?? ''
+  if (
+    revision.length === 0 ||
+    revision.length > 10 ||
+    RevisionService.isWorkingRevision(revision)
+  ) {
+    fail(revision || '(empty)', 'a released revision (not -, DRAFT, or empty)')
+  }
+
+  const resolved = scheme ?? ({ type: 'alpha' } as const)
+  switch (resolved.type) {
+    case 'alpha':
+      if (!/^[A-Z]+$/.test(revision)) fail(revision, 'A, B, ... Z, AA, ...')
+      return revision
+
+    case 'numeric': {
+      if (!/^(0|[1-9]\d*)$/.test(revision)) {
+        fail(revision, `an integer at or above ${configuredStart(resolved)}`)
+      }
+      if (Number(revision) < configuredStart(resolved)) {
+        fail(revision, `an integer at or above ${configuredStart(resolved)}`)
+      }
+      return revision
+    }
+
+    case 'prefixed-numeric': {
+      const numeric = revision.slice(resolved.prefix.length)
+      if (
+        !revision.startsWith(resolved.prefix) ||
+        !/^(0|[1-9]\d*)$/.test(numeric) ||
+        Number(numeric) < configuredStart(resolved)
+      ) {
+        fail(
+          revision,
+          `${resolved.prefix}${configuredStart(resolved)} or a later revision`,
+        )
+      }
+      return revision
+    }
+
+    case 'none':
+      if (revision !== RevisionService.NO_REVISION) {
+        fail(revision, RevisionService.NO_REVISION)
+      }
+      return revision
+  }
+}

--- a/packages/core/src/lib/import/types.ts
+++ b/packages/core/src/lib/import/types.ts
@@ -19,6 +19,8 @@ export interface ImportContext {
   branchId?: string // Required for post-release designs
   designPhase?: 'pre-release' | 'post-release' // Not applicable for Issues
   itemType?: ImportItemType // Item type being imported
+  /** Record source-system revisions as existing formal releases on main. */
+  importAsReleased?: boolean
 }
 
 /**
@@ -190,6 +192,7 @@ export const importPartsRequestSchema = z.object({
     .min(1, 'At least one row is required')
     .max(500, 'Maximum 500 rows per import'),
   bypassBranchProtection: z.boolean().optional().default(false),
+  importAsReleased: z.boolean().optional().default(false),
 })
 
 export type ImportPartsRequest = z.infer<typeof importPartsRequestSchema>

--- a/packages/core/src/lib/import/types/document.ts
+++ b/packages/core/src/lib/import/types/document.ts
@@ -46,6 +46,7 @@ export const importDocumentsRequestSchema = z.object({
     .min(1, 'At least one row is required')
     .max(500, 'Maximum 500 rows per import'),
   bypassBranchProtection: z.boolean().optional().default(false),
+  importAsReleased: z.boolean().optional().default(false),
 })
 
 export type ImportDocumentsRequest = z.infer<

--- a/packages/core/src/lib/import/validator.ts
+++ b/packages/core/src/lib/import/validator.ts
@@ -14,6 +14,7 @@ import type {
   ValidatedRow,
 } from './types'
 import type { z } from 'zod'
+import { RevisionService } from '@/lib/services/RevisionService'
 
 /**
  * Get the validation schema for a specific item type
@@ -77,6 +78,7 @@ function validateRow(
   mappedData: Record<string, unknown>,
   _rowNumber: number,
   itemType: ImportItemType = 'Part',
+  options: { importAsReleased?: boolean } = {},
 ): {
   errors: Array<RowValidationError>
   warnings: Array<RowValidationWarning>
@@ -91,7 +93,11 @@ function validateRow(
   }
 
   // Set default revision if not provided (for Parts and Documents)
-  if (itemType !== 'Issue' && !coercedData.revision) {
+  if (
+    itemType !== 'Issue' &&
+    !coercedData.revision &&
+    !options.importAsReleased
+  ) {
     coercedData.revision = '-'
   }
 
@@ -109,6 +115,25 @@ function validateRow(
         message: issue.message,
       })
     }
+  }
+
+  // The browser does not own lifecycle configuration, so exact scheme
+  // validation remains in the API. It can still prevent known working-copy
+  // markers from being presented as valid formal releases in the preview.
+  if (
+    options.importAsReleased &&
+    itemType !== 'Issue' &&
+    RevisionService.isWorkingRevision(
+      typeof coercedData.revision === 'string'
+        ? coercedData.revision
+        : undefined,
+    )
+  ) {
+    errors.push({
+      field: 'Revision',
+      message:
+        'A formal released revision is required; -, DRAFT, and branch working revisions are not allowed',
+    })
   }
 
   // Additional warnings
@@ -146,6 +171,7 @@ export function validateRows(
   rows: Array<Record<string, unknown>>,
   rawRows: Array<Record<string, unknown>>,
   itemType: ImportItemType = 'Part',
+  options: { importAsReleased?: boolean } = {},
 ): Array<ValidatedRow> {
   const validatedRows: Array<ValidatedRow> = []
   const seenItemNumbers = new Map<string, number>() // itemNumber -> rowNumber
@@ -161,11 +187,20 @@ export function validateRows(
     }
 
     // Set default revision if not provided (for Parts and Documents)
-    if (itemType !== 'Issue' && !coercedData.revision) {
+    if (
+      itemType !== 'Issue' &&
+      !coercedData.revision &&
+      !options.importAsReleased
+    ) {
       coercedData.revision = '-'
     }
 
-    const { errors, warnings } = validateRow(mappedData, rowNumber, itemType)
+    const { errors, warnings } = validateRow(
+      mappedData,
+      rowNumber,
+      itemType,
+      options,
+    )
 
     // Check for duplicate item numbers within the file
     if (coercedData.itemNumber) {

--- a/packages/core/src/lib/items/services/ItemService.ts
+++ b/packages/core/src/lib/items/services/ItemService.ts
@@ -28,6 +28,7 @@ import {
   computeInitialFieldValues,
 } from '../../services/CheckoutService'
 import { BranchService } from '../../services/BranchService'
+import { parseBaselineReleaseRevision } from '../../import/baseline-revision'
 // Imported directly rather than through lib/auth/access.ts, whose static
 // FileService import would recreate the ItemService <-> FileService cycle that
 // the dynamic import further down this file exists to break.
@@ -183,7 +184,15 @@ export class ItemService {
     type: string,
     data: T,
     userId: string,
-    options?: { bypassBranchProtection?: boolean },
+    options?: {
+      bypassBranchProtection?: boolean
+      /**
+       * Import a source system's existing formal release directly onto main.
+       * HTTP callers reach this only through the Administrator-gated import
+       * routes; normal create and ECO flows must never set it.
+       */
+      importAsReleased?: boolean
+    },
   ): Promise<T> {
     const typeConfig = ItemTypeRegistry.getType(type)
     if (!typeConfig) {
@@ -244,14 +253,43 @@ export class ItemService {
       }
     }
 
-    // The revision is the lifecycle's to assign, not the caller's. A client
-    // that names one is honoured (imports carry the revision the source system
-    // recorded); one that omits it gets the value its lifecycle implies. Bound
-    // as a const as well as written back, because the insert below runs inside
-    // a closure where the narrowing on a mutable field does not survive.
-    const revision =
-      validatedData.revision ?? (await this.resolveInitialRevision(type))
-    validatedData.revision = revision
+    // A baseline import is the one controlled exception to assigning formal
+    // revisions through an ECO: the release happened in the source system and
+    // Cascadia is recording that existing fact. Resolve both fields from the
+    // lifecycle so R4 cannot be stored as a Draft-shaped row.
+    let revision: string
+    let initialState: string
+    if (options?.importAsReleased) {
+      const { LifecycleService } =
+        await import('../../services/LifecycleService')
+      const lifecycle = await LifecycleService.getLifecycleForItemType(type)
+      const releaseState = await LifecycleService.getTargetState(
+        type,
+        'release',
+      )
+      if (!lifecycle || !releaseState) {
+        throw new ValidationError(
+          `${type} does not define a formal release action and cannot be imported as a released baseline`,
+          undefined,
+          { operation: 'importBaselineRelease', resource: type },
+        )
+      }
+      revision = parseBaselineReleaseRevision(
+        validatedData.revision,
+        LifecycleService.getRevisionSchemeForState(lifecycle, releaseState),
+      )
+      initialState = releaseState
+      validatedData.revision = revision
+      validatedData.state = releaseState
+    } else {
+      // The revision is the lifecycle's to assign, not the caller's. A client
+      // that names one is honoured (imports may carry source metadata); one
+      // that omits it gets the value its lifecycle implies.
+      revision =
+        validatedData.revision ?? (await this.resolveInitialRevision(type))
+      validatedData.revision = revision
+      initialState = await this.resolveInitialStateId(type)
+    }
 
     // Check branch protection if item is associated with a design
     // Skip this check if:
@@ -286,8 +324,6 @@ export class ItemService {
         await import('../../services/LifecycleService')
       await LifecycleService.validateStateForType(type, validatedData.state)
     }
-    const initialState = await this.resolveInitialStateId(type)
-
     // Auto-assign sysmlType based on whether this is a usage or definition
     // If usageOf is set, this is a usage; otherwise it's a definition
     const isUsage = !!(validatedData as unknown as { usageOf?: string }).usageOf
@@ -350,7 +386,9 @@ export class ItemService {
               const commit = await CommitService.create(
                 {
                   branchId: targetBranchId,
-                  message: `${type} ${validatedData.itemNumber || 'item'} created`,
+                  message: options?.importAsReleased
+                    ? `${type} ${validatedData.itemNumber || 'item'} imported as released revision ${revision}`
+                    : `${type} ${validatedData.itemNumber || 'item'} created`,
                   itemChanges: [
                     {
                       itemId: item.id,

--- a/packages/core/src/server/routes/import.ts
+++ b/packages/core/src/server/routes/import.ts
@@ -81,7 +81,19 @@ app.post(
         const userId = user.id
 
         // Parse and validate request body
-        const { designId, branchId, rows, bypassBranchProtection } = body
+        const {
+          designId,
+          branchId,
+          rows,
+          bypassBranchProtection,
+          importAsReleased,
+        } = body
+
+        if (importAsReleased && branchId) {
+          throw new ValidationError(
+            'Existing formal releases must be imported directly to main; do not provide a branch ID',
+          )
+        }
 
         // Verify design access
         await requireDesignAccess(user.id, designId)
@@ -92,7 +104,7 @@ app.post(
         }
 
         // Bypass branch protection requires Administrator role
-        if (bypassBranchProtection) {
+        if (bypassBranchProtection || importAsReleased) {
           await requireRole(request, 'Administrator')
         }
 
@@ -108,7 +120,12 @@ app.post(
         const isPostRelease = designStatus.phase === 'post-release'
 
         // If post-release and no bypass, require branchId
-        if (isPostRelease && !bypassBranchProtection && !branchId) {
+        if (
+          isPostRelease &&
+          !bypassBranchProtection &&
+          !importAsReleased &&
+          !branchId
+        ) {
           throw new ValidationError(
             'Branch ID is required for post-release designs',
           )
@@ -145,7 +162,7 @@ app.post(
 
             let createdItem: BaseItem
 
-            if (branchId && !bypassBranchProtection) {
+            if (branchId && !bypassBranchProtection && !importAsReleased) {
               // Create on branch (post-release)
               const branchResult = await ItemService.createOnBranch(
                 'Document',
@@ -161,7 +178,11 @@ app.post(
                 'Document',
                 documentData,
                 userId,
-                { bypassBranchProtection: bypassBranchProtection || false },
+                {
+                  bypassBranchProtection:
+                    bypassBranchProtection || importAsReleased,
+                  importAsReleased,
+                },
               )
             }
 
@@ -326,8 +347,15 @@ app.post(
           branchId,
           rows,
           bypassBranchProtection,
+          importAsReleased,
           bomRelationships,
         } = body
+
+        if (importAsReleased && branchId) {
+          throw new ValidationError(
+            'Existing formal releases must be imported directly to main; do not provide a branch ID',
+          )
+        }
 
         // Verify design access
         await requireDesignAccess(user.id, designId)
@@ -338,7 +366,7 @@ app.post(
         }
 
         // Bypass branch protection requires Administrator role
-        if (bypassBranchProtection) {
+        if (bypassBranchProtection || importAsReleased) {
           await requireRole(request, 'Administrator')
         }
 
@@ -354,7 +382,12 @@ app.post(
         const isPostRelease = designStatus.phase === 'post-release'
 
         // If post-release and no bypass, require branchId
-        if (isPostRelease && !bypassBranchProtection && !branchId) {
+        if (
+          isPostRelease &&
+          !bypassBranchProtection &&
+          !importAsReleased &&
+          !branchId
+        ) {
           throw new ValidationError(
             'Branch ID is required for post-release designs',
           )
@@ -398,7 +431,7 @@ app.post(
 
             let createdItem: BaseItem
 
-            if (branchId && !bypassBranchProtection) {
+            if (branchId && !bypassBranchProtection && !importAsReleased) {
               // Create on branch (post-release)
               const branchResult = await ItemService.createOnBranch(
                 'Part',
@@ -411,7 +444,9 @@ app.post(
             } else {
               // Create directly (pre-release or bypass)
               createdItem = await ItemService.create('Part', partData, userId, {
-                bypassBranchProtection: bypassBranchProtection || false,
+                bypassBranchProtection:
+                  bypassBranchProtection || importAsReleased,
+                importAsReleased,
               })
             }
 


### PR DESCRIPTION
Allows administrators to import existing Parts and Documents directly as formal released revisions, such as R4, without creating placeholder ECOs. The revision is validated against the configured lifecycle, imported onto main as the current release, and working revision markers are rejected during import preview and by the API.